### PR TITLE
Fix: Deploy cert-manager.io with Vault ClusterIssuer

### DIFF
--- a/deploy/kustomize/base/cert-manager-io/cluster-issuer.yaml
+++ b/deploy/kustomize/base/cert-manager-io/cluster-issuer.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+# ClusterIssuer using Vault PKI backend (embedded in cert-manager pod)
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: vault-issuer
+spec:
+  vault:
+    # Vault server URL (embedded in carbide-rest-cert-manager pod)
+    server: http://carbide-rest-cert-manager.carbide.svc.cluster.local:8200
+    # PKI path and role configured in Vault
+    path: pki/sign/cloud-cert
+    auth:
+      tokenSecretRef:
+        name: vault-token
+        key: token

--- a/deploy/kustomize/base/cert-manager-io/kustomization.yaml
+++ b/deploy/kustomize/base/cert-manager-io/kustomization.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+# cert-manager.io configuration with Vault issuer
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - vault-token-secret.yaml
+  - cluster-issuer.yaml

--- a/deploy/kustomize/base/cert-manager-io/vault-token-secret.yaml
+++ b/deploy/kustomize/base/cert-manager-io/vault-token-secret.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+# Vault token for cert-manager.io to authenticate with Vault PKI
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vault-token
+  namespace: cert-manager
+type: Opaque
+stringData:
+  token: "root"


### PR DESCRIPTION
Adds cert-manager.io to the local Kind cluster setup.

- Installs cert-manager.io during make kind-reset
- Configures ClusterIssuer to use embedded Vault PKI backend
- Verified certificate issuance works end-to-end

Closes #47