### PR TITLE
feat: support multi-arch build for arm64

### DIFF
--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -74,867 +74,122 @@ jobs:
   # Build and push carbide-rest-api
   build-carbide-rest-api:
     name: Build carbide-rest-api
-    runs-on: ${{ inputs.runner }}
-
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to NVCR
-        if: inputs.push_enabled
-        uses: docker/login-action@v3
-        with:
-          registry: nvcr.io
-          username: ${{ secrets.NVCR_USERNAME }}
-          password: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Determine Docker tags
-        id: docker-tags
-        run: |
-          # Always include branch-sha tag
-          TAGS="${{ inputs.target_registry }}/carbide-rest-api:${{ inputs.branch_sha_tag }}"
-          
-          # On main branch, also add semantic version and latest tags
-          # Check both the input and github.ref_name for robustness (handles force push edge cases)
-          if [ "${{ inputs.is_main_branch }}" = "true" ] || [ "${{ github.ref_name }}" = "main" ]; then
-            TAGS="${TAGS},${{ inputs.target_registry }}/carbide-rest-api:${{ inputs.semantic_version }}"
-            TAGS="${TAGS},${{ inputs.target_registry }}/carbide-rest-api:latest"
-          fi
-          
-          echo "tags=$TAGS" >> $GITHUB_OUTPUT
-          echo "DEBUG: is_main_branch=${{ inputs.is_main_branch }}, ref_name=${{ github.ref_name }}, tags=$TAGS"
-
-      - name: Build carbide-rest-api
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./docker/production/Dockerfile.carbide-rest-api
-          platforms: linux/amd64
-          push: ${{ inputs.push_enabled }}
-          load: true
-          tags: ${{ steps.docker-tags.outputs.tags }}
-          cache-from: type=gha,scope=carbide-rest-api
-          cache-to: type=gha,mode=max,scope=carbide-rest-api
-          labels: |
-            org.opencontainers.image.title=carbide-rest-api
-            org.opencontainers.image.version=${{ inputs.semantic_version }}
-            org.opencontainers.image.revision=${{ inputs.short_sha }}
-            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
-            org.opencontainers.image.source=${{ github.repositoryUrl }}
-            org.opencontainers.image.url=${{ github.repositoryUrl }}
-
-      - name: Extract binary from image
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        run: |
-          mkdir -p artifacts
-          docker create --name temp-container ${{ inputs.target_registry }}/carbide-rest-api:${{ inputs.branch_sha_tag }}
-          docker cp temp-container:/app/api artifacts/api
-          docker rm temp-container
-          chmod +x artifacts/api
-
-      - name: Export Docker image
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        run: |
-          docker save ${{ inputs.target_registry }}/carbide-rest-api:${{ inputs.branch_sha_tag }} | gzip > artifacts/carbide-rest-api-${{ inputs.branch_sha_tag }}.tar.gz
-
-      - name: Upload binary artifact with semantic version
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-api-binary
-          display-name: carbide-rest-api-binary
-          description: Carbide REST API binary
-          version: ${{ inputs.semantic_version }}
-          path: artifacts/api
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload binary artifact with latest tag
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-api-binary
-          display-name: carbide-rest-api-binary
-          description: Carbide REST API binary
-          version: latest
-          path: artifacts/api
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload binary artifact with branch-sha tag
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-api-binary
-          display-name: carbide-rest-api-binary
-          description: Carbide REST API binary
-          version: ${{ inputs.branch_sha_tag }}
-          path: artifacts/api
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload Docker image artifact with semantic version
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-api-image
-          display-name: carbide-rest-api-image
-          description: Carbide REST API image
-          version: ${{ inputs.semantic_version }}
-          path: artifacts/carbide-rest-api-${{ inputs.branch_sha_tag }}.tar.gz
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload Docker image artifact with latest tag
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-api-image
-          display-name: carbide-rest-api-image
-          description: Carbide REST API image
-          version: latest
-          path: artifacts/carbide-rest-api-${{ inputs.branch_sha_tag }}.tar.gz
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload Docker image artifact with branch-sha tag
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-api-image
-          display-name: carbide-rest-api-image
-          description: Carbide REST API image
-          version: ${{ inputs.branch_sha_tag }}
-          path: artifacts/carbide-rest-api-${{ inputs.branch_sha_tag }}.tar.gz
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
+    uses: ./.github/workflows/build-push-service.yml
+    with:
+      runner: ${{ inputs.runner }}
+      service_name: carbide-rest-api
+      binary_name: api
+      binary_path: /app/api
+      dockerfile: ./docker/production/Dockerfile.carbide-rest-api
+      semantic_version: ${{ inputs.semantic_version }}
+      short_sha: ${{ inputs.short_sha }}
+      branch_sha_tag: ${{ inputs.branch_sha_tag }}
+      target_registry: ${{ inputs.target_registry }}
+      push_enabled: ${{ inputs.push_enabled }}
+      is_main_branch: ${{ inputs.is_main_branch }}
+    secrets:
+      NVCR_USERNAME: ${{ secrets.NVCR_USERNAME }}
+      NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}
 
   # Build and push carbide-rest-db
   build-carbide-rest-db:
     name: Build carbide-rest-db
-    runs-on: ${{ inputs.runner }}
-
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to NVCR
-        if: inputs.push_enabled
-        uses: docker/login-action@v3
-        with:
-          registry: nvcr.io
-          username: ${{ secrets.NVCR_USERNAME }}
-          password: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Determine Docker tags
-        id: docker-tags
-        run: |
-          # Always include branch-sha tag
-          TAGS="${{ inputs.target_registry }}/carbide-rest-db:${{ inputs.branch_sha_tag }}"
-          
-          # On main branch, also add semantic version and latest tags
-          # Check both the input and github.ref_name for robustness (handles force push edge cases)
-          if [ "${{ inputs.is_main_branch }}" = "true" ] || [ "${{ github.ref_name }}" = "main" ]; then
-            TAGS="${TAGS},${{ inputs.target_registry }}/carbide-rest-db:${{ inputs.semantic_version }}"
-            TAGS="${TAGS},${{ inputs.target_registry }}/carbide-rest-db:latest"
-          fi
-          
-          echo "tags=$TAGS" >> $GITHUB_OUTPUT
-
-      - name: Build carbide-rest-db
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./docker/production/Dockerfile.carbide-rest-db
-          platforms: linux/amd64
-          push: ${{ inputs.push_enabled }}
-          load: true
-          tags: ${{ steps.docker-tags.outputs.tags }}
-          cache-from: type=gha,scope=carbide-rest-db
-          cache-to: type=gha,mode=max,scope=carbide-rest-db
-          labels: |
-            org.opencontainers.image.title=carbide-rest-db
-            org.opencontainers.image.version=${{ inputs.semantic_version }}
-            org.opencontainers.image.revision=${{ inputs.short_sha }}
-            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
-            org.opencontainers.image.source=${{ github.repositoryUrl }}
-            org.opencontainers.image.url=${{ github.repositoryUrl }}
-
-      - name: Extract binary from image
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        run: |
-          mkdir -p artifacts
-          docker create --name temp-container ${{ inputs.target_registry }}/carbide-rest-db:${{ inputs.branch_sha_tag }}
-          docker cp temp-container:/app/migrations artifacts/migrations
-          docker rm temp-container
-          chmod +x artifacts/migrations
-
-      - name: Export Docker image
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        run: |
-          docker save ${{ inputs.target_registry }}/carbide-rest-db:${{ inputs.branch_sha_tag }} | gzip > artifacts/carbide-rest-db-${{ inputs.branch_sha_tag }}.tar.gz
-
-      - name: Upload binary artifact with semantic version
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-db-binary
-          display-name: carbide-rest-db-binary
-          description: Carbide REST DB binary
-          version: ${{ inputs.semantic_version }}
-          path: artifacts/migrations
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload binary artifact with latest tag
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-db-binary
-          display-name: carbide-rest-db-binary
-          description: Carbide REST DB binary
-          version: latest
-          path: artifacts/migrations
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload binary artifact with branch-sha tag
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-db-binary
-          display-name: carbide-rest-db-binary
-          description: Carbide REST DB binary
-          version: ${{ inputs.branch_sha_tag }}
-          path: artifacts/migrations
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload Docker image artifact with semantic version
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-db-image
-          display-name: carbide-rest-db-image
-          description: Carbide REST DB image
-          version: ${{ inputs.semantic_version }}
-          path: artifacts/carbide-rest-db-${{ inputs.branch_sha_tag }}.tar.gz
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload Docker image artifact with latest tag
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-db-image
-          display-name: carbide-rest-db-image
-          description: Carbide REST DB image
-          version: latest
-          path: artifacts/carbide-rest-db-${{ inputs.branch_sha_tag }}.tar.gz
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload Docker image artifact with branch-sha tag
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-db-image
-          display-name: carbide-rest-db-image
-          description: Carbide REST DB image
-          version: ${{ inputs.branch_sha_tag }}
-          path: artifacts/carbide-rest-db-${{ inputs.branch_sha_tag }}.tar.gz
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
+    uses: ./.github/workflows/build-push-service.yml
+    with:
+      runner: ${{ inputs.runner }}
+      service_name: carbide-rest-db
+      binary_name: migrations
+      binary_path: /app/migrations
+      dockerfile: ./docker/production/Dockerfile.carbide-rest-db
+      semantic_version: ${{ inputs.semantic_version }}
+      short_sha: ${{ inputs.short_sha }}
+      branch_sha_tag: ${{ inputs.branch_sha_tag }}
+      target_registry: ${{ inputs.target_registry }}
+      push_enabled: ${{ inputs.push_enabled }}
+      is_main_branch: ${{ inputs.is_main_branch }}
+    secrets:
+      NVCR_USERNAME: ${{ secrets.NVCR_USERNAME }}
+      NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}
 
   # Build and push carbide-rest-site-manager
   build-carbide-rest-site-manager:
     name: Build carbide-rest-site-manager
-    runs-on: ${{ inputs.runner }}
-
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to NVCR
-        if: inputs.push_enabled
-        uses: docker/login-action@v3
-        with:
-          registry: nvcr.io
-          username: ${{ secrets.NVCR_USERNAME }}
-          password: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Determine Docker tags
-        id: docker-tags
-        run: |
-          # Always include branch-sha tag
-          TAGS="${{ inputs.target_registry }}/carbide-rest-site-manager:${{ inputs.branch_sha_tag }}"
-          
-          # On main branch, also add semantic version and latest tags
-          # Check both the input and github.ref_name for robustness (handles force push edge cases)
-          if [ "${{ inputs.is_main_branch }}" = "true" ] || [ "${{ github.ref_name }}" = "main" ]; then
-            TAGS="${TAGS},${{ inputs.target_registry }}/carbide-rest-site-manager:${{ inputs.semantic_version }}"
-            TAGS="${TAGS},${{ inputs.target_registry }}/carbide-rest-site-manager:latest"
-          fi
-          
-          echo "tags=$TAGS" >> $GITHUB_OUTPUT
-
-      - name: Build carbide-rest-site-manager
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./docker/production/Dockerfile.carbide-rest-site-manager
-          platforms: linux/amd64
-          push: ${{ inputs.push_enabled }}
-          load: true
-          tags: ${{ steps.docker-tags.outputs.tags }}
-          cache-from: type=gha,scope=carbide-rest-site-manager
-          cache-to: type=gha,mode=max,scope=carbide-rest-site-manager
-          labels: |
-            org.opencontainers.image.title=carbide-rest-site-manager
-            org.opencontainers.image.version=${{ inputs.semantic_version }}
-            org.opencontainers.image.revision=${{ inputs.short_sha }}
-            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
-            org.opencontainers.image.source=${{ github.repositoryUrl }}
-            org.opencontainers.image.url=${{ github.repositoryUrl }}
-
-      - name: Extract binary from image
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        run: |
-          mkdir -p artifacts
-          docker create --name temp-container ${{ inputs.target_registry }}/carbide-rest-site-manager:${{ inputs.branch_sha_tag }}
-          docker cp temp-container:/app/sitemgr artifacts/sitemgr
-          docker rm temp-container
-          chmod +x artifacts/sitemgr
-
-      - name: Export Docker image
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        run: |
-          docker save ${{ inputs.target_registry }}/carbide-rest-site-manager:${{ inputs.branch_sha_tag }} | gzip > artifacts/carbide-rest-site-manager-${{ inputs.branch_sha_tag }}.tar.gz
-
-      - name: Upload binary artifact with semantic version
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-site-manager-binary
-          display-name: carbide-rest-site-manager-binary
-          description: Carbide REST Site Manager binary
-          version: ${{ inputs.semantic_version }}
-          path: artifacts/sitemgr
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload binary artifact with latest tag
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-site-manager-binary
-          display-name: carbide-rest-site-manager-binary
-          description: Carbide REST Site Manager binary
-          version: latest
-          path: artifacts/sitemgr
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload binary artifact with branch-sha tag
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-site-manager-binary
-          display-name: carbide-rest-site-manager-binary
-          description: Carbide REST Site Manager binary
-          version: ${{ inputs.branch_sha_tag }}
-          path: artifacts/sitemgr
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload Docker image artifact with semantic version
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-site-manager-image
-          display-name: carbide-rest-site-manager-image
-          description: Carbide REST Site Manager image
-          version: ${{ inputs.semantic_version }}
-          path: artifacts/carbide-rest-site-manager-${{ inputs.branch_sha_tag }}.tar.gz
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload Docker image artifact with latest tag
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-site-manager-image
-          display-name: carbide-rest-site-manager-image
-          description: Carbide REST Site Manager image
-          version: latest
-          path: artifacts/carbide-rest-site-manager-${{ inputs.branch_sha_tag }}.tar.gz
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload Docker image artifact with branch-sha tag
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-site-manager-image
-          display-name: carbide-rest-site-manager-image
-          description: Carbide REST Site Manager image
-          version: ${{ inputs.branch_sha_tag }}
-          path: artifacts/carbide-rest-site-manager-${{ inputs.branch_sha_tag }}.tar.gz
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
+    uses: ./.github/workflows/build-push-service.yml
+    with:
+      runner: ${{ inputs.runner }}
+      service_name: carbide-rest-site-manager
+      binary_name: sitemgr
+      binary_path: /app/sitemgr
+      dockerfile: ./docker/production/Dockerfile.carbide-rest-site-manager
+      semantic_version: ${{ inputs.semantic_version }}
+      short_sha: ${{ inputs.short_sha }}
+      branch_sha_tag: ${{ inputs.branch_sha_tag }}
+      target_registry: ${{ inputs.target_registry }}
+      push_enabled: ${{ inputs.push_enabled }}
+      is_main_branch: ${{ inputs.is_main_branch }}
+    secrets:
+      NVCR_USERNAME: ${{ secrets.NVCR_USERNAME }}
+      NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}
 
   # Build and push carbide-rest-workflow
   build-carbide-rest-workflow:
     name: Build carbide-rest-workflow
-    runs-on: ${{ inputs.runner }}
-
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to NVCR
-        if: inputs.push_enabled
-        uses: docker/login-action@v3
-        with:
-          registry: nvcr.io
-          username: ${{ secrets.NVCR_USERNAME }}
-          password: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Determine Docker tags
-        id: docker-tags
-        run: |
-          # Always include branch-sha tag
-          TAGS="${{ inputs.target_registry }}/carbide-rest-workflow:${{ inputs.branch_sha_tag }}"
-          
-          # On main branch, also add semantic version and latest tags
-          # Check both the input and github.ref_name for robustness (handles force push edge cases)
-          if [ "${{ inputs.is_main_branch }}" = "true" ] || [ "${{ github.ref_name }}" = "main" ]; then
-            TAGS="${TAGS},${{ inputs.target_registry }}/carbide-rest-workflow:${{ inputs.semantic_version }}"
-            TAGS="${TAGS},${{ inputs.target_registry }}/carbide-rest-workflow:latest"
-          fi
-          
-          echo "tags=$TAGS" >> $GITHUB_OUTPUT
-
-      - name: Build carbide-rest-workflow
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./docker/production/Dockerfile.carbide-rest-workflow
-          platforms: linux/amd64
-          push: ${{ inputs.push_enabled }}
-          load: true
-          tags: ${{ steps.docker-tags.outputs.tags }}
-          cache-from: type=gha,scope=carbide-rest-workflow
-          cache-to: type=gha,mode=max,scope=carbide-rest-workflow
-          labels: |
-            org.opencontainers.image.title=carbide-rest-workflow
-            org.opencontainers.image.version=${{ inputs.semantic_version }}
-            org.opencontainers.image.revision=${{ inputs.short_sha }}
-            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
-            org.opencontainers.image.source=${{ github.repositoryUrl }}
-            org.opencontainers.image.url=${{ github.repositoryUrl }}
-
-      - name: Extract binary from image
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        run: |
-          mkdir -p artifacts
-          docker create --name temp-container ${{ inputs.target_registry }}/carbide-rest-workflow:${{ inputs.branch_sha_tag }}
-          docker cp temp-container:/app/workflow artifacts/workflow
-          docker rm temp-container
-          chmod +x artifacts/workflow
-
-      - name: Export Docker image
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        run: |
-          docker save ${{ inputs.target_registry }}/carbide-rest-workflow:${{ inputs.branch_sha_tag }} | gzip > artifacts/carbide-rest-workflow-${{ inputs.branch_sha_tag }}.tar.gz
-
-      - name: Upload binary artifact with semantic version
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-workflow-binary
-          display-name: carbide-rest-workflow-binary
-          description: Carbide REST Workflow binary
-          version: ${{ inputs.semantic_version }}
-          path: artifacts/workflow
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload binary artifact with latest tag
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-workflow-binary
-          display-name: carbide-rest-workflow-binary
-          description: Carbide REST Workflow binary
-          version: latest
-          path: artifacts/workflow
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload binary artifact with branch-sha tag
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-workflow-binary
-          display-name: carbide-rest-workflow-binary
-          description: Carbide REST Workflow binary
-          version: ${{ inputs.branch_sha_tag }}
-          path: artifacts/workflow
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload Docker image artifact with semantic version
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-workflow-image
-          display-name: carbide-rest-workflow-image
-          description: Carbide REST Workflow image
-          version: ${{ inputs.semantic_version }}
-          path: artifacts/carbide-rest-workflow-${{ inputs.branch_sha_tag }}.tar.gz
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload Docker image artifact with latest tag
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-workflow-image
-          display-name: carbide-rest-workflow-image
-          description: Carbide REST Workflow image
-          version: latest
-          path: artifacts/carbide-rest-workflow-${{ inputs.branch_sha_tag }}.tar.gz
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload Docker image artifact with branch-sha tag
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-workflow-image
-          display-name: carbide-rest-workflow-image
-          description: Carbide REST Workflow image
-          version: ${{ inputs.branch_sha_tag }}
-          path: artifacts/carbide-rest-workflow-${{ inputs.branch_sha_tag }}.tar.gz
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
+    uses: ./.github/workflows/build-push-service.yml
+    with:
+      runner: ${{ inputs.runner }}
+      service_name: carbide-rest-workflow
+      binary_name: workflow
+      binary_path: /app/workflow
+      dockerfile: ./docker/production/Dockerfile.carbide-rest-workflow
+      semantic_version: ${{ inputs.semantic_version }}
+      short_sha: ${{ inputs.short_sha }}
+      branch_sha_tag: ${{ inputs.branch_sha_tag }}
+      target_registry: ${{ inputs.target_registry }}
+      push_enabled: ${{ inputs.push_enabled }}
+      is_main_branch: ${{ inputs.is_main_branch }}
+    secrets:
+      NVCR_USERNAME: ${{ secrets.NVCR_USERNAME }}
+      NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}
 
   # Build and push carbide-rest-site-agent
   build-carbide-rest-site-agent:
     name: Build carbide-rest-site-agent
-    runs-on: ${{ inputs.runner }}
+    uses: ./.github/workflows/build-push-service.yml
+    with:
+      runner: ${{ inputs.runner }}
+      service_name: carbide-rest-site-agent
+      binary_name: elektra
+      binary_path: /app/elektra
+      dockerfile: ./docker/production/Dockerfile.carbide-rest-site-agent
+      semantic_version: ${{ inputs.semantic_version }}
+      short_sha: ${{ inputs.short_sha }}
+      branch_sha_tag: ${{ inputs.branch_sha_tag }}
+      target_registry: ${{ inputs.target_registry }}
+      push_enabled: ${{ inputs.push_enabled }}
+      is_main_branch: ${{ inputs.is_main_branch }}
+    secrets:
+      NVCR_USERNAME: ${{ secrets.NVCR_USERNAME }}
+      NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}
 
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to NVCR
-        if: inputs.push_enabled
-        uses: docker/login-action@v3
-        with:
-          registry: nvcr.io
-          username: ${{ secrets.NVCR_USERNAME }}
-          password: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Determine Docker tags
-        id: docker-tags
-        run: |
-          # Always include branch-sha tag
-          TAGS="${{ inputs.target_registry }}/carbide-rest-site-agent:${{ inputs.branch_sha_tag }}"
-          
-          # On main branch, also add semantic version and latest tags
-          # Check both the input and github.ref_name for robustness (handles force push edge cases)
-          if [ "${{ inputs.is_main_branch }}" = "true" ] || [ "${{ github.ref_name }}" = "main" ]; then
-            TAGS="${TAGS},${{ inputs.target_registry }}/carbide-rest-site-agent:${{ inputs.semantic_version }}"
-            TAGS="${TAGS},${{ inputs.target_registry }}/carbide-rest-site-agent:latest"
-          fi
-          
-          echo "tags=$TAGS" >> $GITHUB_OUTPUT
-
-      - name: Build carbide-rest-site-agent
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./docker/production/Dockerfile.carbide-rest-site-agent
-          platforms: linux/amd64
-          push: ${{ inputs.push_enabled }}
-          load: true
-          tags: ${{ steps.docker-tags.outputs.tags }}
-          cache-from: type=gha,scope=carbide-rest-site-agent
-          cache-to: type=gha,mode=max,scope=carbide-rest-site-agent
-          labels: |
-            org.opencontainers.image.title=carbide-rest-site-agent
-            org.opencontainers.image.version=${{ inputs.semantic_version }}
-            org.opencontainers.image.revision=${{ inputs.short_sha }}
-            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
-            org.opencontainers.image.source=${{ github.repositoryUrl }}
-            org.opencontainers.image.url=${{ github.repositoryUrl }}
-
-      - name: Extract binary from image
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        run: |
-          mkdir -p artifacts
-          docker create --name temp-container ${{ inputs.target_registry }}/carbide-rest-site-agent:${{ inputs.branch_sha_tag }}
-          docker cp temp-container:/app/elektra artifacts/elektra
-          docker rm temp-container
-          chmod +x artifacts/elektra
-
-      - name: Export Docker image
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        run: |
-          docker save ${{ inputs.target_registry }}/carbide-rest-site-agent:${{ inputs.branch_sha_tag }} | gzip > artifacts/carbide-rest-site-agent-${{ inputs.branch_sha_tag }}.tar.gz
-
-      - name: Upload binary artifact with semantic version
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-site-agent-binary
-          display-name: carbide-rest-site-agent-binary
-          description: Carbide Site Agent binary
-          version: ${{ inputs.semantic_version }}
-          path: artifacts/elektra
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload binary artifact with latest tag
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-site-agent-binary
-          display-name: carbide-rest-site-agent-binary
-          description: Carbide Site Agent binary
-          version: latest
-          path: artifacts/elektra
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload binary artifact with branch-sha tag
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-site-agent-binary
-          display-name: carbide-rest-site-agent-binary
-          description: Carbide Site Agent binary
-          version: ${{ inputs.branch_sha_tag }}
-          path: artifacts/elektra
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload Docker image artifact with semantic version
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-site-agent-image
-          display-name: carbide-rest-site-agent-image
-          description: Carbide Site Agent image
-          version: ${{ inputs.semantic_version }}
-          path: artifacts/carbide-rest-site-agent-${{ inputs.branch_sha_tag }}.tar.gz
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload Docker image artifact with latest tag
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-site-agent-image
-          display-name: carbide-rest-site-agent-image
-          description: Carbide Site Agent image
-          version: latest
-          path: artifacts/carbide-rest-site-agent-${{ inputs.branch_sha_tag }}.tar.gz
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload Docker image artifact with branch-sha tag
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-site-agent-image
-          display-name: carbide-rest-site-agent-image
-          description: Carbide Site Agent image
-          version: ${{ inputs.branch_sha_tag }}
-          path: artifacts/carbide-rest-site-agent-${{ inputs.branch_sha_tag }}.tar.gz
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-  # Build and push carbide-rest-cert-manager (credsmgr)
+  # Build and push carbide-rest-cert-manager
   build-carbide-rest-cert-manager:
     name: Build carbide-rest-cert-manager
-    runs-on: ${{ inputs.runner }}
-
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to NVCR
-        if: inputs.push_enabled
-        uses: docker/login-action@v3
-        with:
-          registry: nvcr.io
-          username: ${{ secrets.NVCR_USERNAME }}
-          password: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Determine Docker tags
-        id: docker-tags
-        run: |
-          # Always include branch-sha tag
-          TAGS="${{ inputs.target_registry }}/carbide-rest-cert-manager:${{ inputs.branch_sha_tag }}"
-          
-          # On main branch, also add semantic version and latest tags
-          # Check both the input and github.ref_name for robustness (handles force push edge cases)
-          if [ "${{ inputs.is_main_branch }}" = "true" ] || [ "${{ github.ref_name }}" = "main" ]; then
-            TAGS="${TAGS},${{ inputs.target_registry }}/carbide-rest-cert-manager:${{ inputs.semantic_version }}"
-            TAGS="${TAGS},${{ inputs.target_registry }}/carbide-rest-cert-manager:latest"
-          fi
-          
-          echo "tags=$TAGS" >> $GITHUB_OUTPUT
-
-      - name: Build carbide-rest-cert-manager
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./docker/production/Dockerfile.carbide-rest-cert-manager
-          platforms: linux/amd64
-          push: ${{ inputs.push_enabled }}
-          load: true
-          tags: ${{ steps.docker-tags.outputs.tags }}
-          cache-from: type=gha,scope=carbide-rest-cert-manager
-          cache-to: type=gha,mode=max,scope=carbide-rest-cert-manager
-          labels: |
-            org.opencontainers.image.title=carbide-rest-cert-manager
-            org.opencontainers.image.version=${{ inputs.semantic_version }}
-            org.opencontainers.image.revision=${{ inputs.short_sha }}
-            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
-            org.opencontainers.image.source=${{ github.repositoryUrl }}
-            org.opencontainers.image.url=${{ github.repositoryUrl }}
-
-      - name: Extract binary from image
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        run: |
-          mkdir -p artifacts
-          docker create --name temp-container ${{ inputs.target_registry }}/carbide-rest-cert-manager:${{ inputs.branch_sha_tag }}
-          docker cp temp-container:/app/credsmgr artifacts/credsmgr
-          docker rm temp-container
-          chmod +x artifacts/credsmgr
-
-      - name: Export Docker image
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        run: |
-          docker save ${{ inputs.target_registry }}/carbide-rest-cert-manager:${{ inputs.branch_sha_tag }} | gzip > artifacts/carbide-rest-cert-manager-${{ inputs.branch_sha_tag }}.tar.gz
-
-      - name: Upload binary artifact with semantic version
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-cert-manager-binary
-          display-name: carbide-rest-cert-manager-binary
-          description: Carbide REST Cert Manager binary
-          version: ${{ inputs.semantic_version }}
-          path: artifacts/credsmgr
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload binary artifact with latest tag
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-cert-manager-binary
-          display-name: carbide-rest-cert-manager-binary
-          description: Carbide REST Cert Manager binary
-          version: latest
-          path: artifacts/credsmgr
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload binary artifact with branch-sha tag
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-cert-manager-binary
-          display-name: carbide-rest-cert-manager-binary
-          description: Carbide REST Cert Manager binary
-          version: ${{ inputs.branch_sha_tag }}
-          path: artifacts/credsmgr
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload Docker image artifact with semantic version
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-cert-manager-image
-          display-name: carbide-rest-cert-manager-image
-          description: Carbide REST Cert Manager image
-          version: ${{ inputs.semantic_version }}
-          path: artifacts/carbide-rest-cert-manager-${{ inputs.branch_sha_tag }}.tar.gz
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload Docker image artifact with latest tag
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-cert-manager-image
-          display-name: carbide-rest-cert-manager-image
-          description: Carbide REST Cert Manager image
-          version: latest
-          path: artifacts/carbide-rest-cert-manager-${{ inputs.branch_sha_tag }}.tar.gz
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
-
-      - name: Upload Docker image artifact with branch-sha tag
-        if: inputs.is_main_branch || github.ref_name == 'main'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: carbide-rest-cert-manager-image
-          display-name: carbide-rest-cert-manager-image
-          description: Carbide REST Cert Manager image
-          version: ${{ inputs.branch_sha_tag }}
-          path: artifacts/carbide-rest-cert-manager-${{ inputs.branch_sha_tag }}.tar.gz
-          ngc-path: 0837451325059433/carbide-dev
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
+    uses: ./.github/workflows/build-push-service.yml
+    with:
+      runner: ${{ inputs.runner }}
+      service_name: carbide-rest-cert-manager
+      binary_name: credsmgr
+      binary_path: /app/credsmgr
+      dockerfile: ./docker/production/Dockerfile.carbide-rest-cert-manager
+      semantic_version: ${{ inputs.semantic_version }}
+      short_sha: ${{ inputs.short_sha }}
+      branch_sha_tag: ${{ inputs.branch_sha_tag }}
+      target_registry: ${{ inputs.target_registry }}
+      push_enabled: ${{ inputs.push_enabled }}
+      is_main_branch: ${{ inputs.is_main_branch }}
+    secrets:
+      NVCR_USERNAME: ${{ secrets.NVCR_USERNAME }}
+      NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}
 
   # Build summary
   build-summary:
@@ -962,7 +217,7 @@ jobs:
           echo "- **Registry**: \`${{ inputs.target_registry }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Push Enabled**: \`${{ inputs.push_enabled }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Is Main Branch**: \`${{ inputs.is_main_branch }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Ref Name**: \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Platforms**: \`linux/amd64, linux/arm64\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           if [ "${{ inputs.push_enabled }}" = "false" ]; then
             echo "> **Note**: Images were built but NOT pushed to registry (build-only mode)" >> $GITHUB_STEP_SUMMARY
@@ -970,6 +225,10 @@ jobs:
           fi
           echo "## Docker Image Tags" >> $GITHUB_STEP_SUMMARY
           echo "All images tagged with: \`${{ inputs.branch_sha_tag }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Multi-architecture support:**" >> $GITHUB_STEP_SUMMARY
+          echo "- \`linux/amd64\` (x86_64)" >> $GITHUB_STEP_SUMMARY
+          echo "- \`linux/arm64\` (aarch64)" >> $GITHUB_STEP_SUMMARY
           if [ "${{ inputs.is_main_branch }}" = "true" ] || [ "${{ github.ref_name }}" = "main" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**Main branch additional tags:**" >> $GITHUB_STEP_SUMMARY
@@ -978,16 +237,16 @@ jobs:
           fi
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "## Images Built" >> $GITHUB_STEP_SUMMARY
-          echo "1. \`carbide-rest-api:${{ inputs.branch_sha_tag }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "2. \`carbide-rest-db:${{ inputs.branch_sha_tag }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "3. \`carbide-rest-site-manager:${{ inputs.branch_sha_tag }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "4. \`carbide-rest-workflow:${{ inputs.branch_sha_tag }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "5. \`carbide-rest-site-agent:${{ inputs.branch_sha_tag }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "6. \`carbide-rest-cert-manager:${{ inputs.branch_sha_tag }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "1. \`carbide-rest-api:${{ inputs.branch_sha_tag }}\` (amd64 + arm64)" >> $GITHUB_STEP_SUMMARY
+          echo "2. \`carbide-rest-db:${{ inputs.branch_sha_tag }}\` (amd64 + arm64)" >> $GITHUB_STEP_SUMMARY
+          echo "3. \`carbide-rest-site-manager:${{ inputs.branch_sha_tag }}\` (amd64 + arm64)" >> $GITHUB_STEP_SUMMARY
+          echo "4. \`carbide-rest-workflow:${{ inputs.branch_sha_tag }}\` (amd64 + arm64)" >> $GITHUB_STEP_SUMMARY
+          echo "5. \`carbide-rest-site-agent:${{ inputs.branch_sha_tag }}\` (amd64 + arm64)" >> $GITHUB_STEP_SUMMARY
+          echo "6. \`carbide-rest-cert-manager:${{ inputs.branch_sha_tag }}\` (amd64 + arm64)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           if [ "${{ inputs.is_main_branch }}" = "true" ] || [ "${{ github.ref_name }}" = "main" ]; then
             echo "## Binary Artifacts Uploaded (Main Branch)" >> $GITHUB_STEP_SUMMARY
-            echo "Each binary uploaded with versions: \`${{ inputs.semantic_version }}\`, \`latest\`, \`${{ inputs.branch_sha_tag }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "Each binary uploaded for both amd64 and arm64 with versions: \`${{ inputs.semantic_version }}\`, \`latest\`, \`${{ inputs.branch_sha_tag }}\`" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
           fi
           echo "## Job Status" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-push-service.yml
+++ b/.github/workflows/build-push-service.yml
@@ -1,0 +1,259 @@
+# SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+name: Build and Push Service
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: 'Runner type for the build job'
+        required: false
+        default: 'ubuntu-latest'
+        type: string
+      service_name:
+        description: 'Service name (e.g., carbide-rest-api)'
+        required: true
+        type: string
+      binary_name:
+        description: 'Binary name in artifacts (e.g., api, migrations, sitemgr)'
+        required: true
+        type: string
+      binary_path:
+        description: 'Path to binary in container (e.g., /app/api)'
+        required: true
+        type: string
+      dockerfile:
+        description: 'Path to Dockerfile'
+        required: true
+        type: string
+      semantic_version:
+        description: 'Semantic version from VERSION file'
+        required: true
+        type: string
+      short_sha:
+        description: 'Short SHA for tagging'
+        required: true
+        type: string
+      branch_sha_tag:
+        description: 'Combined branch name and short SHA tag'
+        required: true
+        type: string
+      target_registry:
+        description: 'Target NVCR registry path'
+        required: true
+        type: string
+      push_enabled:
+        description: 'Whether to push images to registry'
+        required: true
+        type: boolean
+      is_main_branch:
+        description: 'Whether this is the main branch'
+        required: true
+        type: string
+      ngc_path:
+        description: 'NGC path for resource uploads'
+        required: false
+        default: '0837451325059433/carbide-dev'
+        type: string
+    secrets:
+      NVCR_USERNAME:
+        description: 'NVCR username'
+        required: false
+      NVCR_TOKEN:
+        description: 'NVCR token'
+        required: false
+
+jobs:
+  build:
+    name: Build ${{ inputs.service_name }}
+    runs-on: ${{ inputs.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU for multi-architecture builds
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to NVCR
+        if: inputs.push_enabled == true
+        uses: docker/login-action@v3
+        with:
+          registry: nvcr.io
+          username: ${{ secrets.NVCR_USERNAME }}
+          password: ${{ secrets.NVCR_TOKEN }}
+
+      - name: Determine Docker tags
+        id: docker-tags
+        run: |
+          # Always include branch-sha tag
+          TAGS="${{ inputs.target_registry }}/${{ inputs.service_name }}:${{ inputs.branch_sha_tag }}"
+
+          # On main branch, also add semantic version and latest tags
+          if [ "${{ inputs.is_main_branch }}" = "true" ] || [ "${{ github.ref_name }}" = "main" ]; then
+            TAGS="${TAGS},${{ inputs.target_registry }}/${{ inputs.service_name }}:${{ inputs.semantic_version }}"
+            TAGS="${TAGS},${{ inputs.target_registry }}/${{ inputs.service_name }}:latest"
+          fi
+
+          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+
+      - name: Build and push ${{ inputs.service_name }} (multi-arch)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ inputs.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: ${{ inputs.push_enabled }}
+          tags: ${{ steps.docker-tags.outputs.tags }}
+          cache-from: type=gha,scope=${{ inputs.service_name }}
+          cache-to: type=gha,mode=max,scope=${{ inputs.service_name }}
+          labels: |
+            org.opencontainers.image.title=${{ inputs.service_name }}
+            org.opencontainers.image.version=${{ inputs.semantic_version }}
+            org.opencontainers.image.revision=${{ inputs.short_sha }}
+            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
+            org.opencontainers.image.url=${{ github.repositoryUrl }}
+
+      - name: Extract amd64 binary from image
+        if: (inputs.is_main_branch == 'true' || github.ref_name == 'main') && inputs.push_enabled == true
+        run: |
+          mkdir -p artifacts
+          docker pull --platform linux/amd64 ${{ inputs.target_registry }}/${{ inputs.service_name }}:${{ inputs.branch_sha_tag }}
+          docker create --name temp-container --platform linux/amd64 ${{ inputs.target_registry }}/${{ inputs.service_name }}:${{ inputs.branch_sha_tag }}
+          docker cp temp-container:${{ inputs.binary_path }} artifacts/${{ inputs.binary_name }}-amd64
+          docker rm temp-container
+          chmod +x artifacts/${{ inputs.binary_name }}-amd64
+
+      - name: Extract arm64 binary from image
+        if: (inputs.is_main_branch == 'true' || github.ref_name == 'main') && inputs.push_enabled == true
+        run: |
+          docker pull --platform linux/arm64 ${{ inputs.target_registry }}/${{ inputs.service_name }}:${{ inputs.branch_sha_tag }}
+          docker create --name temp-container-arm --platform linux/arm64 ${{ inputs.target_registry }}/${{ inputs.service_name }}:${{ inputs.branch_sha_tag }}
+          docker cp temp-container-arm:${{ inputs.binary_path }} artifacts/${{ inputs.binary_name }}-arm64
+          docker rm temp-container-arm
+          chmod +x artifacts/${{ inputs.binary_name }}-arm64
+
+      - name: Export Docker image
+        if: (inputs.is_main_branch == 'true' || github.ref_name == 'main') && inputs.push_enabled == true
+        run: |
+          docker save ${{ inputs.target_registry }}/${{ inputs.service_name }}:${{ inputs.branch_sha_tag }} | gzip > artifacts/${{ inputs.service_name }}-${{ inputs.branch_sha_tag }}.tar.gz
+
+      # Upload amd64 binary artifacts
+      - name: Upload binary artifact with semantic version
+        if: (inputs.is_main_branch == 'true' || github.ref_name == 'main') && inputs.push_enabled == true
+        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
+        with:
+          name: ${{ inputs.service_name }}-binary-amd64
+          display-name: ${{ inputs.service_name }}-binary-amd64
+          description: ${{ inputs.service_name }} binary (amd64)
+          version: ${{ inputs.semantic_version }}
+          path: artifacts/${{ inputs.binary_name }}-amd64
+          ngc-path: ${{ inputs.ngc_path }}
+          ngc-key: ${{ secrets.NVCR_TOKEN }}
+
+      - name: Upload binary artifact with latest tag
+        if: (inputs.is_main_branch == 'true' || github.ref_name == 'main') && inputs.push_enabled == true
+        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
+        with:
+          name: ${{ inputs.service_name }}-binary-amd64
+          display-name: ${{ inputs.service_name }}-binary-amd64
+          description: ${{ inputs.service_name }} binary (amd64)
+          version: latest
+          path: artifacts/${{ inputs.binary_name }}-amd64
+          ngc-path: ${{ inputs.ngc_path }}
+          ngc-key: ${{ secrets.NVCR_TOKEN }}
+
+      - name: Upload binary artifact with branch-sha tag
+        if: (inputs.is_main_branch == 'true' || github.ref_name == 'main') && inputs.push_enabled == true
+        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
+        with:
+          name: ${{ inputs.service_name }}-binary-amd64
+          display-name: ${{ inputs.service_name }}-binary-amd64
+          description: ${{ inputs.service_name }} binary (amd64)
+          version: ${{ inputs.branch_sha_tag }}
+          path: artifacts/${{ inputs.binary_name }}-amd64
+          ngc-path: ${{ inputs.ngc_path }}
+          ngc-key: ${{ secrets.NVCR_TOKEN }}
+
+      # Upload arm64 binary artifacts
+      - name: Upload arm64 binary artifact with semantic version
+        if: (inputs.is_main_branch == 'true' || github.ref_name == 'main') && inputs.push_enabled == true
+        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
+        with:
+          name: ${{ inputs.service_name }}-binary-arm64
+          display-name: ${{ inputs.service_name }}-binary-arm64
+          description: ${{ inputs.service_name }} binary (arm64)
+          version: ${{ inputs.semantic_version }}
+          path: artifacts/${{ inputs.binary_name }}-arm64
+          ngc-path: ${{ inputs.ngc_path }}
+          ngc-key: ${{ secrets.NVCR_TOKEN }}
+
+      - name: Upload arm64 binary artifact with latest tag
+        if: (inputs.is_main_branch == 'true' || github.ref_name == 'main') && inputs.push_enabled == true
+        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
+        with:
+          name: ${{ inputs.service_name }}-binary-arm64
+          display-name: ${{ inputs.service_name }}-binary-arm64
+          description: ${{ inputs.service_name }} binary (arm64)
+          version: latest
+          path: artifacts/${{ inputs.binary_name }}-arm64
+          ngc-path: ${{ inputs.ngc_path }}
+          ngc-key: ${{ secrets.NVCR_TOKEN }}
+
+      - name: Upload arm64 binary artifact with branch-sha tag
+        if: (inputs.is_main_branch == 'true' || github.ref_name == 'main') && inputs.push_enabled == true
+        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
+        with:
+          name: ${{ inputs.service_name }}-binary-arm64
+          display-name: ${{ inputs.service_name }}-binary-arm64
+          description: ${{ inputs.service_name }} binary (arm64)
+          version: ${{ inputs.branch_sha_tag }}
+          path: artifacts/${{ inputs.binary_name }}-arm64
+          ngc-path: ${{ inputs.ngc_path }}
+          ngc-key: ${{ secrets.NVCR_TOKEN }}
+
+      # Upload Docker image artifacts
+      - name: Upload Docker image artifact with semantic version
+        if: (inputs.is_main_branch == 'true' || github.ref_name == 'main') && inputs.push_enabled == true
+        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
+        with:
+          name: ${{ inputs.service_name }}-image
+          display-name: ${{ inputs.service_name }}-image
+          description: ${{ inputs.service_name }} image
+          version: ${{ inputs.semantic_version }}
+          path: artifacts/${{ inputs.service_name }}-${{ inputs.branch_sha_tag }}.tar.gz
+          ngc-path: ${{ inputs.ngc_path }}
+          ngc-key: ${{ secrets.NVCR_TOKEN }}
+
+      - name: Upload Docker image artifact with latest tag
+        if: (inputs.is_main_branch == 'true' || github.ref_name == 'main') && inputs.push_enabled == true
+        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
+        with:
+          name: ${{ inputs.service_name }}-image
+          display-name: ${{ inputs.service_name }}-image
+          description: ${{ inputs.service_name }} image
+          version: latest
+          path: artifacts/${{ inputs.service_name }}-${{ inputs.branch_sha_tag }}.tar.gz
+          ngc-path: ${{ inputs.ngc_path }}
+          ngc-key: ${{ secrets.NVCR_TOKEN }}
+
+      - name: Upload Docker image artifact with branch-sha tag
+        if: (inputs.is_main_branch == 'true' || github.ref_name == 'main') && inputs.push_enabled == true
+        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
+        with:
+          name: ${{ inputs.service_name }}-image
+          display-name: ${{ inputs.service_name }}-image
+          description: ${{ inputs.service_name }} image
+          version: ${{ inputs.branch_sha_tag }}
+          path: artifacts/${{ inputs.service_name }}-${{ inputs.branch_sha_tag }}.tar.gz
+          ngc-path: ${{ inputs.ngc_path }}
+          ngc-key: ${{ secrets.NVCR_TOKEN }}

--- a/docker/production/Dockerfile.carbide-rest-api
+++ b/docker/production/Dockerfile.carbide-rest-api
@@ -9,12 +9,16 @@
 # its affiliates is strictly prohibited.
 
 # Build stage
-FROM golang:1.25.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.1 AS builder
 
-# Set environment variables
+# Docker automatically provides these args during multi-platform builds
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+
+# Set environment variables for cross-compilation
 ENV CGO_ENABLED=0
-ENV GOOS=linux
-ENV GOARCH=amd64
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/production/Dockerfile.carbide-rest-cert-manager
+++ b/docker/production/Dockerfile.carbide-rest-cert-manager
@@ -9,12 +9,16 @@
 # its affiliates is strictly prohibited.
 
 # Build stage
-FROM golang:1.25.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.1 AS builder
 
-# Set environment variables
+# Docker automatically provides these args during multi-platform builds
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+
+# Set environment variables for cross-compilation
 ENV CGO_ENABLED=0
-ENV GOOS=linux
-ENV GOARCH=amd64
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/production/Dockerfile.carbide-rest-db
+++ b/docker/production/Dockerfile.carbide-rest-db
@@ -9,12 +9,16 @@
 # its affiliates is strictly prohibited.
 
 # Build stage
-FROM golang:1.25.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.1 AS builder
 
-# Set environment variables
+# Docker automatically provides these args during multi-platform builds
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+
+# Set environment variables for cross-compilation
 ENV CGO_ENABLED=0
-ENV GOOS=linux
-ENV GOARCH=amd64
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/production/Dockerfile.carbide-rest-site-agent
+++ b/docker/production/Dockerfile.carbide-rest-site-agent
@@ -9,12 +9,16 @@
 # its affiliates is strictly prohibited.
 
 # Build stage
-FROM golang:1.25.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.1 AS builder
 
-# Set environment variables
+# Docker automatically provides these args during multi-platform builds
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+
+# Set environment variables for cross-compilation
 ENV CGO_ENABLED=0
-ENV GOOS=linux
-ENV GOARCH=amd64
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/production/Dockerfile.carbide-rest-site-manager
+++ b/docker/production/Dockerfile.carbide-rest-site-manager
@@ -9,12 +9,16 @@
 # its affiliates is strictly prohibited.
 
 # Build stage
-FROM golang:1.25.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.1 AS builder
 
-# Set environment variables
+# Docker automatically provides these args during multi-platform builds
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+
+# Set environment variables for cross-compilation
 ENV CGO_ENABLED=0
-ENV GOOS=linux
-ENV GOARCH=amd64
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/production/Dockerfile.carbide-rest-workflow
+++ b/docker/production/Dockerfile.carbide-rest-workflow
@@ -9,12 +9,16 @@
 # its affiliates is strictly prohibited.
 
 # Build stage
-FROM golang:1.25.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.1 AS builder
 
-# Set environment variables
+# Docker automatically provides these args during multi-platform builds
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+
+# Set environment variables for cross-compilation
 ENV CGO_ENABLED=0
-ENV GOOS=linux
-ENV GOARCH=amd64
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Issue

https://github.com/NVIDIA/carbide-rest/issues/27

## Changes

### Dockerfiles (`docker/production/Dockerfile.carbide-rest-*`)
- Added `--platform=$BUILDPLATFORM` to builder stage for native compilation speed
- Replaced hardcoded `GOARCH=amd64` with Docker build args (`TARGETARCH`), to make Go cross-compiles to target architecture automatically

### GitHub Actions (`.github/workflows/build-push-docker.yml`)
- Added QEMU setup for ARM emulation on x86 runners ([ref](https://docs.docker.com/build/ci/github-actions/multi-platform)) - QEMU emulates ARM when running on x86 runners (and vice versa).
- Changed build platforms from `linux/amd64` to `linux/amd64,linux/arm64`
- Removed `load: true` (incompatible with multi-platform builds) - when it enabled, Docker will load the built image into the local Docker daemon. However, the local Docker daemon can only hold images for one architecture at a time (should  be the native architecture of the host).
- Added architecture suffix to arm binary artifacts (`-arm64`) but keep amd64 as current naming convention, and updated artifact extraction to pull images from registry after push
- Extracted common build logic to `.github/actions/build-push-service/action.yml`
- Changed the resource naming from `carbide-rest-*-binary` to `carbide-rest-*-binary-{arm64|amd64}`

### Makefile
- Added `make build-amd64` - build binaries for x86_64
- Added `make build-arm64` - build binaries for ARM64
- Added `make build-all` - build for both architectures
- Added `make docker-build-multiarch` - build & push multi-arch images

## Tests

### Container Images 

Supported multiple arch as below - 

<img width="2667" height="488" alt="image" src="https://github.com/user-attachments/assets/28d5586c-140d-4e67-b32d-ab3f3082e7e5" />

### Resources

Built the resource binrary as below 

<img width="2327" height="722" alt="image" src="https://github.com/user-attachments/assets/9896ce85-b7f5-4dd9-adde-faaa86affb8b" />

