### PR TITLE
feat: Add unknown query parameter validation for handlers

### DIFF
--- a/api/pkg/api/handler/rack.go
+++ b/api/pkg/api/handler/rack.go
@@ -96,8 +96,8 @@ func (grh GetRackHandler) Handle(c echo.Context) error {
 		defer handlerSpan.End()
 	}
 
-	if err := common.ValidateQueryParams(c, getRackAllowedParams); err != nil {
-		return cerr.NewAPIErrorResponse(c, http.StatusBadRequest, err.Error(), nil)
+	if apiErr := common.ValidateQueryParams(c.QueryParams(), getRackAllowedParams); apiErr != nil {
+		return cerr.NewAPIErrorResponse(c, apiErr.Code, apiErr.Message, nil)
 	}
 
 	// Is DB user missing?
@@ -263,8 +263,8 @@ func (garh GetAllRackHandler) Handle(c echo.Context) error {
 		defer handlerSpan.End()
 	}
 
-	if err := common.ValidateQueryParams(c, getAllRackAllowedParams); err != nil {
-		return cerr.NewAPIErrorResponse(c, http.StatusBadRequest, err.Error(), nil)
+	if apiErr := common.ValidateQueryParams(c.QueryParams(), getAllRackAllowedParams); apiErr != nil {
+		return cerr.NewAPIErrorResponse(c, apiErr.Code, apiErr.Message, nil)
 	}
 
 	// Is DB user missing?
@@ -474,8 +474,8 @@ func (vrh ValidateRackHandler) Handle(c echo.Context) error {
 		defer handlerSpan.End()
 	}
 
-	if err := common.ValidateQueryParams(c, validateRackAllowedParams); err != nil {
-		return cerr.NewAPIErrorResponse(c, http.StatusBadRequest, err.Error(), nil)
+	if apiErr := common.ValidateQueryParams(c.QueryParams(), validateRackAllowedParams); apiErr != nil {
+		return cerr.NewAPIErrorResponse(c, apiErr.Code, apiErr.Message, nil)
 	}
 
 	// Is DB user missing?
@@ -639,8 +639,8 @@ func (vrsh ValidateRacksHandler) Handle(c echo.Context) error {
 		defer handlerSpan.End()
 	}
 
-	if err := common.ValidateQueryParams(c, validateRacksAllowedParams); err != nil {
-		return cerr.NewAPIErrorResponse(c, http.StatusBadRequest, err.Error(), nil)
+	if apiErr := common.ValidateQueryParams(c.QueryParams(), validateRacksAllowedParams); apiErr != nil {
+		return cerr.NewAPIErrorResponse(c, apiErr.Code, apiErr.Message, nil)
 	}
 
 	// Is DB user missing?

--- a/api/pkg/api/handler/tray.go
+++ b/api/pkg/api/handler/tray.go
@@ -93,8 +93,8 @@ func (gth GetTrayHandler) Handle(c echo.Context) error {
 		defer handlerSpan.End()
 	}
 
-	if err := common.ValidateQueryParams(c, getTrayAllowedParams); err != nil {
-		return cerr.NewAPIErrorResponse(c, http.StatusBadRequest, err.Error(), nil)
+	if apiErr := common.ValidateQueryParams(c.QueryParams(), getTrayAllowedParams); apiErr != nil {
+		return cerr.NewAPIErrorResponse(c, apiErr.Code, apiErr.Message, nil)
 	}
 
 	// Is DB user missing?
@@ -255,8 +255,8 @@ func (gath GetAllTrayHandler) Handle(c echo.Context) error {
 		defer handlerSpan.End()
 	}
 
-	if err := common.ValidateQueryParams(c, getAllTrayAllowedParams); err != nil {
-		return cerr.NewAPIErrorResponse(c, http.StatusBadRequest, err.Error(), nil)
+	if apiErr := common.ValidateQueryParams(c.QueryParams(), getAllTrayAllowedParams); apiErr != nil {
+		return cerr.NewAPIErrorResponse(c, apiErr.Code, apiErr.Message, nil)
 	}
 
 	// Is DB user missing?

--- a/api/pkg/api/handler/util/common/common.go
+++ b/api/pkg/api/handler/util/common/common.go
@@ -1501,11 +1501,11 @@ func AddToValidationErrors(errs validation.Errors, key string, err error) {
 }
 
 // ValidateQueryParams checks that all query parameters in the request are in the allowed set.
-// Returns an error naming the first unknown parameter found, or nil if all are valid.
-func ValidateQueryParams(c echo.Context, allowedParams []string) error {
-	for key := range c.QueryParams() {
+// Returns an APIError naming the first unknown parameter found, or nil if all are valid.
+func ValidateQueryParams(queryParams url.Values, allowedParams []string) *cau.APIError {
+	for key := range queryParams {
 		if !slices.Contains(allowedParams, key) {
-			return fmt.Errorf("unknown query parameter: %s", key)
+			return cau.NewAPIError(http.StatusBadRequest, fmt.Sprintf("Unknown query parameter specified in request: %s", key), nil)
 		}
 	}
 	return nil


### PR DESCRIPTION
Reject requests with unrecognized query parameters early (400 Bad Request), preventing typos from being silently ignored and improving workflow ID dedup accuracy with QueryParamHash.