### PR TITLE
chore: Use non-deprecated UserData field

### DIFF
--- a/api/pkg/api/handler/instance.go
+++ b/api/pkg/api/handler/instance.go
@@ -94,9 +94,9 @@ func (cih CreateInstanceHandler) buildInstanceCreateRequestOsConfig(c echo.Conte
 			Variant: &cwssaws.OperatingSystem_Ipxe{
 				Ipxe: &cwssaws.IpxeOperatingSystem{
 					IpxeScript: *apiRequest.IpxeScript,
-					UserData:   apiRequest.UserData,
 				},
 			},
+			UserData: apiRequest.UserData,
 		}, nil, nil
 	}
 
@@ -185,9 +185,9 @@ func (cih CreateInstanceHandler) buildInstanceCreateRequestOsConfig(c echo.Conte
 			Variant: &cwssaws.OperatingSystem_Ipxe{
 				Ipxe: &cwssaws.IpxeOperatingSystem{
 					IpxeScript: *apiRequest.IpxeScript,
-					UserData:   apiRequest.UserData,
 				},
 			},
+			UserData: apiRequest.UserData,
 		}, osID, nil
 	} else {
 		return &cwssaws.OperatingSystem{
@@ -1609,9 +1609,9 @@ func (uih UpdateInstanceHandler) buildInstanceUpdateRequestOsConfig(c echo.Conte
 			Variant: &cwssaws.OperatingSystem_Ipxe{
 				Ipxe: &cwssaws.IpxeOperatingSystem{
 					IpxeScript: *apiRequest.IpxeScript,
-					UserData:   apiRequest.UserData,
 				},
 			},
+			UserData: apiRequest.UserData,
 		}, nil, nil
 	}
 
@@ -1743,9 +1743,9 @@ func (uih UpdateInstanceHandler) buildInstanceUpdateRequestOsConfig(c echo.Conte
 				Variant: &cwssaws.OperatingSystem_Ipxe{
 					Ipxe: &cwssaws.IpxeOperatingSystem{
 						IpxeScript: *ipxeScript,
-						UserData:   userData,
 					},
 				},
+				UserData: userData,
 			}, osID, nil
 		} else if os.Type == cdbm.OperatingSystemTypeImage {
 			return &cwssaws.OperatingSystem{
@@ -1766,9 +1766,9 @@ func (uih UpdateInstanceHandler) buildInstanceUpdateRequestOsConfig(c echo.Conte
 		Variant: &cwssaws.OperatingSystem_Ipxe{
 			Ipxe: &cwssaws.IpxeOperatingSystem{
 				IpxeScript: *ipxeScript,
-				UserData:   userData,
 			},
 		},
+		UserData: userData,
 	}, osID, nil
 }
 

--- a/api/pkg/api/handler/instancebatch.go
+++ b/api/pkg/api/handler/instancebatch.go
@@ -92,9 +92,9 @@ func (bcih BatchCreateInstanceHandler) buildBatchInstanceCreateRequestOsConfig(c
 			Variant: &cwssaws.OperatingSystem_Ipxe{
 				Ipxe: &cwssaws.IpxeOperatingSystem{
 					IpxeScript: *apiRequest.IpxeScript,
-					UserData:   apiRequest.UserData,
 				},
 			},
+			UserData: apiRequest.UserData,
 		}, nil, nil
 	}
 
@@ -183,9 +183,9 @@ func (bcih BatchCreateInstanceHandler) buildBatchInstanceCreateRequestOsConfig(c
 			Variant: &cwssaws.OperatingSystem_Ipxe{
 				Ipxe: &cwssaws.IpxeOperatingSystem{
 					IpxeScript: *apiRequest.IpxeScript,
-					UserData:   apiRequest.UserData,
 				},
 			},
+			UserData: apiRequest.UserData,
 		}, osID, nil
 	} else {
 		return &cwssaws.OperatingSystem{

--- a/site-agent/pkg/components/instance_workflow_test.go
+++ b/site-agent/pkg/components/instance_workflow_test.go
@@ -22,9 +22,9 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.opentelemetry.io/otel"
 
-	wflows "github.com/nvidia/carbide-rest/workflow-schema/schema/site-agent/workflows/v1"
 	"github.com/nvidia/carbide-rest/site-agent/pkg/components/managers/carbide"
 	"github.com/nvidia/carbide-rest/site-agent/pkg/components/managers/instance"
+	wflows "github.com/nvidia/carbide-rest/workflow-schema/schema/site-agent/workflows/v1"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -333,9 +333,9 @@ func TestInstanceWorkflows(t *testing.T) {
 				Variant: &wflows.OperatingSystem_Ipxe{
 					Ipxe: &wflows.IpxeOperatingSystem{
 						IpxeScript: "#!ipxe",
-						UserData:   &testUserData,
 					},
 				},
+				UserData: &testUserData,
 			},
 		},
 		Status: &wflows.InstanceStatus{},

--- a/site-workflow/pkg/activity/instance_test.go
+++ b/site-workflow/pkg/activity/instance_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
-	cwssaws "github.com/nvidia/carbide-rest/workflow-schema/schema/site-agent/workflows/v1"
 	cClient "github.com/nvidia/carbide-rest/site-workflow/pkg/grpc/client"
+	cwssaws "github.com/nvidia/carbide-rest/workflow-schema/schema/site-agent/workflows/v1"
 )
 
 func TestManageInstance_UpdateInstanceConfigOnSite(t *testing.T) {
@@ -74,9 +74,9 @@ func TestManageInstance_UpdateInstanceConfigOnSite(t *testing.T) {
 							Variant: &cwssaws.OperatingSystem_Ipxe{
 								Ipxe: &cwssaws.IpxeOperatingSystem{
 									IpxeScript: ipxeScript,
-									UserData:   &userData,
 								},
 							},
+							UserData: &userData,
 						},
 					},
 				},
@@ -147,9 +147,9 @@ func TestManageInstance_CreateInstanceOnSiteOnSite(t *testing.T) {
 							Variant: &cwssaws.OperatingSystem_Ipxe{
 								Ipxe: &cwssaws.IpxeOperatingSystem{
 									IpxeScript: ipxeScript,
-									UserData:   &userData,
 								},
 							},
+							UserData: &userData,
 						},
 					},
 				},
@@ -228,9 +228,9 @@ func TestManageInstance_CreateInstancesOnSite(t *testing.T) {
 									Variant: &cwssaws.OperatingSystem_Ipxe{
 										Ipxe: &cwssaws.IpxeOperatingSystem{
 											IpxeScript: ipxeScript,
-											UserData:   &userData,
 										},
 									},
+									UserData: &userData,
 								},
 							},
 						},
@@ -252,9 +252,9 @@ func TestManageInstance_CreateInstancesOnSite(t *testing.T) {
 									Variant: &cwssaws.OperatingSystem_Ipxe{
 										Ipxe: &cwssaws.IpxeOperatingSystem{
 											IpxeScript: ipxeScript,
-											UserData:   &userData,
 										},
 									},
+									UserData: &userData,
 								},
 							},
 						},

--- a/site-workflow/pkg/workflow/instance_test.go
+++ b/site-workflow/pkg/workflow/instance_test.go
@@ -67,9 +67,9 @@ func (s *UpdateInstanceTestSuite) Test_UpdateInstance_Success() {
 				Variant: &cwssaws.OperatingSystem_Ipxe{
 					Ipxe: &cwssaws.IpxeOperatingSystem{
 						IpxeScript: ipxeScript,
-						UserData:   &userData,
 					},
 				},
+				UserData: &userData,
 			},
 		},
 	}
@@ -110,9 +110,9 @@ func (s *UpdateInstanceTestSuite) Test_UpdateInstance_Failure() {
 				Variant: &cwssaws.OperatingSystem_Ipxe{
 					Ipxe: &cwssaws.IpxeOperatingSystem{
 						IpxeScript: ipxeScript,
-						UserData:   &userData,
 					},
 				},
+				UserData: &userData,
 			},
 		},
 	}
@@ -174,9 +174,9 @@ func (s *CreateInstanceV2TestSuite) Test_CreateInstanceV2_Success() {
 				Variant: &cwssaws.OperatingSystem_Ipxe{
 					Ipxe: &cwssaws.IpxeOperatingSystem{
 						IpxeScript: ipxeScript,
-						UserData:   &userData,
 					},
 				},
+				UserData: &userData,
 			},
 		},
 	}
@@ -217,9 +217,9 @@ func (s *CreateInstanceV2TestSuite) Test_CreateInstanceV2_Failure() {
 				Variant: &cwssaws.OperatingSystem_Ipxe{
 					Ipxe: &cwssaws.IpxeOperatingSystem{
 						IpxeScript: ipxeScript,
-						UserData:   &userData,
 					},
 				},
+				UserData: &userData,
 			},
 		},
 	}
@@ -287,9 +287,9 @@ func (s *CreateInstancesTestSuite) Test_CreateInstances_Success() {
 						Variant: &cwssaws.OperatingSystem_Ipxe{
 							Ipxe: &cwssaws.IpxeOperatingSystem{
 								IpxeScript: ipxeScript,
-								UserData:   &userData,
 							},
 						},
+						UserData: &userData,
 					},
 				},
 			},
@@ -311,9 +311,9 @@ func (s *CreateInstancesTestSuite) Test_CreateInstances_Success() {
 						Variant: &cwssaws.OperatingSystem_Ipxe{
 							Ipxe: &cwssaws.IpxeOperatingSystem{
 								IpxeScript: ipxeScript,
-								UserData:   &userData,
 							},
 						},
+						UserData: &userData,
 					},
 				},
 			},
@@ -360,9 +360,9 @@ func (s *CreateInstancesTestSuite) Test_CreateInstances_Failure() {
 						Variant: &cwssaws.OperatingSystem_Ipxe{
 							Ipxe: &cwssaws.IpxeOperatingSystem{
 								IpxeScript: ipxeScript,
-								UserData:   &userData,
 							},
 						},
+						UserData: &userData,
 					},
 				},
 			},


### PR DESCRIPTION
The UserData field in the Carbide gRPC API is duplicated: One does only apply for the iPXE OS, the other for all OS types. This change moves site-agent from using the latter.