### PR TITLE
fix: Check power status DB attribute when filtering Instances by status

### DIFF
--- a/api/pkg/api/handler/instance_test.go
+++ b/api/pkg/api/handler/instance_test.go
@@ -421,7 +421,7 @@ func testInstanceBuildMachineInterface(t *testing.T, dbSession *cdb.Session, sub
 	return mi
 }
 
-func testInstanceBuildInstance(t *testing.T, dbSession *cdb.Session, name string, al uuid.UUID, alc uuid.UUID, tn uuid.UUID, ip uuid.UUID, st uuid.UUID, ist *uuid.UUID, vpc uuid.UUID, mc *string, os *uuid.UUID, ipxeScript *string, status string) *cdbm.Instance {
+func testInstanceBuildInstance(t *testing.T, dbSession *cdb.Session, name string, al uuid.UUID, alc uuid.UUID, tn uuid.UUID, ip uuid.UUID, st uuid.UUID, ist *uuid.UUID, vpc uuid.UUID, mc *string, os *uuid.UUID, ipxeScript *string, status string, powerStatus *string) *cdbm.Instance {
 	insID := uuid.New()
 	ins := &cdbm.Instance{
 		ID:                       insID,
@@ -444,6 +444,7 @@ func testInstanceBuildInstance(t *testing.T, dbSession *cdb.Session, name string
 		Created:                  cdb.GetCurTime(),
 		Updated:                  cdb.GetCurTime(),
 		Status:                   status,
+		PowerStatus:              powerStatus,
 	}
 	_, err := dbSession.DB.NewInsert().Model(ins).Exec(context.Background())
 	assert.Nil(t, err)
@@ -935,7 +936,7 @@ func TestCreateInstanceHandler_Handle(t *testing.T) {
 	// Create 25 test Instances
 	insts2 := []*cdbm.Instance{}
 	for i := 0; i < 25; i++ {
-		inst := testInstanceBuildInstance(t, dbSession, fmt.Sprintf("test-instance-%d", i), al2.ID, alc2.ID, tn2.ID, ip.ID, st2.ID, &ist2.ID, vpc3.ID, cdb.GetStrPtr(ms2[i].ID), &os3.ID, nil, cdbm.InstanceStatusReady)
+		inst := testInstanceBuildInstance(t, dbSession, fmt.Sprintf("test-instance-%d", i), al2.ID, alc2.ID, tn2.ID, ip.ID, st2.ID, &ist2.ID, vpc3.ID, cdb.GetStrPtr(ms2[i].ID), &os3.ID, nil, cdbm.InstanceStatusReady, nil)
 		assert.NotNil(t, inst)
 		insts2 = append(insts2, inst)
 	}
@@ -971,7 +972,7 @@ func TestCreateInstanceHandler_Handle(t *testing.T) {
 	subnet6 := testInstanceBuildSubnet(t, dbSession, "test-subnet-5", tn3, vpc6, cdb.GetUUIDPtr(uuid.New()), cdbm.SubnetStatusReady, tnu3)
 	assert.NotNil(t, subnet6)
 
-	inst3 := testInstanceBuildInstance(t, dbSession, "test-instance-2", al3.ID, alc4.ID, tn3.ID, ip.ID, st3.ID, &ist3.ID, vpc5.ID, nil, &os4.ID, nil, cdbm.InstanceStatusReady)
+	inst3 := testInstanceBuildInstance(t, dbSession, "test-instance-2", al3.ID, alc4.ID, tn3.ID, ip.ID, st3.ID, &ist3.ID, vpc5.ID, nil, &os4.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst3)
 
 	// Tenant 4
@@ -998,7 +999,7 @@ func TestCreateInstanceHandler_Handle(t *testing.T) {
 	subnet7 := testInstanceBuildSubnet(t, dbSession, "test-subnet-7", tn5, vpc7, cdb.GetUUIDPtr(uuid.New()), cdbm.SubnetStatusReady, tnu5)
 
 	testInstanceBuildMachineInterface(t, dbSession, subnet7.ID, mc5.ID)
-	inst4 := testInstanceBuildInstance(t, dbSession, "test-instance-9001", al5.ID, alc5.ID, tn5.ID, ip.ID, st4.ID, &ist5.ID, vpc7.ID, nil, &os5.ID, nil, cdbm.InstanceStatusReady)
+	inst4 := testInstanceBuildInstance(t, dbSession, "test-instance-9001", al5.ID, alc5.ID, tn5.ID, ip.ID, st4.ID, &ist5.ID, vpc7.ID, nil, &os5.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst4)
 
 	// Build components for multiple allocation constraint test
@@ -1025,7 +1026,7 @@ func TestCreateInstanceHandler_Handle(t *testing.T) {
 	subnet8 := testInstanceBuildSubnet(t, dbSession, "test-subnet-8", tn6, vpc8, cdb.GetUUIDPtr(uuid.New()), cdbm.SubnetStatusReady, tnu6)
 	testInstanceBuildMachineInterface(t, dbSession, subnet8.ID, mc6.ID)
 
-	inst6 := testInstanceBuildInstance(t, dbSession, "test-instance-900100", al6.ID, alc6.ID, tn5.ID, ip.ID, st6.ID, &ist6.ID, vpc8.ID, nil, &os6.ID, nil, cdbm.InstanceStatusReady)
+	inst6 := testInstanceBuildInstance(t, dbSession, "test-instance-900100", al6.ID, alc6.ID, tn5.ID, ip.ID, st6.ID, &ist6.ID, vpc8.ID, nil, &os6.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst6)
 
 	// Tenant 7
@@ -1106,7 +1107,7 @@ func TestCreateInstanceHandler_Handle(t *testing.T) {
 	vpcPrefix5 := common.TestBuildVPCPrefix(t, dbSession, "test-vpcprefix-5", st1, tn1, vpc9.ID, &ipb5.ID, cdb.GetStrPtr("192.168.0.0/24"), cdb.GetIntPtr(24), cdbm.VpcPrefixStatusReady, tnu1)
 	vpcPrefix7 := common.TestBuildVPCPrefix(t, dbSession, "test-vpcprefix-7", st1, tn1, vpc9.ID, &ipb5.ID, cdb.GetStrPtr("192.168.0.0/24"), cdb.GetIntPtr(24), cdbm.VpcPrefixStatusReady, tnu1)
 	/*
-		inst4 := testInstanceBuildInstance(t, dbSession, "test-instance-9001", al5.ID, alc5.ID, tn5.ID, ip.ID, st4.ID, ist5.ID, vpc7.ID, nil, &os5.ID, nil, cdbm.InstanceStatusReady)
+		inst4 := testInstanceBuildInstance(t, dbSession, "test-instance-9001", al5.ID, alc5.ID, tn5.ID, ip.ID, st4.ID, ist5.ID, vpc7.ID, nil, &os5.ID, nil, cdbm.InstanceStatusReady, nil)
 		assert.NotNil(t, inst4)
 	*/
 
@@ -3309,42 +3310,42 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 	mci1 := testInstanceBuildMachineInterface(t, dbSession, subnet1.ID, mc1.ID)
 	assert.NotNil(t, mci1)
 
-	inst1 := testInstanceBuildInstance(t, dbSession, "test-instance-1", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os2.ID, nil, cdbm.InstanceStatusReady)
+	inst1 := testInstanceBuildInstance(t, dbSession, "test-instance-1", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os2.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst1)
 
-	inst2 := testInstanceBuildInstance(t, dbSession, "test-instance-name-updated", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc2.ID), &os2.ID, nil, cdbm.InstanceStatusReady)
+	inst2 := testInstanceBuildInstance(t, dbSession, "test-instance-name-updated", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc2.ID), &os2.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst2)
 
-	inst3 := testInstanceBuildInstance(t, dbSession, "test-instance-3", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os2.ID, nil, cdbm.InstanceStatusTerminating)
+	inst3 := testInstanceBuildInstance(t, dbSession, "test-instance-3", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os2.ID, nil, cdbm.InstanceStatusTerminating, nil)
 	assert.NotNil(t, inst3)
 
-	instConfiguring := testInstanceBuildInstance(t, dbSession, "test-instance-configuring", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os2.ID, nil, cdbm.InstanceStatusConfiguring)
+	instConfiguring := testInstanceBuildInstance(t, dbSession, "test-instance-configuring", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os2.ID, nil, cdbm.InstanceStatusConfiguring, nil)
 	assert.NotNil(t, instConfiguring)
 
 	// Instance with iPXE OS type and user-data allowed
-	inst4 := testInstanceBuildInstance(t, dbSession, "test-instance-4", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os2.ID, nil, cdbm.InstanceStatusReady)
+	inst4 := testInstanceBuildInstance(t, dbSession, "test-instance-4", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os2.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst4)
 
 	// Instance with iPXE OS type and user-data NOT allowed
-	inst5 := testInstanceBuildInstance(t, dbSession, "test-instance-5", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os3.ID, nil, cdbm.InstanceStatusReady)
+	inst5 := testInstanceBuildInstance(t, dbSession, "test-instance-5", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os3.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst5)
 
-	inst6 := testInstanceBuildInstance(t, dbSession, "test-instance-6", al2.ID, alc2.ID, tn2.ID, ip.ID, st2.ID, &ist2.ID, vpc3.ID, cdb.GetStrPtr(mc3.ID), &os4.ID, nil, cdbm.InstanceStatusReady)
+	inst6 := testInstanceBuildInstance(t, dbSession, "test-instance-6", al2.ID, alc2.ID, tn2.ID, ip.ID, st2.ID, &ist2.ID, vpc3.ID, cdb.GetStrPtr(mc3.ID), &os4.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst6)
 
-	inst7 := testInstanceBuildInstance(t, dbSession, "test-instance-7", al2.ID, alc2.ID, tn2.ID, ip.ID, st2.ID, &ist2.ID, vpc3.ID, cdb.GetStrPtr(mc3.ID), &os5.ID, nil, cdbm.InstanceStatusReady)
+	inst7 := testInstanceBuildInstance(t, dbSession, "test-instance-7", al2.ID, alc2.ID, tn2.ID, ip.ID, st2.ID, &ist2.ID, vpc3.ID, cdb.GetStrPtr(mc3.ID), &os5.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst7)
 
-	inst8 := testInstanceBuildInstance(t, dbSession, "test-instance-8", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os2.ID, nil, cdbm.InstanceStatusReady)
+	inst8 := testInstanceBuildInstance(t, dbSession, "test-instance-8", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os2.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst8)
 
 	skgia8 := testInstanceBuildSSHKeyGroupInstanceAssociation(t, dbSession, skg1.ID, st1.ID, inst8.ID)
 	assert.NotNil(t, skgia8)
 
-	inst9 := testInstanceBuildInstance(t, dbSession, "test-instance-9", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os2.ID, nil, cdbm.InstanceStatusReady)
+	inst9 := testInstanceBuildInstance(t, dbSession, "test-instance-9", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os2.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst9)
 
-	inst10 := testInstanceBuildInstance(t, dbSession, "test-instance-10", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os2.ID, nil, cdbm.InstanceStatusReady)
+	inst10 := testInstanceBuildInstance(t, dbSession, "test-instance-10", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os2.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst10)
 
 	instsub1 := testInstanceBuildInstanceInterface(t, dbSession, inst1.ID, &subnet1.ID, nil, nil, cdbm.InterfaceStatusReady)
@@ -3390,10 +3391,10 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 	vpcPrefix3 := common.TestBuildVPCPrefix(t, dbSession, "test-vpcprefix-3", st3, tn1, vpc4.ID, &ipb3.ID, cdb.GetStrPtr("192.152.0.0/24"), cdb.GetIntPtr(24), cdbm.VpcPrefixStatusReady, tnu1)
 	assert.NotNil(t, vpcPrefix3)
 
-	inst11 := testInstanceBuildInstance(t, dbSession, "test-instance-11", al3.ID, alc3.ID, tn1.ID, ip.ID, st3.ID, &ist1.ID, vpc4.ID, cdb.GetStrPtr(mc1.ID), &os2.ID, nil, cdbm.InstanceStatusReady)
+	inst11 := testInstanceBuildInstance(t, dbSession, "test-instance-11", al3.ID, alc3.ID, tn1.ID, ip.ID, st3.ID, &ist1.ID, vpc4.ID, cdb.GetStrPtr(mc1.ID), &os2.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst11)
 
-	inst12 := testInstanceBuildInstance(t, dbSession, "test-instance-12", al3.ID, alc3.ID, tn1.ID, ip.ID, st3.ID, &ist4.ID, vpc4.ID, cdb.GetStrPtr(mc5.ID), &os2.ID, nil, cdbm.InstanceStatusReady)
+	inst12 := testInstanceBuildInstance(t, dbSession, "test-instance-12", al3.ID, alc3.ID, tn1.ID, ip.ID, st3.ID, &ist4.ID, vpc4.ID, cdb.GetStrPtr(mc5.ID), &os2.ID, nil, cdbm.InstanceStatusReady, nil)
 
 	instifc1 := testInstanceBuildInstanceInterface(t, dbSession, inst12.ID, nil, &vpcPrefix1.ID, nil, cdbm.InterfaceStatusReady)
 	assert.NotNil(t, instifc1)
@@ -3404,7 +3405,7 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 	// Add Network DPU capability to Instance Type
 	common.TestBuildMachineCapability(t, dbSession, nil, &ist4.ID, cdbm.MachineCapabilityTypeNetwork, "MT42822 BlueField-2 integrated ConnectX-6 Dx network controller", nil, nil, cdb.GetStrPtr("Mellanox Technologies"), cdb.GetIntPtr(2), cdb.GetStrPtr("DPU"), nil)
 
-	inst13 := testInstanceBuildInstance(t, dbSession, "test-instance-nvlink-update", al3.ID, alc3.ID, tn1.ID, ip.ID, st3.ID, &ist4.ID, vpc4.ID, cdb.GetStrPtr(mc5.ID), &os2.ID, nil, cdbm.InstanceStatusReady)
+	inst13 := testInstanceBuildInstance(t, dbSession, "test-instance-nvlink-update", al3.ID, alc3.ID, tn1.ID, ip.ID, st3.ID, &ist4.ID, vpc4.ID, cdb.GetStrPtr(mc5.ID), &os2.ID, nil, cdbm.InstanceStatusReady, nil)
 
 	// Add NVLink GPU capability to Machine
 	common.TestBuildMachineCapability(t, dbSession, &mc5.ID, nil, cdbm.MachineCapabilityTypeGPU, "NVIDIA GB200", nil, nil, cdb.GetStrPtr("NVIDIA"), cdb.GetIntPtr(4), cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink), nil)
@@ -5193,7 +5194,7 @@ func TestGetInstanceHandler_Handle(t *testing.T) {
 	mci1 := testInstanceBuildMachineInterface(t, dbSession, subnet1.ID, mc1.ID)
 	assert.NotNil(t, mci1)
 
-	inst1 := testInstanceBuildInstance(t, dbSession, "test-instance-2", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady)
+	inst1 := testInstanceBuildInstance(t, dbSession, "test-instance-2", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst1)
 
 	// Attach an NSG to this instance
@@ -5217,12 +5218,12 @@ func TestGetInstanceHandler_Handle(t *testing.T) {
 	desd1 := common.TestBuildDpuExtensionServiceDeployment(t, dbSession, des1, inst1.ID, "1.0.0", cdbm.DpuExtensionServiceDeploymentStatusRunning, tnu1)
 	assert.NotNil(t, desd1)
 
-	inst2 := testInstanceBuildInstance(t, dbSession, "test-instance-3", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc2.ID), &os1.ID, nil, cdbm.InstanceStatusReady)
+	inst2 := testInstanceBuildInstance(t, dbSession, "test-instance-3", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc2.ID), &os1.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst2)
 
 	inst2.ControllerInstanceID = cdb.GetUUIDPtr(uuid.New())
 
-	inst3 := testInstanceBuildInstance(t, dbSession, "test-instance-4", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc2.ID, cdb.GetStrPtr(mc3.ID), &os1.ID, nil, cdbm.InstanceStatusReady)
+	inst3 := testInstanceBuildInstance(t, dbSession, "test-instance-4", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc2.ID, cdb.GetStrPtr(mc3.ID), &os1.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst3)
 
 	e := echo.New()
@@ -5722,7 +5723,7 @@ func TestGetAllInstanceHandler_Handle(t *testing.T) {
 	instarr := []*cdbm.Instance{}
 	instsubarr := []*cdbm.Interface{}
 	for i := 11; i <= 35; i++ {
-		inst := testInstanceBuildInstance(t, dbSession, fmt.Sprintf("test-instance-%d", i), al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady)
+		inst := testInstanceBuildInstance(t, dbSession, fmt.Sprintf("test-instance-%d", i), al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady, nil)
 		assert.NotNil(t, inst)
 
 		instsub := testInstanceBuildInstanceInterface(t, dbSession, inst.ID, &subnet1.ID, nil, nil, cdbm.InterfaceStatusPending)
@@ -5754,7 +5755,7 @@ func TestGetAllInstanceHandler_Handle(t *testing.T) {
 	desd1 := common.TestBuildDpuExtensionServiceDeployment(t, dbSession, des1, inst1.ID, "1.0.0", cdbm.DpuExtensionServiceDeploymentStatusRunning, tnu1)
 	assert.NotNil(t, desd1)
 
-	inst2 := testInstanceBuildInstance(t, dbSession, "test-instance-vpc", al3.ID, alc2.ID, tn1.ID, ip.ID, st1.ID, &ist2.ID, vpc3.ID, cdb.GetStrPtr(mc2.ID), &os2.ID, cdb.GetStrPtr("test-ipxe-script"), cdbm.InstanceStatusReady)
+	inst2 := testInstanceBuildInstance(t, dbSession, "test-instance-vpc", al3.ID, alc2.ID, tn1.ID, ip.ID, st1.ID, &ist2.ID, vpc3.ID, cdb.GetStrPtr(mc2.ID), &os2.ID, cdb.GetStrPtr("test-ipxe-script"), cdbm.InstanceStatusReady, cdb.GetStrPtr(cdbm.InstancePowerStatusRebooting))
 	assert.NotNil(t, inst2)
 
 	instsub2 := testInstanceBuildInstanceInterface(t, dbSession, inst2.ID, &subnet1.ID, nil, nil, cdbm.InterfaceStatusPending)
@@ -5763,7 +5764,7 @@ func TestGetAllInstanceHandler_Handle(t *testing.T) {
 	common.TestBuildStatusDetail(t, dbSession, inst2.ID.String(), cdbm.InstanceStatusPending, cdb.GetStrPtr("request received, pending processing"))
 	common.TestBuildStatusDetail(t, dbSession, inst2.ID.String(), cdbm.InstanceStatusProvisioning, cdb.GetStrPtr("Instance is being provisioned on Site"))
 
-	inst4 := testInstanceBuildInstance(t, dbSession, "test-instance-no-site-id", al4.ID, alc3.ID, tn1.ID, ip.ID, st3.ID, &ist4.ID, vpc4.ID, cdb.GetStrPtr(mc3.ID), &os2.ID, cdb.GetStrPtr("test-ipxe-script"), cdbm.InstanceStatusReady)
+	inst4 := testInstanceBuildInstance(t, dbSession, "test-instance-no-site-id", al4.ID, alc3.ID, tn1.ID, ip.ID, st3.ID, &ist4.ID, vpc4.ID, cdb.GetStrPtr(mc3.ID), &os2.ID, cdb.GetStrPtr("test-ipxe-script"), cdbm.InstanceStatusError, nil)
 	assert.NotNil(t, inst4)
 
 	// Setup instances with specific IP addresses for IP filtering tests
@@ -6492,7 +6493,7 @@ func TestGetAllInstanceHandler_Handle(t *testing.T) {
 			},
 			wantErr:       false,
 			expectedCount: 20,
-			expectedTotal: 26,
+			expectedTotal: 25,
 		},
 		{
 			name: "test Instance getall API endpoint success multiple statuses",
@@ -6503,18 +6504,18 @@ func TestGetAllInstanceHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqInstance:                 nil,
-				reqSiteIDs:                  []string{st1.ID.String()},
+				reqSiteIDs:                  []string{st1.ID.String(), st3.ID.String()},
 				reqInfrastructureProviderID: "",
 				reqOrg:                      tnOrg1,
 				reqUser:                     tnu1,
 				respCode:                    http.StatusOK,
 			},
 			filter: cdbm.InstanceFilterInput{
-				Statuses: []string{cdbm.InstanceStatusReady, cdbm.InstanceStatusPending},
+				Statuses: []string{cdbm.InstancePowerStatusRebooting, cdbm.InstancePowerStatusError},
 			},
 			wantErr:       false,
-			expectedCount: 20,
-			expectedTotal: 26,
+			expectedCount: 2,
+			expectedTotal: 2,
 		},
 		{
 			name: "test Instance getall API endpoint success with name filter",
@@ -7020,13 +7021,13 @@ func TestDeleteInstanceHandler_Handle(t *testing.T) {
 	mci1 := testInstanceBuildMachineInterface(t, dbSession, subnet1.ID, mc1.ID)
 	assert.NotNil(t, mci1)
 
-	inst1 := testInstanceBuildInstance(t, dbSession, "test-instance-2", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady)
+	inst1 := testInstanceBuildInstance(t, dbSession, "test-instance-2", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst1)
 
-	instVpcNotReady := testInstanceBuildInstance(t, dbSession, "test-instance-2", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc2.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady)
+	instVpcNotReady := testInstanceBuildInstance(t, dbSession, "test-instance-2", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc2.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst1)
 
-	instSiteNotReady := testInstanceBuildInstance(t, dbSession, "test-instance-2", al1.ID, alc1.ID, tn1.ID, ip.ID, stNotReady.ID, &ist1.ID, vpc3.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady)
+	instSiteNotReady := testInstanceBuildInstance(t, dbSession, "test-instance-2", al1.ID, alc1.ID, tn1.ID, ip.ID, stNotReady.ID, &ist1.ID, vpc3.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst1)
 
 	instsub1 := testInstanceBuildInstanceInterface(t, dbSession, inst1.ID, &subnet1.ID, nil, nil, cdbm.InterfaceStatusPending)
@@ -7643,7 +7644,7 @@ func TestInstanceHandler_GetStatusDetails(t *testing.T) {
 	vpc1 := testInstanceBuildVPC(t, dbSession, "test-vpc-1", ip, tn1, st1, cdb.GetUUIDPtr(uuid.New()), nil, cdb.GetStrPtr(cdbm.VpcEthernetVirtualizer), nil, cdbm.VpcStatusReady, tnu1)
 	assert.NotNil(t, vpc1)
 
-	inst1 := testInstanceBuildInstance(t, dbSession, "test-instance-2", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady)
+	inst1 := testInstanceBuildInstance(t, dbSession, "test-instance-2", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst1)
 
 	// add status details objects

--- a/api/pkg/api/handler/instance_test.go
+++ b/api/pkg/api/handler/instance_test.go
@@ -5814,6 +5814,7 @@ func TestGetAllInstanceHandler_Handle(t *testing.T) {
 		expectedIBInterfaceID                       *string
 		expectedDpuExtensionServiceDeploymentID     *string
 		expectedMachineIDOverride                   *string
+		expectedStatusOverride                      *string
 		expectedAnyNetworkSecurityGroupInherited    bool
 		expectedAnyNetworkSecurityGroupNotInherited bool
 		expectSubnet                                bool
@@ -6120,6 +6121,7 @@ func TestGetAllInstanceHandler_Handle(t *testing.T) {
 				VpcIDs: []uuid.UUID{vpc3.ID},
 			},
 			expectedMachineIDOverride: cdb.GetStrPtr(mc2.ID),
+			expectedStatusOverride:    cdb.GetStrPtr(cdbm.InstancePowerStatusRebooting),
 			expectedCount:             1,
 			expectedTotal:             1,
 			expectSubnet:              true,
@@ -6189,6 +6191,7 @@ func TestGetAllInstanceHandler_Handle(t *testing.T) {
 				InstanceTypeIDs: []uuid.UUID{ist2.ID},
 			},
 			expectedMachineIDOverride: cdb.GetStrPtr(mc2.ID),
+			expectedStatusOverride:    cdb.GetStrPtr(cdbm.InstancePowerStatusRebooting),
 			expectedCount:             1,
 			expectedTotal:             1,
 		},
@@ -6275,6 +6278,7 @@ func TestGetAllInstanceHandler_Handle(t *testing.T) {
 				OperatingSystemIDs: []uuid.UUID{os2.ID},
 			},
 			expectedMachineIDOverride: cdb.GetStrPtr(mc2.ID),
+			expectedStatusOverride:    cdb.GetStrPtr(cdbm.InstancePowerStatusRebooting),
 			expectedCount:             1,
 			expectedTotal:             1,
 		},
@@ -6339,6 +6343,7 @@ func TestGetAllInstanceHandler_Handle(t *testing.T) {
 				MachineIDs: []string{mc2.ID},
 			},
 			expectedMachineIDOverride: cdb.GetStrPtr(mc2.ID),
+			expectedStatusOverride:    cdb.GetStrPtr(cdbm.InstancePowerStatusRebooting),
 			expectedCount:             1,
 			expectedTotal:             1,
 		},
@@ -6540,6 +6545,7 @@ func TestGetAllInstanceHandler_Handle(t *testing.T) {
 			expectedTotal:             1,
 			expectedFirstEntryName:    "test-instance-vpc",
 			expectedMachineIDOverride: cdb.GetStrPtr(mc2.ID),
+			expectedStatusOverride:    cdb.GetStrPtr(cdbm.InstancePowerStatusRebooting),
 		},
 		{
 			name: "test Instance getall API endpoint success with single IP address filter",
@@ -6853,9 +6859,12 @@ func TestGetAllInstanceHandler_Handle(t *testing.T) {
 				if tt.expectedMachineIDOverride != nil {
 					expectedMachineID = tt.expectedMachineIDOverride
 				}
-
+				expectedStatus := cdb.GetStrPtr(cdbm.InstanceStatusReady)
+				if tt.expectedStatusOverride != nil {
+					expectedStatus = tt.expectedStatusOverride
+				}
 				assert.Equal(t, *rst[0].MachineID, *expectedMachineID)
-				assert.Equal(t, rst[0].Status, cdbm.InstanceStatusReady)
+				assert.Equal(t, rst[0].Status, *expectedStatus)
 
 				if tt.expectSubnet {
 					assert.Equal(t, *rst[0].Interfaces[0].SubnetID, instsub1.SubnetID.String())
@@ -6929,7 +6938,9 @@ func TestGetAllInstanceHandler_Handle(t *testing.T) {
 			}
 
 			for _, apiInst := range rst {
-				assert.Equal(t, 2, len(apiInst.StatusHistory))
+				if tt.expectedStatusOverride == nil {
+					assert.Equal(t, 2, len(apiInst.StatusHistory))
+				}
 			}
 
 			if tt.expectedIBInterfaceID != nil {

--- a/api/pkg/api/handler/instancetype_test.go
+++ b/api/pkg/api/handler/instancetype_test.go
@@ -599,22 +599,22 @@ func TestGetAllInstanceTypeHandler_Handle(t *testing.T) {
 
 	// Build Instance
 	tn1inss := []cdbm.Instance{}
-	ins1 := testInstanceBuildInstance(t, dbSession, "test-instance-1", al1.ID, alc1.ID, tn1.ID, ip.ID, st.ID, &its[0].ID, vpc1.ID, cdb.GetStrPtr(ms[0].ID), &os1.ID, nil, cdbm.InstanceStatusReady)
+	ins1 := testInstanceBuildInstance(t, dbSession, "test-instance-1", al1.ID, alc1.ID, tn1.ID, ip.ID, st.ID, &its[0].ID, vpc1.ID, cdb.GetStrPtr(ms[0].ID), &os1.ID, nil, cdbm.InstanceStatusReady, nil)
 	tn1inss = append(tn1inss, *ins1)
-	ins2 := testInstanceBuildInstance(t, dbSession, "test-instance-2", al2.ID, alc2.ID, tn1.ID, ip.ID, st.ID, &its[0].ID, vpc1.ID, cdb.GetStrPtr(ms[0].ID), &os1.ID, nil, cdbm.InstanceStatusReady)
+	ins2 := testInstanceBuildInstance(t, dbSession, "test-instance-2", al2.ID, alc2.ID, tn1.ID, ip.ID, st.ID, &its[0].ID, vpc1.ID, cdb.GetStrPtr(ms[0].ID), &os1.ID, nil, cdbm.InstanceStatusReady, nil)
 	tn1inss = append(tn1inss, *ins2)
 
 	// This instance is not associated with an instance type
 	// But has tenant reference
 	// Case of Targeted Instance
-	targetedInstance := testInstanceBuildInstance(t, dbSession, "test-instance-2", al2.ID, alc2.ID, tn1.ID, ip.ID, st.ID, nil, vpc1.ID, cdb.GetStrPtr(ms[0].ID), &os1.ID, nil, cdbm.InstanceStatusReady)
+	targetedInstance := testInstanceBuildInstance(t, dbSession, "test-instance-2", al2.ID, alc2.ID, tn1.ID, ip.ID, st.ID, nil, vpc1.ID, cdb.GetStrPtr(ms[0].ID), &os1.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, targetedInstance)
 
 	os2 := testInstanceBuildOperatingSystem(t, dbSession, "test-operating-system-1", tn2, cdbm.OperatingSystemTypeImage, false, nil, false, cdbm.OperatingSystemStatusReady, tnu2)
 	vpc2 := testInstanceBuildVPC(t, dbSession, "test-vpc-1", ip, tn2, st, cdb.GetUUIDPtr(uuid.New()), nil, cdb.GetStrPtr(cdbm.VpcEthernetVirtualizer), nil, cdbm.VpcStatusReady, tnu2)
 
 	tn2inss := []cdbm.Instance{}
-	ins3 := testInstanceBuildInstance(t, dbSession, "test-instance-3", al3.ID, alc3.ID, tn2.ID, ip.ID, st.ID, &its[0].ID, vpc2.ID, cdb.GetStrPtr(ms[0].ID), &os2.ID, nil, cdbm.InstanceStatusReady)
+	ins3 := testInstanceBuildInstance(t, dbSession, "test-instance-3", al3.ID, alc3.ID, tn2.ID, ip.ID, st.ID, &its[0].ID, vpc2.ID, cdb.GetStrPtr(ms[0].ID), &os2.ID, nil, cdbm.InstanceStatusReady, nil)
 	tn2inss = append(tn2inss, *ins3)
 
 	e := echo.New()

--- a/api/pkg/api/handler/interface_test.go
+++ b/api/pkg/api/handler/interface_test.go
@@ -118,7 +118,7 @@ func TestGetAllInterfaceHandler_Handle(t *testing.T) {
 	mci1 := testInstanceBuildMachineInterface(t, dbSession, subnets[0].ID, mc1.ID)
 	assert.NotNil(t, mci1)
 
-	inst1 := testInstanceBuildInstance(t, dbSession, "test-instance-2", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady)
+	inst1 := testInstanceBuildInstance(t, dbSession, "test-instance-2", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst1)
 
 	ifcs := []*cdbm.Interface{}

--- a/api/pkg/api/handler/networksecuritygroup_test.go
+++ b/api/pkg/api/handler/networksecuritygroup_test.go
@@ -875,11 +875,11 @@ func TestNetworkSecurityGroupHandler_GetAll(t *testing.T) {
 	mci2 := testInstanceBuildMachineInterface(t, dbSession, subnet1.ID, mc2.ID)
 	assert.NotNil(t, mci2)
 
-	inst1Site1Vpc1 := testInstanceBuildInstance(t, dbSession, "test-instance-1", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1Site1.ID, cdb.GetStrPtr(mc1.ID), nil, nil, cdbm.InstanceStatusReady)
+	inst1Site1Vpc1 := testInstanceBuildInstance(t, dbSession, "test-instance-1", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1Site1.ID, cdb.GetStrPtr(mc1.ID), nil, nil, cdbm.InstanceStatusReady, nil)
 	inst1Site1Vpc1.NetworkSecurityGroupID = cdb.GetStrPtr(nsg1Site1.ID)
 	testUpdateInstance(t, dbSession, inst1Site1Vpc1)
 
-	inst2Site1Vpc1 := testInstanceBuildInstance(t, dbSession, "test-instance-1", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1Site1.ID, cdb.GetStrPtr(mc1.ID), nil, nil, cdbm.InstanceStatusReady)
+	inst2Site1Vpc1 := testInstanceBuildInstance(t, dbSession, "test-instance-1", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1Site1.ID, cdb.GetStrPtr(mc1.ID), nil, nil, cdbm.InstanceStatusReady, nil)
 	inst2Site1Vpc1.NetworkSecurityGroupID = cdb.GetStrPtr(nsg1Site1.ID)
 	testUpdateInstance(t, dbSession, inst2Site1Vpc1)
 
@@ -1269,11 +1269,11 @@ func TestNetworkSecurityGroupHandler_Get(t *testing.T) {
 	mci2 := testInstanceBuildMachineInterface(t, dbSession, subnet1.ID, mc2.ID)
 	assert.NotNil(t, mci2)
 
-	inst1Site1Vpc1 := testInstanceBuildInstance(t, dbSession, "test-instance-1", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1Site1.ID, cdb.GetStrPtr(mc1.ID), nil, nil, cdbm.InstanceStatusReady)
+	inst1Site1Vpc1 := testInstanceBuildInstance(t, dbSession, "test-instance-1", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1Site1.ID, cdb.GetStrPtr(mc1.ID), nil, nil, cdbm.InstanceStatusReady, nil)
 	inst1Site1Vpc1.NetworkSecurityGroupID = cdb.GetStrPtr(nsg1Site1.ID)
 	testUpdateInstance(t, dbSession, inst1Site1Vpc1)
 
-	inst2Site1Vpc1 := testInstanceBuildInstance(t, dbSession, "test-instance-1", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1Site1.ID, cdb.GetStrPtr(mc1.ID), nil, nil, cdbm.InstanceStatusReady)
+	inst2Site1Vpc1 := testInstanceBuildInstance(t, dbSession, "test-instance-1", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1Site1.ID, cdb.GetStrPtr(mc1.ID), nil, nil, cdbm.InstanceStatusReady, nil)
 	inst2Site1Vpc1.NetworkSecurityGroupID = cdb.GetStrPtr(nsg1Site1.ID)
 	testUpdateInstance(t, dbSession, inst2Site1Vpc1)
 
@@ -1560,7 +1560,7 @@ func TestNetworkSecurityGroupHandler_Delete(t *testing.T) {
 	mci2 := testInstanceBuildMachineInterface(t, dbSession, subnet1.ID, mc2.ID)
 	assert.NotNil(t, mci2)
 
-	inst1Site1Vpc1 := testInstanceBuildInstance(t, dbSession, "test-instance-1", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1Site1.ID, cdb.GetStrPtr(mc1.ID), nil, nil, cdbm.InstanceStatusReady)
+	inst1Site1Vpc1 := testInstanceBuildInstance(t, dbSession, "test-instance-1", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1Site1.ID, cdb.GetStrPtr(mc1.ID), nil, nil, cdbm.InstanceStatusReady, nil)
 	inst1Site1Vpc1.NetworkSecurityGroupID = cdb.GetStrPtr(nsg2Site1.ID)
 	testUpdateInstance(t, dbSession, inst1Site1Vpc1)
 
@@ -1980,7 +1980,7 @@ func TestNetworkSecurityGroupHandler_Update(t *testing.T) {
 	mci2 := testInstanceBuildMachineInterface(t, dbSession, subnet1.ID, mc2.ID)
 	assert.NotNil(t, mci2)
 
-	inst1Site1Vpc1 := testInstanceBuildInstance(t, dbSession, "test-instance-1", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1Site1.ID, cdb.GetStrPtr(mc1.ID), nil, nil, cdbm.InstanceStatusReady)
+	inst1Site1Vpc1 := testInstanceBuildInstance(t, dbSession, "test-instance-1", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1Site1.ID, cdb.GetStrPtr(mc1.ID), nil, nil, cdbm.InstanceStatusReady, nil)
 	inst1Site1Vpc1.NetworkSecurityGroupID = cdb.GetStrPtr(nsg2Site1.ID)
 	testUpdateInstance(t, dbSession, inst1Site1Vpc1)
 

--- a/api/pkg/api/handler/nvlinkinterface_test.go
+++ b/api/pkg/api/handler/nvlinkinterface_test.go
@@ -115,7 +115,7 @@ func TestGetAllNVLinkInterface_Handle(t *testing.T) {
 	vpc2 := testInstanceBuildVPC(t, dbSession, "test-vpc-2", ip, tn1, st1, nil, nil, cdb.GetStrPtr(cdbm.VpcEthernetVirtualizer), nil, cdbm.VpcStatusPending, tnu1)
 	assert.NotNil(t, vpc2)
 
-	inst1 := testInstanceBuildInstance(t, dbSession, "test-instance-2", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady)
+	inst1 := testInstanceBuildInstance(t, dbSession, "test-instance-2", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst1)
 
 	nvlinklogicalpartitions := []*cdbm.NVLinkLogicalPartition{}

--- a/api/pkg/api/handler/nvlinklogicalpartition_test.go
+++ b/api/pkg/api/handler/nvlinklogicalpartition_test.go
@@ -845,10 +845,10 @@ func TestNVLinkLogicalPartitionHandler_GetAll(t *testing.T) {
 	vpc2 := testInstanceBuildVPC(t, dbSession, "test-vpc-2", ip1, tn2, site2, nil, nil, cdb.GetStrPtr(cdbm.VpcEthernetVirtualizer), cdb.GetUUIDPtr(nvllp1.ID), cdbm.VpcStatusPending, tnu1)
 	assert.NotNil(t, vpc2)
 
-	inst1 := testInstanceBuildInstance(t, dbSession, "test-instance-2", al1.ID, alc1.ID, tn1.ID, ip1.ID, site1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady)
+	inst1 := testInstanceBuildInstance(t, dbSession, "test-instance-2", al1.ID, alc1.ID, tn1.ID, ip1.ID, site1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst1)
 
-	inst2 := testInstanceBuildInstance(t, dbSession, "test-instance-2", al1.ID, alc1.ID, tn1.ID, ip1.ID, site2.ID, &ist1.ID, vpc2.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady)
+	inst2 := testInstanceBuildInstance(t, dbSession, "test-instance-2", al1.ID, alc1.ID, tn1.ID, ip1.ID, site2.ID, &ist1.ID, vpc2.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst2)
 
 	// Create NVLinkInterface records for each NVLinkLogicalPartition
@@ -1271,10 +1271,10 @@ func TestNVLinkLogicalPartitionHandler_GetByID(t *testing.T) {
 	vpc2 := testInstanceBuildVPC(t, dbSession, "test-vpc-2", ip1, tn1, site2, nil, nil, cdb.GetStrPtr(cdbm.VpcEthernetVirtualizer), cdb.GetUUIDPtr(nvllp2.ID), cdbm.VpcStatusPending, tnu1)
 	assert.NotNil(t, vpc2)
 
-	inst1 := testInstanceBuildInstance(t, dbSession, "test-instance-2", al1.ID, alc1.ID, tn1.ID, ip1.ID, site1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady)
+	inst1 := testInstanceBuildInstance(t, dbSession, "test-instance-2", al1.ID, alc1.ID, tn1.ID, ip1.ID, site1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst1)
 
-	inst2 := testInstanceBuildInstance(t, dbSession, "test-instance-2", al1.ID, alc1.ID, tn1.ID, ip1.ID, site2.ID, &ist1.ID, vpc2.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady)
+	inst2 := testInstanceBuildInstance(t, dbSession, "test-instance-2", al1.ID, alc1.ID, tn1.ID, ip1.ID, site2.ID, &ist1.ID, vpc2.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst2)
 
 	nvlifc1 := testInstanceBuildInstanceNVLinkInterface(t, dbSession, site1.ID, inst1.ID, nvllp1.ID, cdb.GetUUIDPtr(uuid.New()), cdb.GetStrPtr("NVIDIA GB200"), 0, cdbm.NVLinkInterfaceStatusReady)

--- a/api/pkg/api/handler/sshkeygroup_test.go
+++ b/api/pkg/api/handler/sshkeygroup_test.go
@@ -1243,7 +1243,7 @@ func TestSSHKeyGroupHandler_GetAll(t *testing.T) {
 	mci1 := testInstanceBuildMachineInterface(t, dbSession, subnet1.ID, mc1.ID)
 	assert.NotNil(t, mci1)
 
-	inst1 := testInstanceBuildInstance(t, dbSession, "test-instance-2", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady)
+	inst1 := testInstanceBuildInstance(t, dbSession, "test-instance-2", al1.ID, alc1.ID, tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst1)
 
 	skgia1 := testInstanceBuildSSHKeyGroupInstanceAssociation(t, dbSession, skgs[0].ID, st1.ID, inst1.ID)

--- a/api/pkg/api/handler/tenant_test.go
+++ b/api/pkg/api/handler/tenant_test.go
@@ -399,7 +399,7 @@ func TestGetCurrentTenantStatsHandler_Handle(t *testing.T) {
 	mci1 := testInstanceBuildMachineInterface(t, dbSession, subnet1.ID, mc1.ID)
 	assert.NotNil(t, mci1)
 
-	inst1 := testInstanceBuildInstance(t, dbSession, "test-instance-2", al1.ID, alc1.ID, tn1.ID, ip.ID, st.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady)
+	inst1 := testInstanceBuildInstance(t, dbSession, "test-instance-2", al1.ID, alc1.ID, tn1.ID, ip.ID, st.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mc1.ID), &os1.ID, nil, cdbm.InstanceStatusReady, nil)
 	assert.NotNil(t, inst1)
 
 	instsub1 := testInstanceBuildInstanceInterface(t, dbSession, inst1.ID, &subnet1.ID, nil, nil, cdbm.InterfaceStatusPending)

--- a/db/pkg/db/model/instance.go
+++ b/db/pkg/db/model/instance.go
@@ -551,7 +551,10 @@ func (isd InstanceSQLDAO) setQueryWithFilter(filter InstanceFilterInput, query *
 	}
 
 	if filter.Statuses != nil {
-		query = query.Where("i.status IN (?)", bun.In(filter.Statuses))
+		query = query.WhereGroup(" AND ", func(q *bun.SelectQuery) *bun.SelectQuery {
+			return q.Where("i.status IN (?)", bun.In(filter.Statuses)).
+				WhereOr("i.power_status IN (?)", bun.In(filter.Statuses))
+		})
 		if instanceDAOSpan != nil {
 			isd.tracerSpan.SetAttribute(instanceDAOSpan, "statuses", filter.Statuses)
 		}


### PR DESCRIPTION
- Currently Instance status attribute in API layer presents both status and power status. However when filtering at DB layer we only check against DB status attribute
- This change checks both status and power status DB attribute to return a better set of matches aligning with API values