### PR TITLE
fix: Return Machine board serial, product name & vendor in DMI data

### DIFF
--- a/api/pkg/api/model/machine.go
+++ b/api/pkg/api/model/machine.go
@@ -222,18 +222,22 @@ type APIMachine struct {
 type APIDMIData struct {
 	// BoardName is the name of the Machine's board
 	BoardName *string `json:"boardName"`
-	// boardSerial is the searial number of the Machine's board
-	BoardSerial *string `json:"boardSerial"`
 	// BoardVersion is the version of the Machine's board
 	BoardVersion *string `json:"boardVersion"`
 	// BiosDate is the date of the Machine's bios
 	BiosDate *string `json:"biosDate"`
 	// BiosVersion is the version of the Machine's bios
 	BiosVersion *string `json:"biosVersion"`
+	// ProductName is the name of the Machine's product
+	ProductName *string `json:"productName"`
 	// ProductSerial is searial number the Machine
 	ProductSerial *string `json:"productSerial"`
+	// BoardSerial is the searial number of the Machine's board
+	BoardSerial *string `json:"boardSerial"`
 	// ChassisSerial is searial number the Machine's Chassis
 	ChassisSerial *string `json:"chassisSerial"`
+	// SysVendor is the vendor of the Machine's system
+	SysVendor *string `json:"sysVendor"`
 }
 
 // APIBMCInfo is the data structure to capture API representation of a Machine's BMC Info
@@ -423,8 +427,11 @@ func NewAPIMachine(dbm *cdbm.Machine, dbmcs []cdbm.MachineCapability, dbmis []cd
 					BoardVersion:  &machine.DiscoveryInfo.DmiData.BoardVersion,
 					BiosDate:      &machine.DiscoveryInfo.DmiData.BiosDate,
 					BiosVersion:   &machine.DiscoveryInfo.DmiData.BiosVersion,
+					ProductName:   &machine.DiscoveryInfo.DmiData.ProductName,
 					ProductSerial: &machine.DiscoveryInfo.DmiData.ProductSerial,
+					BoardSerial:   &machine.DiscoveryInfo.DmiData.BoardSerial,
 					ChassisSerial: &machine.DiscoveryInfo.DmiData.ChassisSerial,
+					SysVendor:     &machine.DiscoveryInfo.DmiData.SysVendor,
 				}
 			}
 

--- a/api/pkg/api/model/machine_test.go
+++ b/api/pkg/api/model/machine_test.go
@@ -10,7 +10,6 @@
  * its affiliates is strictly prohibited.
  */
 
-
 package model
 
 import (
@@ -20,9 +19,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 	cdb "github.com/nvidia/carbide-rest/db/pkg/db"
 	cdbm "github.com/nvidia/carbide-rest/db/pkg/db/model"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/nvidia/carbide-rest/api/pkg/api/model/util"
 	cwssaws "github.com/nvidia/carbide-rest/workflow-schema/schema/site-agent/workflows/v1"
@@ -479,11 +478,13 @@ func TestMachine_NewAPIMachine(t *testing.T) {
 
 		if apimi.Metadata.DMIData != nil {
 			assert.Equal(t, *apimi.Metadata.DMIData.BoardName, machineInfo1.Machine.DiscoveryInfo.DmiData.BoardName)
+			assert.Equal(t, *apimi.Metadata.DMIData.BoardVersion, machineInfo1.Machine.DiscoveryInfo.DmiData.BoardVersion)
 			assert.Equal(t, *apimi.Metadata.DMIData.BiosDate, machineInfo1.Machine.DiscoveryInfo.DmiData.BiosDate)
 			assert.Equal(t, *apimi.Metadata.DMIData.BiosVersion, machineInfo1.Machine.DiscoveryInfo.DmiData.BiosVersion)
-			assert.Equal(t, *apimi.Metadata.DMIData.BoardVersion, machineInfo1.Machine.DiscoveryInfo.DmiData.BoardVersion)
 			assert.Equal(t, *apimi.Metadata.DMIData.ProductSerial, machineInfo1.Machine.DiscoveryInfo.DmiData.ProductSerial)
+			assert.Equal(t, *apimi.Metadata.DMIData.BoardSerial, machineInfo1.Machine.DiscoveryInfo.DmiData.BoardSerial)
 			assert.Equal(t, *apimi.Metadata.DMIData.ChassisSerial, machineInfo1.Machine.DiscoveryInfo.DmiData.ChassisSerial)
+			assert.Equal(t, *apimi.Metadata.DMIData.SysVendor, machineInfo1.Machine.DiscoveryInfo.DmiData.SysVendor)
 		}
 
 		if apimi.Metadata.GPUs != nil {

--- a/db/pkg/db/model/common.go
+++ b/db/pkg/db/model/common.go
@@ -10,11 +10,11 @@
  * its affiliates is strictly prohibited.
  */
 
-
 package model
 
 import "google.golang.org/protobuf/encoding/protojson"
 
 var protoJsonUnmarshalOptions = protojson.UnmarshalOptions{
+	AllowPartial:   true,
 	DiscardUnknown: true,
 }


### PR DESCRIPTION
- We are omitting values that are needed by end users
- Enabled partial deserialization to accommodate older Machine data