### PR TITLE
fix: Correct binary_name and binary_path for carbide-rla build

### DIFF
--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -202,8 +202,8 @@ jobs:
     with:
       runner: ${{ inputs.runner }}
       service_name: carbide-rla
-      binary_name: credsmgr
-      binary_path: /app/credsmgr
+      binary_name: rla
+      binary_path: /app/rla
       dockerfile: ./docker/production/Dockerfile.carbide-rla
       semantic_version: ${{ inputs.semantic_version }}
       short_sha: ${{ inputs.short_sha }}


### PR DESCRIPTION
## Summary

- Fix copy-paste error in `build-carbide-rla` job where `binary_name` and `binary_path` were incorrectly set to `credsmgr` / `/app/credsmgr` (from `build-carbide-rest-cert-manager`), but the actual binary in `Dockerfile.carbide-rla` is `/app/rla`
- This caused the main branch CI to fail at the "Extract binary from image" step with: `Could not find the file /app/credsmgr in container temp-container`

## Changes

| Field | Before (wrong) | After (correct) |
|---|---|---|
| `binary_name` | `credsmgr` | `rla` |
| `binary_path` | `/app/credsmgr` | `/app/rla` |

## Root Cause

The `build-carbide-rla` job config was copied from `build-carbide-rest-cert-manager` but `binary_name` and `binary_path` were not updated to match the RLA service.