### PR TITLE
chore: Update scanner actions with improved PR comment handling

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           fetch-depth: 0  # Full history for secret scanning
       - name: Run TruffleHog Scan
-        uses: NVIDIA/dsx-github-actions/.github/actions/trufflehog-scan@55d1e0af17fb4431edaca19fbd5c78fecd29d18a
+        uses: NVIDIA/dsx-github-actions/.github/actions/trufflehog-scan@f435aa6bf125fe6f9e5ac438f8cef75f90e29a2b
         with:
           extra-args: '--results=verified,unknown --only-verified'
           post-pr-comment: 'true'
@@ -89,7 +89,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy Scan
-        uses: NVIDIA/dsx-github-actions/.github/actions/trivy-scan@55d1e0af17fb4431edaca19fbd5c78fecd29d18a
+        uses: NVIDIA/dsx-github-actions/.github/actions/trivy-scan@f435aa6bf125fe6f9e5ac438f8cef75f90e29a2b
         with:
           scan-type: 'fs'
           scan-ref: '.'


### PR DESCRIPTION
Improve security scanner actions (TruffleHog, Trivy, CodeQL) to update existing PR comments instead of creating new ones on each run, reducing comment noise. #73 

scanner behavior in previous PR: updated each commit: https://github.com/NVIDIA/carbide-rest/pull/59 


Scanner Actions new behaviors:
- Scan actions now find and update their existing comments in PRs rather than creating duplicate comments
- Comments are only updated when scan status changes (e.g., clean to issues_found), preventing unnecessary updates

test:
<img width="935" height="492" alt="image" src="https://github.com/user-attachments/assets/8dcfd5fa-6a88-47d2-b448-403d344cca87" />
