### PR TITLE
fix: Use 127.0.0.1 in the output of make preview-openapi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -439,7 +439,7 @@ lint-openapi:
 
 # Preview OpenAPI spec in Redoc UI (Docker)
 preview-openapi:
-	@echo "Starting Redoc UI at http://localhost:8090"
+	@echo "Starting Redoc UI at http://127.0.0.1:8090"
 	docker run -it --rm -p 8090:80 -v ./openapi/spec.yaml:/usr/share/nginx/html/openapi.yaml -e SPEC_URL=openapi.yaml redocly/redoc
 
 # =============================================================================


### PR DESCRIPTION
Running `make preview-openapi` generates output like this:

```
Starting Redoc UI at http://localhost:8090
...
```

The documentation in the `openapi/README.md` file clearly says that the URL is http://127.0.0.1:8090. But it is very easy to click in the displayed URL instead, and that will not work in systems that resolve `localhost` to `::1` instead of to `127.0.0.1`, which happens to be my case. This simple patch avoid that small annoyance.