### PR TITLE
chore: Update API name config, README for OpenAPI schema development

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ In deployments, NVIDIA Bare Metal Manager REST requires [NVIDIA Bare Metal Manag
 
 The REST layer can be deployed in the datacenter with Bare Metal Manager Core, or deployed anywhere in Cloud and allow Site Agent to connect from the datacenter. Multiple Bare Metal Manager Cores running in different datacenters can also connect to Bare Metal Manager REST through respective Site Agents.
 
+View latest OpenAPI schema on [Github pages](https://nvidia.github.io/bare-metal-manager-rest/).
+
 ## Prerequisites
 
 - Go 1.25.4 or later
@@ -166,7 +168,6 @@ done
 | `carbide-rest-cert-manager` | Native PKI certificate manager |
 
 
-
 ## Architecture
 
 | Service | Binary | Description |
@@ -182,6 +183,10 @@ Supporting modules:
 - **common** - Shared utilities and configurations
 - **auth** - Authentication and authorization
 - **ipam** - IP Address Management
+
+## OpenAPI Schema Development
+
+OpenAPI schema must be updated whenever the API endpoints are added/updated. Please view instructions at [OpenAPI README](openapi/README.md)
 
 ## Pre-commit Hooks
 

--- a/api/config.yaml
+++ b/api/config.yaml
@@ -24,6 +24,11 @@ log:
   sentry:
     dsn: ""
 
+api:
+  name: carbide
+  route:
+    version: v2
+
 db:
   host: localhost
   port: 30432

--- a/openapi/README.md
+++ b/openapi/README.md
@@ -3,14 +3,34 @@ SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All 
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# Cabide REST OpenAPI Schema
+# NVIDIA Bare Metal REST OpenAPI Schema
 
-This repo contains OpenAPI schema for Cabide REST endpoints.
+This repo contains OpenAPI schema for NVIDIA Bare Metal REST endpoints. Redoc rendered latest version can be viewed at https://nvidia.github.io/bare-metal-manager-rest/
 
-To view a rendered/browsable version of the schema, please ensure docker is available and run the following command from project root:
+# Development
+
+OpenAPI schema must be updated whenever the API endpoints are added/updated.
+
+Please ensure that the following tools are installed:
+ - Docker
+ - npm
+
+To lint schema after making changes, run:
+
+    make lint-openapi
+
+To view a rendered/browsable version of the schema locally, run:
 
     make preview-openapi
 
 Then access the schema at:
 
     http://127.0.0.1:8090
+
+# Updating Github Pages
+
+In order to update the Github pages to reflect schema changes, you must include rendered HTML changes in your PR.
+
+To modify the rendered HTML, run:
+
+    make publish-openapi


### PR DESCRIPTION
- API name config was missing from api/config.yaml
- Added instructions to view rendered schema on Github pages
- Added instructions for OpenAPI schema development