### PR TITLE
ci: Remove duplicate Slack notification trigger in new PR workflow

### DIFF
--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -16,8 +16,6 @@
 name: Notify Slack on Pull Request
 
 on:
-  pull_request:
-    types: [opened]
   pull_request_target:
     types: [opened]
 


### PR DESCRIPTION
- `pull_request` is redundant if `pull_request_target` is present.