### PR TITLE
fix: Check if NVLink Logical Partition is already connected on Instance NVLink Interface update

### DIFF
--- a/api/pkg/api/handler/instance.go
+++ b/api/pkg/api/handler/instance.go
@@ -2467,8 +2467,8 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 
 		// Discard if NVLink Logical Partition is already present for the Instance
 		if _, ok := existingNvllpIDMap[nvllpID]; ok {
-			logger.Warn().Msg(fmt.Sprintf("NVLink Logical Partition: %v specified in request is already present for the Instance", nvllpID))
-			return cerr.NewAPIErrorResponse(c, http.StatusBadRequest, fmt.Sprintf("NVLink Logical Partition: %v specified in request is already present for the Instance", nvllpID), nil)
+			logger.Warn().Msg(fmt.Sprintf("NVLink Interfaces of this Instance are already connected to NVLink Logical Partition: %v", nvllpID))
+			return cerr.NewAPIErrorResponse(c, http.StatusBadRequest, fmt.Sprintf("NVLink Interfaces of this Instance are already connected to NVLink Logical Partition: %v", nvllpID), nil)
 		}
 
 		nvllpIDs = append(nvllpIDs, nvllpID)

--- a/api/pkg/api/handler/instance_test.go
+++ b/api/pkg/api/handler/instance_test.go
@@ -4669,7 +4669,7 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 				reqOrg:      tnOrg1,
 				reqUser:     tnu1,
 				respCode:    http.StatusBadRequest,
-				respMessage: cdb.GetStrPtr(fmt.Sprintf("NVLink Logical Partition: %v specified in request is already present for the Instance", nvllp1.ID.String())),
+				respMessage: cdb.GetStrPtr(fmt.Sprintf("NVLink Interfaces of this Instance are already connected to NVLink Logical Partition: %v", nvllp1.ID.String())),
 			},
 			wantErr:                     false,
 			verifySiteControllerRequest: true,


### PR DESCRIPTION
- Make sure to verify if the provided partitionID is the same as the already configured one.