### PR TITLE
fix: Increase Keycloak memory limit

### DIFF
--- a/deploy/kustomize/base/keycloak/deployment.yaml
+++ b/deploy/kustomize/base/keycloak/deployment.yaml
@@ -64,7 +64,7 @@ spec:
               memory: "512Mi"
               cpu: "250m"
             limits:
-              memory: "1Gi"
+              memory: "3Gi"
               cpu: "1000m"
           readinessProbe:
             httpGet:


### PR DESCRIPTION
Currently the Keycloak container has a memory limit of 1 GiB. In my environment (pomdan rootless) it consistently fails to start because it is killed by the out of memory killer of the kernel:

```
$ kubectl get pods | grep keycloak
keycloak-55d7bf4567-pzbc8  0/1  OOMKilled  5  (105s ago)  4m26s
```

I increased the limit to 2 GiB, but it is still killed by the kernel:

```
$ sudo journalctl -b | grep 'Killed process'
Feb 12 13:28:08 ... kernel: Memory cgroup out of memory: Killed process 94702 (java) total-vm:56794160kB, anon-rss:1560580kB, file-rss:28248kB, shmem-rss:0kB, UID:525287 pgtables:4888kB oom_score_adj:992
```

I then increased it to 3 GiB, and then it looks to be stable. That is what this patch does.