### PR TITLE
fix: Only run promotion workflow on main branch

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -63,12 +63,13 @@ jobs:
       NVCR_USERNAME: ${{ secrets.NVCR_STG_USERNAME }}
       NVCR_TOKEN: ${{ secrets.NVCR_STG_TOKEN }}
 
-  # Step 4: Promote to release candidate
+  # Step 4: Promote to release candidate (only on main branch)
   promote-carbide-rest-to-release-candidate:
     name: Promote Carbide REST to Release Candidate
     needs:
       - prepare
       - build-and-push
+    if: github.ref == 'refs/heads/main'
     uses: ./.github/workflows/promotion.yaml
     with:
       runner: ubuntu-latest


### PR DESCRIPTION
## Problem

The promotion job runs on all branches, causing PRs to show a pending "Promote to Release Candidate" check waiting for approval. We shouldn't be promoting images from unmerged PR branches.

## Solution

Add `if: github.ref == 'refs/heads/main'` to the promotion job so it only runs after code is merged to main.