### PR TITLE
feat: Add bmmcli — OpenAPI-driven CLI for Bare Metal Manager REST API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,13 @@ build:
 	cd site-agent && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-extldflags '-static'" -o ../$(BUILD_DIR)/elektra ./cmd/elektra
 	cd db && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-extldflags '-static'" -o ../$(BUILD_DIR)/migrations ./cmd/migrations
 	cd cert-manager && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-extldflags '-static'" -o ../$(BUILD_DIR)/credsmgr ./cmd/credsmgr
+	cd cli && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-extldflags '-static'" -o ../$(BUILD_DIR)/bmmcli ./cmd/bmmcli
+
+INSTALL_DIR ?= $(shell go env GOPATH)/bin
+
+install-bmmcli:
+	cd cli && go build -o $(INSTALL_DIR)/bmmcli ./cmd/bmmcli
+	@echo "Installed bmmcli to $(INSTALL_DIR)/bmmcli"
 
 docker-build:
 	docker build -t $(IMAGE_REGISTRY)/carbide-rest-api:$(IMAGE_TAG) -f $(DOCKERFILE_DIR)/Dockerfile.carbide-rest-api .

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ done
 | carbide-site-agent | `elektra` | On-site agent |
 | carbide-rest-db | `migrations` | Database migrations |
 | carbide-rest-cert-manager | `credsmgr` | Native PKI certificate manager |
+| carbide-cli | `bmmcli` | [CLI client](cli/README.md) for the REST API |
 
 Supporting modules:
 - **common** - Shared utilities and configurations

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,156 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# BMM CLI
+
+Command-line client for the NVIDIA Bare Metal Manager REST API. Commands are dynamically generated from the embedded OpenAPI spec at startup — zero manual command code.
+
+## Install
+
+```bash
+make install-bmmcli
+```
+
+Installs to `$(go env GOPATH)/bin/bmmcli`. Override with `make install-bmmcli INSTALL_DIR=/usr/local/bin`.
+
+## Quick Start
+
+Generate a config file:
+
+```bash
+bmmcli init                    # writes ~/.bmm/config.yaml
+```
+
+Edit `~/.bmm/config.yaml` with your server URL, org, and auth settings, then:
+
+```bash
+bmmcli login                   # exchange credentials for a token
+bmmcli site list               # list all sites
+```
+
+## Configuration
+
+Config file: `~/.bmm/config.yaml`
+
+```yaml
+api:
+  base: http://localhost:8388
+  org: test-org
+  name: carbide                # API path segment (default)
+
+auth:
+  # Option 1: Direct bearer token
+  # token: eyJhbGciOi...
+
+  # Option 2: OIDC provider (e.g. Keycloak)
+  oidc:
+    token_url: http://localhost:8080/realms/carbide-dev/protocol/openid-connect/token
+    client_id: carbide-api
+    client_secret: carbide-local-secret
+
+  # Option 3: NGC API key
+  # api_key:
+  #   authn_url: https://authn.nvidia.com/token
+  #   key: nvapi-xxxx
+```
+
+Flags and environment variables override config values:
+
+| Flag | Env Var | Description |
+|------|---------|-------------|
+| `--base-url` | `BMM_BASE_URL` | API base URL |
+| `--org` | `BMM_ORG` | Organization name |
+| `--token` | `BMM_TOKEN` | Bearer token |
+| `--token-url` | `BMM_TOKEN_URL` | OIDC token endpoint URL |
+| `--keycloak-url` | `BMM_KEYCLOAK_URL` | Keycloak base URL (constructs token-url) |
+| `--keycloak-realm` | `BMM_KEYCLOAK_REALM` | Keycloak realm (default: `carbide-dev`) |
+| `--client-id` | `BMM_CLIENT_ID` | OAuth client ID |
+| `--output`, `-o` | | Output format: `json` (default), `yaml`, `table` |
+
+## Authentication
+
+```bash
+# OIDC (credentials from config, prompts for password if not stored)
+bmmcli login
+
+# OIDC with explicit flags
+bmmcli --token-url https://auth.example.com/token login --username admin@example.com
+
+# NGC API key
+bmmcli login --api-key nvapi-xxxx
+
+# Keycloak shorthand
+bmmcli --keycloak-url http://localhost:8080 login --username admin@example.com
+```
+
+Tokens are saved to `~/.bmm/config.yaml` with auto-refresh for OIDC.
+
+## Usage
+
+```bash
+bmmcli site list
+bmmcli site get <siteId>
+bmmcli site create --name "SJC4"
+bmmcli site create --data-file site.json
+cat site.json | bmmcli site create --data-file -
+bmmcli site delete <siteId>
+bmmcli instance list --status provisioned --page-size 20
+bmmcli instance list --all                # fetch all pages
+bmmcli allocation constraint create <allocationId> --constraint-type SITE
+bmmcli site list --output table
+bmmcli --debug site list
+```
+
+## Command Structure
+
+Commands follow `bmmcli <resource> [sub-resource] <action> [args] [flags]`.
+
+| Spec Pattern | CLI Action |
+|---|---|
+| `get-all-*` | `list` |
+| `get-*` | `get` |
+| `create-*` | `create` |
+| `update-*` | `update` |
+| `delete-*` | `delete` |
+| `batch-create-*` | `batch-create` |
+| `get-*-status-history` | `status-history` |
+| `get-*-stats` | `stats` |
+
+Nested API paths appear as sub-resource groups:
+
+```
+bmmcli allocation list
+bmmcli allocation constraint list
+bmmcli allocation constraint create <allocationId>
+```
+
+## Shell Completion
+
+```bash
+# Bash
+eval "$(bmmcli completion bash)"
+
+# Zsh
+eval "$(bmmcli completion zsh)"
+
+# Fish
+bmmcli completion fish > ~/.config/fish/completions/bmmcli.fish
+```
+
+## Multi-Environment Configs
+
+Place multiple configs in `~/.bmm/`:
+
+```
+~/.bmm/config.yaml           # default (local dev)
+~/.bmm/config.staging.yaml   # staging
+~/.bmm/config.prod.yaml      # production
+```
+
+Select with `--config`:
+
+```bash
+bmmcli --config ~/.bmm/config.staging.yaml site list
+```

--- a/cli/cmd/bmmcli/main.go
+++ b/cli/cmd/bmmcli/main.go
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/nvidia/bare-metal-manager-rest/cli/pkg"
+	"github.com/nvidia/bare-metal-manager-rest/openapi"
+)
+
+func main() {
+	app, err := bmmcli.NewApp(openapi.Spec)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fatal: %v\n", err)
+		os.Exit(1)
+	}
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cli/pkg/app.go
+++ b/cli/pkg/app.go
@@ -1,0 +1,162 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bmmcli
+
+import (
+	"fmt"
+
+	cli "github.com/urfave/cli/v2"
+)
+
+// NewApp builds a cli.App from the embedded OpenAPI spec data.
+func NewApp(specData []byte) (*cli.App, error) {
+	spec, err := ParseSpec(specData)
+	if err != nil {
+		return nil, fmt.Errorf("parsing embedded spec: %w", err)
+	}
+
+	defaultBaseURL := ""
+	if len(spec.Servers) > 0 {
+		defaultBaseURL = spec.Servers[0].URL
+	}
+
+	commands := BuildCommands(spec)
+	commands = append(commands, LoginCommand())
+	commands = append(commands, InitCommand())
+	commands = append(commands, completionCommand())
+
+	app := &cli.App{
+		Name:                 "bmmcli",
+		Usage:                spec.Info.Title,
+		Version:              spec.Info.Version,
+		EnableBashCompletion: true,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "base-url",
+				Usage:   "API base URL",
+				EnvVars: []string{"BMM_BASE_URL"},
+				Value:   defaultBaseURL,
+			},
+			&cli.StringFlag{
+				Name:    "org",
+				Usage:   "Organization name",
+				EnvVars: []string{"BMM_ORG"},
+			},
+			&cli.StringFlag{
+				Name:    "token",
+				Usage:   "API bearer token",
+				EnvVars: []string{"BMM_TOKEN"},
+			},
+			&cli.StringFlag{
+				Name:  "token-command",
+				Usage: "Shell command that prints a bearer token",
+			},
+			&cli.BoolFlag{
+				Name:  "debug",
+				Usage: "Enable debug logging",
+			},
+			&cli.StringFlag{
+				Name:    "token-url",
+				Usage:   "OIDC token endpoint URL for login and token refresh",
+				EnvVars: []string{"BMM_TOKEN_URL"},
+			},
+			&cli.StringFlag{
+				Name:    "keycloak-url",
+				Usage:   "Keycloak base URL (constructs token-url if --token-url is not set)",
+				EnvVars: []string{"BMM_KEYCLOAK_URL"},
+			},
+			&cli.StringFlag{
+				Name:    "keycloak-realm",
+				Usage:   "Keycloak realm (used with --keycloak-url)",
+				EnvVars: []string{"BMM_KEYCLOAK_REALM"},
+				Value:   "carbide-dev",
+			},
+			&cli.StringFlag{
+				Name:    "client-id",
+				Usage:   "OAuth client ID",
+				EnvVars: []string{"BMM_CLIENT_ID"},
+				Value:   "carbide-api",
+			},
+		},
+		Commands: commands,
+	}
+
+	return app, nil
+}
+
+func completionCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "completion",
+		Usage: "Output shell completion script",
+		Subcommands: []*cli.Command{
+			{
+				Name:  "bash",
+				Usage: "Output bash completion script",
+				Action: func(c *cli.Context) error {
+					fmt.Print(bashCompletion)
+					return nil
+				},
+			},
+			{
+				Name:  "zsh",
+				Usage: "Output zsh completion script",
+				Action: func(c *cli.Context) error {
+					fmt.Print(zshCompletion)
+					return nil
+				},
+			},
+			{
+				Name:  "fish",
+				Usage: "Output fish completion script",
+				Action: func(c *cli.Context) error {
+					fmt.Print(fishCompletion)
+					return nil
+				},
+			},
+		},
+	}
+}
+
+const bashCompletion = `# bash completion for bmmcli
+# Add to ~/.bashrc:  eval "$(bmmcli completion bash)"
+_bmmcli_complete() {
+    local cur opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    opts=$(${COMP_WORDS[0]} --generate-bash-completion "${COMP_WORDS[@]:1:$COMP_CWORD}")
+    COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
+    return 0
+}
+complete -o default -F _bmmcli_complete bmmcli
+`
+
+const zshCompletion = `# zsh completion for bmmcli
+# Add to ~/.zshrc:  eval "$(bmmcli completion zsh)"
+_bmmcli_complete() {
+    local -a opts
+    opts=(${(f)"$(${words[1]} --generate-bash-completion ${words:1:$CURRENT-1})"})
+    _describe 'bmmcli' opts
+}
+compdef _bmmcli_complete bmmcli
+`
+
+const fishCompletion = `# fish completion for bmmcli
+# Add to ~/.config/fish/completions/bmmcli.fish or run:
+#   bmmcli completion fish > ~/.config/fish/completions/bmmcli.fish
+complete -c bmmcli -f -a '(bmmcli --generate-bash-completion (commandline -cop))'
+`

--- a/cli/pkg/auth.go
+++ b/cli/pkg/auth.go
@@ -1,0 +1,349 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bmmcli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/term"
+	cli "github.com/urfave/cli/v2"
+)
+
+// TokenResponse is the OAuth2 token endpoint response.
+type TokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int    `json:"expires_in"`
+	TokenType    string `json:"token_type"`
+}
+
+// LoginCommand returns the 'login' CLI command.
+func LoginCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "login",
+		Usage: "Authenticate and save the token",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "username",
+				Usage: "Username for OIDC password grant",
+			},
+			&cli.StringFlag{
+				Name:  "password",
+				Usage: "Password for OIDC password grant (prompted if not provided)",
+			},
+			&cli.StringFlag{
+				Name:    "client-secret",
+				Usage:   "Client secret (required for confidential OIDC clients)",
+				EnvVars: []string{"BMM_CLIENT_SECRET"},
+			},
+			&cli.StringFlag{
+				Name:    "api-key",
+				Usage:   "NGC API key for token exchange",
+				EnvVars: []string{"BMM_API_KEY"},
+			},
+			&cli.StringFlag{
+				Name:    "authn-url",
+				Usage:   "NGC authentication URL for API key exchange",
+				EnvVars: []string{"BMM_AUTHN_URL"},
+				Value:   "https://authn.nvidia.com/token",
+			},
+		},
+		Action: func(c *cli.Context) error {
+			cfg, _ := LoadConfig()
+
+			apiKey := c.String("api-key")
+			if apiKey == "" && HasAPIKeyConfig(cfg) {
+				apiKey = cfg.Auth.APIKey.Key
+			}
+			if apiKey != "" {
+				authnURL := c.String("authn-url")
+				if authnURL == "https://authn.nvidia.com/token" && cfg.Auth.APIKey != nil && cfg.Auth.APIKey.AuthnURL != "" {
+					authnURL = cfg.Auth.APIKey.AuthnURL
+				}
+				return loginWithAPIKey(cfg, authnURL, apiKey)
+			}
+			return loginWithOIDCCmd(c, cfg)
+		},
+	}
+}
+
+// InitCommand returns the 'init' CLI command that generates a sample config.
+func InitCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "init",
+		Usage: "Generate a sample config file at ~/.bmm/config.yaml",
+		Action: func(c *cli.Context) error {
+			path := ConfigPath()
+			if _, err := os.Stat(path); err == nil {
+				return fmt.Errorf("config file already exists: %s", path)
+			}
+			if err := os.MkdirAll(ConfigDir(), 0700); err != nil {
+				return fmt.Errorf("creating config directory: %w", err)
+			}
+			if err := os.WriteFile(path, []byte(SampleConfig), 0600); err != nil {
+				return fmt.Errorf("writing config: %w", err)
+			}
+			fmt.Fprintf(os.Stderr, "Config written to %s\n", path)
+			return nil
+		},
+	}
+}
+
+func loginWithAPIKey(cfg *ConfigFile, authnURL, apiKey string) error {
+	req, err := http.NewRequest("GET", authnURL, nil)
+	if err != nil {
+		return fmt.Errorf("building request: %w", err)
+	}
+	req.Header.Set("Authorization", "ApiKey "+apiKey)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("requesting token from NGC: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("reading response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("NGC token exchange failed (HTTP %d): %s", resp.StatusCode, string(body))
+	}
+
+	token := extractNGCToken(body)
+	if token == "" {
+		return fmt.Errorf("NGC response did not contain a token")
+	}
+
+	if cfg.Auth.APIKey == nil {
+		cfg.Auth.APIKey = &ConfigAPIKey{}
+	}
+	cfg.Auth.APIKey.Token = token
+	if err := SaveConfig(cfg); err != nil {
+		return fmt.Errorf("saving config: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "Login successful (NGC API key). Token saved to %s\n", ConfigPath())
+	return nil
+}
+
+func extractNGCToken(body []byte) string {
+	var resp struct {
+		Token       string `json:"token"`
+		AccessToken string `json:"access_token"`
+	}
+	if json.Unmarshal(body, &resp) != nil {
+		return ""
+	}
+	if resp.Token != "" {
+		return resp.Token
+	}
+	return resp.AccessToken
+}
+
+func loginWithOIDCCmd(c *cli.Context, cfg *ConfigFile) error {
+	tokenURL := c.String("token-url")
+	if tokenURL == "" && cfg.Auth.OIDC != nil {
+		tokenURL = cfg.Auth.OIDC.TokenURL
+	}
+	if tokenURL == "" {
+		if keycloakURL := c.String("keycloak-url"); keycloakURL != "" {
+			realm := c.String("keycloak-realm")
+			tokenURL = fmt.Sprintf("%s/realms/%s/protocol/openid-connect/token",
+				strings.TrimRight(keycloakURL, "/"), realm)
+		}
+	}
+	if tokenURL == "" {
+		return fmt.Errorf("--token-url or --keycloak-url is required (or set auth.oidc.token_url in config)")
+	}
+
+	clientID := c.String("client-id")
+	if clientID == "" && cfg.Auth.OIDC != nil {
+		clientID = cfg.Auth.OIDC.ClientID
+	}
+
+	clientSecret := c.String("client-secret")
+	if clientSecret == "" && cfg.Auth.OIDC != nil {
+		clientSecret = cfg.Auth.OIDC.ClientSecret
+	}
+
+	username := c.String("username")
+	if username == "" && cfg.Auth.OIDC != nil {
+		username = cfg.Auth.OIDC.Username
+	}
+
+	password := c.String("password")
+	if password == "" && cfg.Auth.OIDC != nil {
+		password = cfg.Auth.OIDC.Password
+	}
+
+	var tokenResp *TokenResponse
+	var err error
+
+	if username == "" && clientSecret != "" {
+		tokenResp, err = clientCredentialsGrant(tokenURL, clientID, clientSecret)
+	} else {
+		if username == "" {
+			fmt.Print("Username: ")
+			fmt.Scanln(&username)
+		}
+		if password == "" {
+			fmt.Print("Password: ")
+			pw, pwErr := term.ReadPassword(int(os.Stdin.Fd()))
+			fmt.Println()
+			if pwErr != nil {
+				return fmt.Errorf("reading password: %w", pwErr)
+			}
+			password = string(pw)
+		}
+		tokenResp, err = passwordGrant(tokenURL, clientID, clientSecret, username, password)
+	}
+	if err != nil {
+		return err
+	}
+
+	if cfg.Auth.OIDC == nil {
+		cfg.Auth.OIDC = &ConfigOIDC{}
+	}
+	cfg.Auth.OIDC.Token = tokenResp.AccessToken
+	cfg.Auth.OIDC.RefreshToken = tokenResp.RefreshToken
+	cfg.Auth.OIDC.ExpiresAt = time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second).Format(time.RFC3339)
+	cfg.Auth.OIDC.TokenURL = tokenURL
+	cfg.Auth.OIDC.ClientID = clientID
+	cfg.Auth.OIDC.ClientSecret = clientSecret
+
+	if err := SaveConfig(cfg); err != nil {
+		return fmt.Errorf("saving config: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "Login successful. Token saved to %s\n", ConfigPath())
+	return nil
+}
+
+func passwordGrant(tokenURL, clientID, clientSecret, username, password string) (*TokenResponse, error) {
+	data := url.Values{
+		"grant_type": {"password"},
+		"client_id":  {clientID},
+		"username":   {username},
+		"password":   {password},
+		"scope":      {"openid"},
+	}
+	if clientSecret != "" {
+		data.Set("client_secret", clientSecret)
+	}
+	return postToken(tokenURL, data)
+}
+
+func clientCredentialsGrant(tokenURL, clientID, clientSecret string) (*TokenResponse, error) {
+	data := url.Values{
+		"grant_type":    {"client_credentials"},
+		"client_id":     {clientID},
+		"client_secret": {clientSecret},
+		"scope":         {"openid"},
+	}
+	return postToken(tokenURL, data)
+}
+
+func refreshTokenGrant(tokenURL, clientID, clientSecret, refreshToken string) (*TokenResponse, error) {
+	data := url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {clientID},
+		"refresh_token": {refreshToken},
+	}
+	if clientSecret != "" {
+		data.Set("client_secret", clientSecret)
+	}
+	return postToken(tokenURL, data)
+}
+
+func postToken(tokenURL string, data url.Values) (*TokenResponse, error) {
+	resp, err := http.PostForm(tokenURL, data)
+	if err != nil {
+		return nil, fmt.Errorf("token request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		var errBody struct {
+			Error       string `json:"error"`
+			Description string `json:"error_description"`
+		}
+		if json.Unmarshal(body, &errBody) == nil && errBody.Description != "" {
+			return nil, fmt.Errorf("authentication failed: %s", errBody.Description)
+		}
+		if len(body) > 0 {
+			return nil, fmt.Errorf("authentication failed (%s): %s", resp.Status, string(body))
+		}
+		return nil, fmt.Errorf("authentication failed: %s", resp.Status)
+	}
+
+	var tokenResp TokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return nil, fmt.Errorf("decoding token response: %w", err)
+	}
+	return &tokenResp, nil
+}
+
+// AutoRefreshToken attempts to refresh the OIDC token if it is near expiry.
+func AutoRefreshToken(cfg *ConfigFile) (string, error) {
+	if cfg.Auth.OIDC == nil {
+		return GetAuthToken(cfg), nil
+	}
+
+	oidc := cfg.Auth.OIDC
+	if oidc.Token == "" {
+		return "", nil
+	}
+	if oidc.ExpiresAt == "" {
+		return oidc.Token, nil
+	}
+
+	expiresAt, err := time.Parse(time.RFC3339, oidc.ExpiresAt)
+	if err != nil {
+		return oidc.Token, nil
+	}
+
+	if time.Now().Before(expiresAt.Add(-30 * time.Second)) {
+		return oidc.Token, nil
+	}
+
+	if oidc.RefreshToken == "" || oidc.ClientID == "" || oidc.TokenURL == "" {
+		return oidc.Token, nil
+	}
+
+	tokenResp, err := refreshTokenGrant(oidc.TokenURL, oidc.ClientID, oidc.ClientSecret, oidc.RefreshToken)
+	if err != nil {
+		return oidc.Token, nil
+	}
+
+	oidc.Token = tokenResp.AccessToken
+	oidc.RefreshToken = tokenResp.RefreshToken
+	oidc.ExpiresAt = time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second).Format(time.RFC3339)
+	if err := SaveConfig(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: token refreshed but could not save config: %v\n", err)
+	}
+
+	return oidc.Token, nil
+}

--- a/cli/pkg/auth_test.go
+++ b/cli/pkg/auth_test.go
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bmmcli
+
+import (
+	"testing"
+)
+
+func TestExtractNGCToken(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "token field",
+			body: `{"token": "abc123"}`,
+			want: "abc123",
+		},
+		{
+			name: "access_token field",
+			body: `{"access_token": "xyz789"}`,
+			want: "xyz789",
+		},
+		{
+			name: "token takes precedence over access_token",
+			body: `{"token": "primary", "access_token": "secondary"}`,
+			want: "primary",
+		},
+		{
+			name: "empty response",
+			body: `{}`,
+			want: "",
+		},
+		{
+			name: "invalid json",
+			body: `not json`,
+			want: "",
+		},
+		{
+			name: "empty token values",
+			body: `{"token": "", "access_token": ""}`,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractNGCToken([]byte(tt.body))
+			if got != tt.want {
+				t.Errorf("extractNGCToken(%q) = %q, want %q", tt.body, got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/pkg/client.go
+++ b/cli/pkg/client.go
@@ -1,0 +1,216 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bmmcli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+type Client struct {
+	BaseURL    string
+	Org        string
+	Token      string
+	APIName    string
+	HTTPClient *http.Client
+	Debug      bool
+	Log        *logrus.Entry
+}
+
+type APIError struct {
+	StatusCode int
+	Status     string
+	Body       string
+	Message    string
+	Data       interface{}
+}
+
+func (e *APIError) Error() string {
+	msg := e.Message
+	if msg == "" {
+		msg = e.Body
+	}
+	if e.Data != nil {
+		dataJSON, err := json.Marshal(e.Data)
+		if err == nil && string(dataJSON) != "null" {
+			return fmt.Sprintf("API error %d: %s\nDetails: %s", e.StatusCode, msg, string(dataJSON))
+		}
+	}
+	return fmt.Sprintf("API error %d: %s", e.StatusCode, msg)
+}
+
+func NewClient(baseURL, org, token string, log *logrus.Entry, debug bool) *Client {
+	return &Client{
+		BaseURL: strings.TrimRight(baseURL, "/"),
+		Org:     org,
+		Token:   token,
+		APIName: "carbide",
+		HTTPClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		Debug: debug,
+		Log:   log,
+	}
+}
+
+var orgScopedAPIPathPattern = regexp.MustCompile(`(/v[0-9]+/org/[^/]+/)([^/]+)`)
+
+// rewriteAPIName replaces the API path segment after /org/{org}/ with the
+// configured API name. This decouples the CLI from the hardcoded path in the spec.
+func (c *Client) rewriteAPIName(path string) string {
+	if c.APIName == "" || c.APIName == "carbide" {
+		return path
+	}
+	return orgScopedAPIPathPattern.ReplaceAllString(path, "${1}"+c.APIName)
+}
+
+// Do executes an HTTP request against the API.
+func (c *Client) Do(method, pathTemplate string, pathParams, queryParams map[string]string, body []byte) ([]byte, http.Header, error) {
+	path := pathTemplate
+	path = strings.ReplaceAll(path, "{org}", url.PathEscape(c.Org))
+	for k, v := range pathParams {
+		path = strings.ReplaceAll(path, "{"+k+"}", url.PathEscape(v))
+	}
+
+	path = c.rewriteAPIName(path)
+	reqURL := c.BaseURL + path
+	if len(queryParams) > 0 {
+		q := url.Values{}
+		for k, v := range queryParams {
+			q.Set(k, v)
+		}
+		reqURL += "?" + q.Encode()
+	}
+
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+
+	if c.Debug {
+		c.Log.Debugf("%s %s", method, reqURL)
+		if body != nil {
+			c.Log.Debugf("Body: %s", string(body))
+		}
+	}
+
+	req, err := http.NewRequest(method, reqURL, bodyReader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+	if c.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.Token)
+	}
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	if c.Debug {
+		c.Log.Debugf("Response %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	if resp.StatusCode >= 400 {
+		apiErr := &APIError{
+			StatusCode: resp.StatusCode,
+			Status:     resp.Status,
+			Body:       string(respBody),
+		}
+		var errResp struct {
+			Source  string      `json:"source"`
+			Message string      `json:"message"`
+			Error   string      `json:"error"`
+			Data    interface{} `json:"data"`
+		}
+		if json.Unmarshal(respBody, &errResp) == nil {
+			if errResp.Message != "" {
+				apiErr.Message = errResp.Message
+			} else if errResp.Error != "" {
+				apiErr.Message = errResp.Error
+			}
+			apiErr.Data = errResp.Data
+		}
+		return nil, nil, apiErr
+	}
+
+	return respBody, resp.Header, nil
+}
+
+// ResolveToken returns the token or executes the token command.
+func ResolveToken(token, tokenCommand string) (string, error) {
+	if token != "" {
+		return token, nil
+	}
+	if tokenCommand != "" {
+		out, err := exec.Command("sh", "-c", tokenCommand).Output()
+		if err != nil {
+			return "", fmt.Errorf("executing token command: %w", err)
+		}
+		return strings.TrimSpace(string(out)), nil
+	}
+	return "", nil
+}
+
+// ReadBodyInput reads request body from --data flag or --data-file flag.
+// Use "--data-file -" to read from stdin.
+func ReadBodyInput(data, dataFile string) ([]byte, error) {
+	if data != "" && dataFile != "" {
+		return nil, fmt.Errorf("specify either --data or --data-file, not both")
+	}
+	if data != "" {
+		return []byte(data), nil
+	}
+	if dataFile != "" {
+		if dataFile == "-" {
+			b, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return nil, fmt.Errorf("reading stdin: %w", err)
+			}
+			return b, nil
+		}
+		b, err := os.ReadFile(dataFile)
+		if err != nil {
+			return nil, fmt.Errorf("reading data file: %w", err)
+		}
+		return b, nil
+	}
+	return nil, nil
+}

--- a/cli/pkg/commands.go
+++ b/cli/pkg/commands.go
@@ -1,0 +1,751 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bmmcli
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	cli "github.com/urfave/cli/v2"
+)
+
+type resolvedOp struct {
+	tag        string
+	action     string
+	method     string
+	path       string
+	op         *Operation
+	pathParams []Parameter
+}
+
+// bodyField tracks a request body property for type-aware flag reading.
+type bodyField struct {
+	jsonName string
+	flagName string
+	schema   *Schema
+}
+
+// subResourceHelpTemplate renders actions and sub-resources as separate sections.
+var subResourceHelpTemplate = `NAME:
+   {{.HelpName}} - {{.Usage}}
+
+USAGE:
+   {{.HelpName}} command [command options] [arguments...]
+
+COMMANDS:{{range .VisibleCommands}}{{if not .Category}}
+   {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{end}}
+
+SUB-RESOURCES:{{range .VisibleCommands}}{{if .Category}}
+   {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{end}}
+
+OPTIONS:
+   {{range .VisibleFlagCategories}}{{range .Flags}}{{.}}
+   {{end}}{{end}}
+`
+
+// BuildCommands converts parsed OpenAPI operations into a cli.Command tree grouped by tag.
+func BuildCommands(spec *Spec) []*cli.Command {
+	ops := collectOperations(spec)
+	grouped := groupByTag(ops)
+
+	tagDescriptions := make(map[string]string)
+	for _, t := range spec.Tags {
+		tagDescriptions[tagToCommand(t.Name)] = firstLine(t.Description)
+	}
+
+	var commands []*cli.Command
+	for _, cmdName := range sortedKeys(grouped) {
+		actions := grouped[cmdName]
+		subCmds := buildTagSubcommands(spec, actions)
+		sort.Slice(subCmds, func(i, j int) bool { return subCmds[i].Name < subCmds[j].Name })
+		desc := tagDescriptions[cmdName]
+		if desc == "" {
+			desc = cmdName + " operations"
+		}
+		cmd := &cli.Command{
+			Name:        cmdName,
+			Usage:       desc,
+			Subcommands: subCmds,
+		}
+		for _, sc := range subCmds {
+			if sc.Category != "" {
+				cmd.CustomHelpTemplate = subResourceHelpTemplate
+				break
+			}
+		}
+		commands = append(commands, cmd)
+	}
+	return commands
+}
+
+func collectOperations(spec *Spec) []resolvedOp {
+	var ops []resolvedOp
+	for path, item := range spec.Paths {
+		methods := []struct {
+			m  string
+			op *Operation
+		}{
+			{"GET", item.Get},
+			{"POST", item.Post},
+			{"PATCH", item.Patch},
+			{"PUT", item.Put},
+			{"DELETE", item.Delete},
+		}
+		for _, me := range methods {
+			if me.op == nil {
+				continue
+			}
+			tag := "other"
+			if len(me.op.Tags) > 0 {
+				tag = me.op.Tags[0]
+			}
+			ops = append(ops, resolvedOp{
+				tag:        tag,
+				action:     operationAction(me.op.OperationID),
+				method:     me.m,
+				path:       path,
+				op:         me.op,
+				pathParams: item.Parameters,
+			})
+		}
+	}
+	return ops
+}
+
+func groupByTag(ops []resolvedOp) map[string][]resolvedOp {
+	grouped := make(map[string][]resolvedOp)
+	for _, op := range ops {
+		cmdName := tagToCommand(op.tag)
+		grouped[cmdName] = append(grouped[cmdName], op)
+	}
+	return grouped
+}
+
+// buildTagSubcommands splits a tag's operations into primary resource actions
+// and nested sub-resource groups.
+func buildTagSubcommands(spec *Spec, ops []resolvedOp) []*cli.Command {
+	primary := detectPrimaryResource(ops)
+
+	var primaryOps []resolvedOp
+	subResourceOps := make(map[string][]resolvedOp)
+
+	for _, op := range ops {
+		suffix := extractResourceSuffix(op.op.OperationID)
+		subRes := subResourceName(suffix, primary)
+		if subRes == "" {
+			primaryOps = append(primaryOps, op)
+		} else {
+			subResourceOps[subRes] = append(subResourceOps[subRes], op)
+		}
+	}
+
+	seen := make(map[string]bool)
+	for i := range primaryOps {
+		if seen[primaryOps[i].action] {
+			primaryOps[i].action = primaryOps[i].op.OperationID
+		}
+		seen[primaryOps[i].action] = true
+	}
+
+	var cmds []*cli.Command
+	for _, op := range primaryOps {
+		cmds = append(cmds, buildActionCommand(spec, op, ""))
+	}
+
+	subResNames := make([]string, 0, len(subResourceOps))
+	for name := range subResourceOps {
+		subResNames = append(subResNames, name)
+	}
+	sort.Strings(subResNames)
+
+	for _, name := range subResNames {
+		subOps := subResourceOps[name]
+		subCmds := make([]*cli.Command, 0, len(subOps))
+		for _, op := range subOps {
+			subCmds = append(subCmds, buildActionCommand(spec, op, name))
+		}
+		sort.Slice(subCmds, func(i, j int) bool { return subCmds[i].Name < subCmds[j].Name })
+
+		usage := name + " operations"
+		if len(subCmds) == 1 {
+			usage = subCmds[0].Usage
+		}
+		cmds = append(cmds, &cli.Command{
+			Name:        name,
+			Category:    "Sub-resources",
+			Usage:       usage,
+			Subcommands: subCmds,
+		})
+	}
+
+	return cmds
+}
+
+func detectPrimaryResource(ops []resolvedOp) string {
+	counts := make(map[string]int)
+	for _, op := range ops {
+		suffix := extractResourceSuffix(op.op.OperationID)
+		counts[suffix]++
+	}
+	best := ""
+	bestCount := 0
+	for suffix, count := range counts {
+		if count > bestCount || (count == bestCount && len(suffix) < len(best)) {
+			bestCount = count
+			best = suffix
+		}
+	}
+	return best
+}
+
+func extractResourceSuffix(opID string) string {
+	prefixes := []string{
+		"batch-create-", "batch-update-",
+		"get-all-", "get-current-",
+		"create-", "update-", "delete-", "get-",
+	}
+	for _, p := range prefixes {
+		if strings.HasPrefix(opID, p) {
+			return opID[len(p):]
+		}
+	}
+	return opID
+}
+
+func subResourceName(suffix, primary string) string {
+	if suffix == primary {
+		return ""
+	}
+	if suffix == primary+"s" || suffix == primary+"es" {
+		return ""
+	}
+	if strings.HasPrefix(suffix, primary+"-") {
+		remainder := suffix[len(primary)+1:]
+		if isActionModifier(remainder) {
+			return ""
+		}
+		return remainder
+	}
+	if strings.HasSuffix(suffix, "-"+primary) {
+		return suffix[:len(suffix)-len(primary)-1]
+	}
+	return suffix
+}
+
+func isActionModifier(s string) bool {
+	switch s {
+	case "status-history", "stats":
+		return true
+	}
+	return false
+}
+
+func isListAction(action string) bool {
+	return action == "list" || strings.HasPrefix(action, "list-")
+}
+
+func buildActionCommand(spec *Spec, ro resolvedOp, subResource string) *cli.Command {
+	flags := []cli.Flag{
+		&cli.StringFlag{
+			Name:  "output",
+			Usage: "Output format: json, yaml, table",
+			Value: "json",
+		},
+	}
+
+	isList := isListAction(ro.action)
+	if isList {
+		flags = append(flags, &cli.BoolFlag{
+			Name:  "all",
+			Usage: "Fetch all pages of results",
+		})
+	}
+
+	var argParams []string
+
+	allParams := append([]Parameter{}, ro.pathParams...)
+	allParams = append(allParams, ro.op.Parameters...)
+
+	for _, p := range allParams {
+		if p.Name == "org" {
+			continue
+		}
+		if p.In == "path" {
+			argParams = append(argParams, p.Name)
+			continue
+		}
+		if p.In == "query" {
+			flags = append(flags, paramToFlag(p))
+		}
+	}
+
+	var bodyFields []bodyField
+
+	hasBody := ro.op.RequestBody != nil
+	if hasBody {
+		flags = append(flags,
+			&cli.StringFlag{
+				Name:  "data",
+				Usage: "Request body as inline JSON",
+			},
+			&cli.StringFlag{
+				Name:  "data-file",
+				Usage: "Path to a JSON file containing the request body (use - for stdin)",
+			},
+		)
+		if schema := spec.RequestBodySchema(ro.op); schema != nil {
+			reqSet := make(map[string]bool)
+			for _, r := range schema.Required {
+				reqSet[r] = true
+			}
+			for name, prop := range schema.Properties {
+				resolved := spec.ResolveSchema(prop)
+				if resolved == nil || resolved.Type == "object" || resolved.Type == "array" {
+					continue
+				}
+				usage := name
+				if reqSet[name] {
+					usage += " (required)"
+				}
+				flagName := toKebab(name)
+				bodyFields = append(bodyFields, bodyField{
+					jsonName: name,
+					flagName: flagName,
+					schema:   resolved,
+				})
+				flags = append(flags, schemaToFlag(flagName, usage, resolved))
+			}
+		}
+	}
+
+	sort.Slice(flags, func(i, j int) bool {
+		return flags[i].Names()[0] < flags[j].Names()[0]
+	})
+
+	usageText := "bmmcli " + tagToCommand(ro.tag)
+	if subResource != "" {
+		usageText += " " + subResource
+	}
+	usageText += " " + ro.action
+	for _, ap := range argParams {
+		usageText += " <" + ap + ">"
+	}
+
+	summary := ro.op.Summary
+	if summary == "" {
+		summary = ro.op.OperationID
+	}
+
+	return &cli.Command{
+		Name:      ro.action,
+		Usage:     summary,
+		UsageText: usageText,
+		Flags:     flags,
+		Action: func(c *cli.Context) error {
+			client, err := clientFromContext(c)
+			if err != nil {
+				return err
+			}
+
+			pathParams := make(map[string]string)
+			for i, ap := range argParams {
+				if c.NArg() <= i {
+					return fmt.Errorf("missing required argument: <%s>", ap)
+				}
+				pathParams[ap] = c.Args().Get(i)
+			}
+
+			queryParams := make(map[string]string)
+			for _, p := range allParams {
+				if p.In != "query" {
+					continue
+				}
+				if v := readFlagValue(c, p); v != "" {
+					queryParams[p.Name] = v
+				}
+			}
+
+			var body []byte
+			if hasBody {
+				body, err = buildRequestBody(c, bodyFields)
+				if err != nil {
+					return err
+				}
+			}
+
+			if isList && c.Bool("all") {
+				return fetchAllPages(client, ro.method, ro.path, pathParams, queryParams, c.String("output"))
+			}
+
+			respBody, respHeaders, err := client.Do(ro.method, ro.path, pathParams, queryParams, body)
+			if err != nil {
+				return err
+			}
+
+			printPaginationSummary(respHeaders)
+
+			if len(respBody) == 0 {
+				return nil
+			}
+
+			return FormatOutput(respBody, c.String("output"))
+		},
+	}
+}
+
+func readFlagValue(c *cli.Context, p Parameter) string {
+	flagName := toKebab(p.Name)
+	if p.Schema == nil {
+		return c.String(flagName)
+	}
+	switch p.Schema.Type {
+	case "integer":
+		if c.IsSet(flagName) {
+			return fmt.Sprintf("%d", c.Int(flagName))
+		}
+		return ""
+	case "boolean":
+		if c.IsSet(flagName) {
+			return fmt.Sprintf("%t", c.Bool(flagName))
+		}
+		return ""
+	default:
+		return c.String(flagName)
+	}
+}
+
+func schemaToFlag(flagName, usage string, schema *Schema) cli.Flag {
+	return &cli.StringFlag{Name: flagName, Usage: usage}
+}
+
+func buildRequestBody(c *cli.Context, bodyFields []bodyField) ([]byte, error) {
+	data := c.String("data")
+	dataFile := c.String("data-file")
+	body, err := ReadBodyInput(data, dataFile)
+	if err != nil {
+		return nil, err
+	}
+	if body != nil {
+		return body, nil
+	}
+
+	obj := make(map[string]interface{})
+	for _, bf := range bodyFields {
+		v := c.String(bf.flagName)
+		if v == "" {
+			continue
+		}
+		val, err := coerceValue(v, bf.schema.Type)
+		if err != nil {
+			return nil, fmt.Errorf("flag --%s: %w", bf.flagName, err)
+		}
+		obj[bf.jsonName] = val
+	}
+
+	if len(obj) == 0 {
+		return nil, nil
+	}
+	return json.Marshal(obj)
+}
+
+type paginationHeader struct {
+	PageNumber int `json:"pageNumber"`
+	PageSize   int `json:"pageSize"`
+	Total      int `json:"total"`
+}
+
+func parsePaginationHeader(headers http.Header) *paginationHeader {
+	raw := headers.Get("X-Pagination")
+	if raw == "" {
+		return nil
+	}
+	var h paginationHeader
+	if json.Unmarshal([]byte(raw), &h) != nil {
+		return nil
+	}
+	return &h
+}
+
+func printPaginationSummary(headers http.Header) {
+	h := parsePaginationHeader(headers)
+	if h == nil {
+		return
+	}
+	pageCount := 1
+	if h.PageSize > 0 && h.Total > 0 {
+		pageCount = (h.Total + h.PageSize - 1) / h.PageSize
+	}
+	if pageCount > 1 {
+		fmt.Fprintf(os.Stderr, "Page %d/%d (%d items, %d total). Use --all to fetch everything.\n",
+			h.PageNumber, pageCount, h.PageSize, h.Total)
+	} else {
+		fmt.Fprintf(os.Stderr, "%d items\n", h.Total)
+	}
+}
+
+func fetchAllPages(client *Client, method, path string, pathParams, queryParams map[string]string, outputFormat string) error {
+	const maxPageSize = 100
+	const maxPages = 1000
+	pageNumber := 1
+
+	if queryParams == nil {
+		queryParams = make(map[string]string)
+	}
+	queryParams["pageSize"] = strconv.Itoa(maxPageSize)
+
+	var allItems []json.RawMessage
+	totalFromHeader := 0
+
+	for {
+		queryParams["pageNumber"] = strconv.Itoa(pageNumber)
+
+		respBody, respHeaders, err := client.Do(method, path, pathParams, queryParams, nil)
+		if err != nil {
+			return err
+		}
+
+		var pageItems []json.RawMessage
+		if len(respBody) > 0 {
+			if err := json.Unmarshal(respBody, &pageItems); err != nil {
+				return FormatOutput(respBody, outputFormat)
+			}
+		}
+		allItems = append(allItems, pageItems...)
+
+		h := parsePaginationHeader(respHeaders)
+		if h != nil {
+			totalFromHeader = h.Total
+		}
+
+		if h != nil && h.Total > 0 && len(allItems) >= h.Total {
+			break
+		}
+		if len(pageItems) < maxPageSize {
+			break
+		}
+
+		pageNumber++
+		if pageNumber > maxPages {
+			fmt.Fprintf(os.Stderr, "Warning: stopped after %d pages (%d items). Consider adding filters to reduce the number of fetched items.\n", maxPages, len(allItems))
+			break
+		}
+	}
+
+	if totalFromHeader > 0 {
+		fmt.Fprintf(os.Stderr, "Fetched all %d items\n", totalFromHeader)
+	} else {
+		fmt.Fprintf(os.Stderr, "Fetched %d items\n", len(allItems))
+	}
+
+	merged, err := json.Marshal(allItems)
+	if err != nil {
+		return err
+	}
+	return FormatOutput(merged, outputFormat)
+}
+
+func coerceValue(v string, schemaType SchemaType) (interface{}, error) {
+	switch schemaType {
+	case "integer":
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, fmt.Errorf("expected integer, got %q", v)
+		}
+		return n, nil
+	case "boolean":
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, fmt.Errorf("expected boolean, got %q", v)
+		}
+		return b, nil
+	case "number":
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return nil, fmt.Errorf("expected number, got %q", v)
+		}
+		return f, nil
+	default:
+		return v, nil
+	}
+}
+
+func clientFromContext(c *cli.Context) (*Client, error) {
+	cfg, _ := LoadConfig()
+
+	token := c.String("token")
+	if token == "" {
+		token = GetAuthToken(cfg)
+		if token == "" {
+			token, _ = AutoRefreshToken(cfg)
+		}
+	}
+
+	resolved, err := ResolveToken(token, c.String("token-command"))
+	if err != nil {
+		return nil, err
+	}
+
+	if resolved == "" {
+		return nil, fmt.Errorf("no token available; run 'bmmcli login' or set --token / BMM_TOKEN")
+	}
+
+	// Explicit flag > config > flag default (spec server URL).
+	baseURL := cfg.API.Base
+	if c.IsSet("base-url") {
+		baseURL = c.String("base-url")
+	}
+	if baseURL == "" {
+		baseURL = c.String("base-url")
+	}
+
+	org := cfg.API.Org
+	if c.IsSet("org") {
+		org = c.String("org")
+	}
+	if org == "" {
+		return nil, fmt.Errorf("--org is required (or set api.org in config)")
+	}
+
+	apiName := cfg.API.Name
+	if apiName == "" {
+		apiName = "carbide"
+	}
+
+	debug := c.Bool("debug")
+	log := logrus.NewEntry(logrus.StandardLogger())
+
+	client := NewClient(baseURL, org, resolved, log, debug)
+	client.APIName = apiName
+	return client, nil
+}
+
+func paramToFlag(p Parameter) cli.Flag {
+	flagName := toKebab(p.Name)
+	usage := p.Description
+	if p.Schema != nil && len(p.Schema.Enum) > 0 {
+		usage += " [" + strings.Join(p.Schema.Enum, ", ") + "]"
+	}
+
+	if p.Schema != nil {
+		switch p.Schema.Type {
+		case "integer":
+			f := &cli.IntFlag{Name: flagName, Usage: usage}
+			if p.Schema.Default != nil {
+				if v, ok := p.Schema.Default.(int); ok {
+					f.Value = v
+				}
+			}
+			return f
+		case "boolean":
+			return &cli.BoolFlag{Name: flagName, Usage: usage}
+		}
+	}
+
+	return &cli.StringFlag{Name: flagName, Usage: usage}
+}
+
+func tagToCommand(tag string) string {
+	return toKebab(tag)
+}
+
+func operationAction(opID string) string {
+	patterns := []struct {
+		prefix string
+		action string
+	}{
+		{"batch-create-", "batch-create"},
+		{"batch-update-", "batch-update"},
+		{"get-all-", "list"},
+		{"get-current-", "get"},
+		{"create-", "create"},
+		{"update-", "update"},
+		{"delete-", "delete"},
+		{"get-", ""},
+	}
+
+	for _, p := range patterns {
+		if strings.HasPrefix(opID, p.prefix) {
+			if p.action != "" {
+				return p.action
+			}
+			suffix := opID[len(p.prefix):]
+			if strings.HasSuffix(suffix, "-status-history") {
+				return "status-history"
+			}
+			if strings.HasSuffix(suffix, "-stats") {
+				return "stats"
+			}
+			return "get"
+		}
+	}
+
+	return opID
+}
+
+func toKebab(s string) string {
+	if strings.Contains(s, " ") {
+		parts := strings.Fields(s)
+		for i := range parts {
+			parts[i] = strings.ToLower(parts[i])
+		}
+		return strings.Join(parts, "-")
+	}
+
+	var result []byte
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			if i > 0 && s[i-1] >= 'a' && s[i-1] <= 'z' {
+				result = append(result, '-')
+			}
+			j := i + 1
+			for j < len(s) && s[j] >= 'A' && s[j] <= 'Z' {
+				j++
+			}
+			for k := i; k < j; k++ {
+				result = append(result, s[k]-'A'+'a')
+			}
+			i = j - 1
+		} else {
+			result = append(result, c)
+		}
+	}
+	return string(result)
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+func sortedKeys(m map[string][]resolvedOp) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/cli/pkg/commands_test.go
+++ b/cli/pkg/commands_test.go
@@ -1,0 +1,332 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bmmcli
+
+import (
+	"testing"
+)
+
+func TestToKebab(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		// Space-separated (tag names)
+		{"Site", "site"},
+		{"IP Block", "ip-block"},
+		{"SSH Key Group", "ssh-key-group"},
+		{"DPU Extension Service", "dpu-extension-service"},
+		{"Infrastructure Provider", "infrastructure-provider"},
+		{"NVLink Logical Partition", "nvlink-logical-partition"},
+
+		// CamelCase (parameter and field names)
+		{"siteId", "site-id"},
+		{"pageNumber", "page-number"},
+		{"pageSize", "page-size"},
+		{"infrastructureProviderId", "infrastructure-provider-id"},
+		{"networkSecurityGroupId", "network-security-group-id"},
+		{"serialConsoleHostname", "serial-console-hostname"},
+
+		// Acronym handling
+		{"NVLinkLogicalPartition", "nvlink-logical-partition"},
+		{"isNVLinkPartitionEnabled", "is-nvlink-partition-enabled"},
+		{"dpuExtensionServiceId", "dpu-extension-service-id"},
+
+		// Already lowercase
+		{"site", "site"},
+		{"org", "org"},
+
+		// Single word uppercase
+		{"ID", "id"},
+		{"VPC", "vpc"},
+		{"SKU", "sku"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := toKebab(tt.input)
+			if got != tt.want {
+				t.Errorf("toKebab(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOperationAction(t *testing.T) {
+	tests := []struct {
+		opID string
+		want string
+	}{
+		{"get-all-site", "list"},
+		{"get-all-instance", "list"},
+		{"get-all-allocation-constraint", "list"},
+		{"get-current-infrastructure-provider", "get"},
+		{"get-current-tenant", "get"},
+		{"get-current-service-account", "get"},
+		{"create-site", "create"},
+		{"create-allocation-constraint", "create"},
+		{"update-site", "update"},
+		{"delete-site", "delete"},
+		{"get-site", "get"},
+		{"get-allocation", "get"},
+		{"get-site-status-history", "status-history"},
+		{"get-instance-status-history", "status-history"},
+		{"get-machine-status-history", "status-history"},
+		// get-current-* matches before -stats suffix check
+		{"get-current-infrastructure-provider-stats", "get"},
+		{"get-current-tenant-stats", "get"},
+		{"batch-create-instance", "batch-create"},
+		{"batch-create-expected-machines", "batch-create"},
+		{"batch-update-expected-machines", "batch-update"},
+		{"get-metadata", "get"},
+		{"get-user", "get"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.opID, func(t *testing.T) {
+			got := operationAction(tt.opID)
+			if got != tt.want {
+				t.Errorf("operationAction(%q) = %q, want %q", tt.opID, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractResourceSuffix(t *testing.T) {
+	tests := []struct {
+		opID string
+		want string
+	}{
+		{"get-all-site", "site"},
+		{"create-site", "site"},
+		{"get-site", "site"},
+		{"delete-site", "site"},
+		{"update-site", "site"},
+		{"get-all-allocation-constraint", "allocation-constraint"},
+		{"get-current-infrastructure-provider", "infrastructure-provider"},
+		{"batch-create-expected-machines", "expected-machines"},
+		{"batch-update-expected-machines", "expected-machines"},
+		{"get-site-status-history", "site-status-history"},
+		{"get-instance-status-history", "instance-status-history"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.opID, func(t *testing.T) {
+			got := extractResourceSuffix(tt.opID)
+			if got != tt.want {
+				t.Errorf("extractResourceSuffix(%q) = %q, want %q", tt.opID, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSubResourceName(t *testing.T) {
+	tests := []struct {
+		suffix  string
+		primary string
+		want    string
+	}{
+		// Exact match → primary
+		{"site", "site", ""},
+		{"allocation", "allocation", ""},
+		{"instance", "instance", ""},
+
+		// Plural match → primary
+		{"expected-machines", "expected-machine", ""},
+
+		// Primary as prefix → sub-resource
+		{"allocation-constraint", "allocation", "constraint"},
+		{"dpu-extension-service-version", "dpu-extension-service", "version"},
+		{"instance-type-machine-association", "instance-type", "machine-association"},
+
+		// Action modifiers → primary (not sub-resource)
+		{"site-status-history", "site", ""},
+		{"instance-status-history", "instance", ""},
+		{"infrastructure-provider-stats", "infrastructure-provider", ""},
+
+		// Primary as suffix → sub-resource
+		{"derived-ipblock", "ipblock", "derived"},
+
+		// No overlap → sub-resource (full suffix)
+		{"interface", "instance", "interface"},
+		{"infiniband-interface", "instance", "infiniband-interface"},
+		{"nvlink-interface", "nvlink-logical-partition", "nvlink-interface"},
+	}
+
+	for _, tt := range tests {
+		name := tt.suffix + "_primary_" + tt.primary
+		t.Run(name, func(t *testing.T) {
+			got := subResourceName(tt.suffix, tt.primary)
+			if got != tt.want {
+				t.Errorf("subResourceName(%q, %q) = %q, want %q", tt.suffix, tt.primary, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectPrimaryResource(t *testing.T) {
+	tests := []struct {
+		name    string
+		opIDs   []string
+		want    string
+	}{
+		{
+			name: "site is primary",
+			opIDs: []string{
+				"get-all-site", "create-site", "get-site", "update-site", "delete-site",
+				"get-site-status-history",
+			},
+			want: "site",
+		},
+		{
+			name: "allocation wins over allocation-constraint by shorter length on tie",
+			opIDs: []string{
+				"get-all-allocation", "create-allocation", "get-allocation", "update-allocation", "delete-allocation",
+				"get-all-allocation-constraint", "create-allocation-constraint", "get-allocation-constraint", "update-allocation-constraint", "delete-allocation-constraint",
+			},
+			want: "allocation",
+		},
+		{
+			name: "instance wins with more operations",
+			opIDs: []string{
+				"get-all-instance", "create-instance", "get-instance", "update-instance", "delete-instance",
+				"batch-create-instance", "get-instance-status-history",
+				"get-all-interface",
+				"get-all-infiniband-interface",
+			},
+			want: "instance",
+		},
+		{
+			name: "expected-machine with plural batch ops",
+			opIDs: []string{
+				"create-expected-machine", "get-all-expected-machine", "get-expected-machine",
+				"update-expected-machine", "delete-expected-machine",
+				"batch-create-expected-machines", "batch-update-expected-machines",
+			},
+			want: "expected-machine",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ops := make([]resolvedOp, len(tt.opIDs))
+			for i, opID := range tt.opIDs {
+				ops[i] = resolvedOp{
+					op: &Operation{OperationID: opID},
+				}
+			}
+			got := detectPrimaryResource(ops)
+			if got != tt.want {
+				t.Errorf("detectPrimaryResource() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCoerceValue(t *testing.T) {
+	tests := []struct {
+		value      string
+		schemaType SchemaType
+		want       interface{}
+		wantErr    bool
+	}{
+		// Integers
+		{"42", "integer", 42, false},
+		{"0", "integer", 0, false},
+		{"-1", "integer", -1, false},
+		{"abc", "integer", nil, true},
+
+		// Booleans
+		{"true", "boolean", true, false},
+		{"false", "boolean", false, false},
+		{"1", "boolean", true, false},
+		{"0", "boolean", false, false},
+		{"yes", "boolean", nil, true},
+
+		// Numbers (float)
+		{"3.14", "number", 3.14, false},
+		{"0", "number", float64(0), false},
+		{"abc", "number", nil, true},
+
+		// Strings (passthrough)
+		{"hello", "string", "hello", false},
+		{"", "string", "", false},
+		{"123", "string", "123", false},
+	}
+
+	for _, tt := range tests {
+		name := string(tt.schemaType) + "_" + tt.value
+		t.Run(name, func(t *testing.T) {
+			got, err := coerceValue(tt.value, tt.schemaType)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("coerceValue(%q, %q) error = %v, wantErr %v", tt.value, tt.schemaType, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("coerceValue(%q, %q) = %v (%T), want %v (%T)", tt.value, tt.schemaType, got, got, tt.want, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsListAction(t *testing.T) {
+	tests := []struct {
+		action string
+		want   bool
+	}{
+		{"list", true},
+		{"list-interfaces", true},
+		{"list-infiniband-interfaces", true},
+		{"get", false},
+		{"create", false},
+		{"delete", false},
+		{"listing", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.action, func(t *testing.T) {
+			got := isListAction(tt.action)
+			if got != tt.want {
+				t.Errorf("isListAction(%q) = %v, want %v", tt.action, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsActionModifier(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"status-history", true},
+		{"stats", true},
+		{"constraint", false},
+		{"version", false},
+		{"virtualization", false},
+		{"machine-association", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := isActionModifier(tt.input)
+			if got != tt.want {
+				t.Errorf("isActionModifier(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/pkg/config.go
+++ b/cli/pkg/config.go
@@ -1,0 +1,202 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bmmcli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ConfigFile mirrors the ~/.bmm/config.yaml structure.
+type ConfigFile struct {
+	API  ConfigAPI  `yaml:"api"`
+	Auth ConfigAuth `yaml:"auth"`
+}
+
+type ConfigAPI struct {
+	Base string `yaml:"base,omitempty"`
+	Org  string `yaml:"org,omitempty"`
+	Name string `yaml:"name,omitempty"`
+}
+
+type ConfigAuth struct {
+	Token  string        `yaml:"token,omitempty"`
+	OIDC   *ConfigOIDC   `yaml:"oidc,omitempty"`
+	APIKey *ConfigAPIKey `yaml:"api_key,omitempty"`
+}
+
+type ConfigOIDC struct {
+	TokenURL     string `yaml:"token_url,omitempty"`
+	ClientID     string `yaml:"client_id,omitempty"`
+	ClientSecret string `yaml:"client_secret,omitempty"`
+	Username     string `yaml:"username,omitempty"`
+	Password     string `yaml:"password,omitempty"`
+	Token        string `yaml:"token,omitempty"`
+	RefreshToken string `yaml:"refresh_token,omitempty"`
+	ExpiresAt    string `yaml:"expires_at,omitempty"`
+}
+
+type ConfigAPIKey struct {
+	AuthnURL string `yaml:"authn_url,omitempty"`
+	Key      string `yaml:"key,omitempty"`
+	Token    string `yaml:"token,omitempty"`
+}
+
+// ConfigPath returns the default config file path.
+func ConfigPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		fmt.Fprintln(os.Stderr, "Warning: could not determine home directory, using current directory for config")
+		return filepath.Join(".bmm", "config.yaml")
+	}
+	return filepath.Join(home, ".bmm", "config.yaml")
+}
+
+// ConfigDir returns the ~/.bmm directory.
+func ConfigDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ".bmm"
+	}
+	return filepath.Join(home, ".bmm")
+}
+
+// LoadConfig reads the default config file.
+func LoadConfig() (*ConfigFile, error) {
+	return LoadConfigFromPath(ConfigPath())
+}
+
+// LoadConfigFromPath reads a config file at a specific path.
+func LoadConfigFromPath(path string) (*ConfigFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &ConfigFile{}, nil
+		}
+		return nil, err
+	}
+	var cfg ConfigFile
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing config %s: %w", path, err)
+	}
+	return &cfg, nil
+}
+
+// SaveConfig writes the config back to ConfigPath(), preserving unknown keys.
+func SaveConfig(cfg *ConfigFile) error {
+	return SaveConfigToPath(cfg, ConfigPath())
+}
+
+// SaveConfigToPath writes the config to a specific path, preserving any
+// unknown keys the user may have manually added.
+func SaveConfigToPath(cfg *ConfigFile, path string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
+	}
+
+	// Load existing file as raw map to preserve unknown keys.
+	raw := make(map[string]interface{})
+	if existing, err := os.ReadFile(path); err == nil {
+		yaml.Unmarshal(existing, &raw)
+	}
+
+	// Marshal the struct and merge into the raw map.
+	structured, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshaling config: %w", err)
+	}
+	var cfgMap map[string]interface{}
+	yaml.Unmarshal(structured, &cfgMap)
+	for k, v := range cfgMap {
+		raw[k] = v
+	}
+
+	data, err := yaml.Marshal(raw)
+	if err != nil {
+		return fmt.Errorf("marshaling config: %w", err)
+	}
+	return os.WriteFile(path, data, 0600)
+}
+
+// GetAuthToken returns the best available bearer token from the config.
+// Priority: auth.token > auth.oidc.token > auth.api_key.token
+func GetAuthToken(cfg *ConfigFile) string {
+	if cfg.Auth.Token != "" {
+		return cfg.Auth.Token
+	}
+	if cfg.Auth.OIDC != nil && cfg.Auth.OIDC.Token != "" {
+		return cfg.Auth.OIDC.Token
+	}
+	if cfg.Auth.APIKey != nil && cfg.Auth.APIKey.Token != "" {
+		return cfg.Auth.APIKey.Token
+	}
+	return ""
+}
+
+// HasOIDCConfig returns true when OIDC credentials are present in the config.
+func HasOIDCConfig(cfg *ConfigFile) bool {
+	return cfg.Auth.OIDC != nil &&
+		cfg.Auth.OIDC.TokenURL != "" &&
+		cfg.Auth.OIDC.ClientID != ""
+}
+
+// HasAPIKeyConfig returns true when NGC API key settings are present.
+func HasAPIKeyConfig(cfg *ConfigFile) bool {
+	return cfg.Auth.APIKey != nil &&
+		cfg.Auth.APIKey.AuthnURL != "" &&
+		cfg.Auth.APIKey.Key != ""
+}
+
+const SampleConfig = `# BMM CLI configuration
+#
+# API connection:
+#   api.base -- server URL
+#   api.org  -- organization name used in API paths
+#   api.name -- API path segment (default: carbide)
+#
+# Authentication options (choose one):
+#   auth.token      -- direct bearer token (no login required)
+#   auth.oidc       -- OIDC password/client-credentials flow
+#   auth.api_key    -- NGC API key exchange
+#
+api:
+  base: http://localhost:8388
+  org: test-org
+  name: carbide
+
+auth:
+  # Option 1: Direct bearer token
+  # token: eyJhbGciOi...
+
+  # Option 2: OIDC provider (e.g. Keycloak)
+  oidc:
+    token_url: http://localhost:8080/realms/carbide-dev/protocol/openid-connect/token
+    client_id: carbide-api
+    client_secret: carbide-local-secret
+    username: admin@example.com
+    password: adminpassword
+
+  # Option 3: NGC API key
+  # api_key:
+  #   authn_url: https://authn.nvidia.com/token
+  #   key: nvapi-xxxx
+`

--- a/cli/pkg/config_test.go
+++ b/cli/pkg/config_test.go
@@ -1,0 +1,284 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bmmcli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetAuthToken_Priority(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  ConfigFile
+		want string
+	}{
+		{
+			name: "direct token wins",
+			cfg: ConfigFile{
+				Auth: ConfigAuth{
+					Token: "direct-token",
+					OIDC:  &ConfigOIDC{Token: "oidc-token"},
+					APIKey: &ConfigAPIKey{Token: "api-key-token"},
+				},
+			},
+			want: "direct-token",
+		},
+		{
+			name: "oidc token when no direct token",
+			cfg: ConfigFile{
+				Auth: ConfigAuth{
+					OIDC:   &ConfigOIDC{Token: "oidc-token"},
+					APIKey: &ConfigAPIKey{Token: "api-key-token"},
+				},
+			},
+			want: "oidc-token",
+		},
+		{
+			name: "api key token as last resort",
+			cfg: ConfigFile{
+				Auth: ConfigAuth{
+					APIKey: &ConfigAPIKey{Token: "api-key-token"},
+				},
+			},
+			want: "api-key-token",
+		},
+		{
+			name: "empty when nothing configured",
+			cfg:  ConfigFile{},
+			want: "",
+		},
+		{
+			name: "empty oidc token falls through to api key",
+			cfg: ConfigFile{
+				Auth: ConfigAuth{
+					OIDC:   &ConfigOIDC{Token: ""},
+					APIKey: &ConfigAPIKey{Token: "api-key-token"},
+				},
+			},
+			want: "api-key-token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetAuthToken(&tt.cfg)
+			if got != tt.want {
+				t.Errorf("GetAuthToken() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasOIDCConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  ConfigFile
+		want bool
+	}{
+		{
+			name: "fully configured",
+			cfg: ConfigFile{
+				Auth: ConfigAuth{
+					OIDC: &ConfigOIDC{
+						TokenURL: "https://auth.example.com/token",
+						ClientID: "my-client",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "missing token url",
+			cfg: ConfigFile{
+				Auth: ConfigAuth{
+					OIDC: &ConfigOIDC{ClientID: "my-client"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "nil oidc",
+			cfg:  ConfigFile{},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HasOIDCConfig(&tt.cfg)
+			if got != tt.want {
+				t.Errorf("HasOIDCConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasAPIKeyConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  ConfigFile
+		want bool
+	}{
+		{
+			name: "fully configured",
+			cfg: ConfigFile{
+				Auth: ConfigAuth{
+					APIKey: &ConfigAPIKey{
+						AuthnURL: "https://authn.nvidia.com/token",
+						Key:      "nvapi-xxx",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "missing key",
+			cfg: ConfigFile{
+				Auth: ConfigAuth{
+					APIKey: &ConfigAPIKey{AuthnURL: "https://authn.nvidia.com/token"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "nil api key",
+			cfg:  ConfigFile{},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HasAPIKeyConfig(&tt.cfg)
+			if got != tt.want {
+				t.Errorf("HasAPIKeyConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSaveConfigPreservesUnknownKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	// Write a config with a custom key.
+	initial := "api:\n  base: http://localhost\ncustom_key: my-value\n"
+	if err := os.WriteFile(path, []byte(initial), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Load, modify, and save.
+	cfg, err := LoadConfigFromPath(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.API.Org = "test-org"
+	if err := SaveConfigToPath(cfg, path); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read back and verify custom key is preserved.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+
+	if !contains(content, "custom_key") {
+		t.Errorf("SaveConfigToPath lost unknown key 'custom_key'. Content:\n%s", content)
+	}
+	if !contains(content, "test-org") {
+		t.Errorf("SaveConfigToPath lost org value. Content:\n%s", content)
+	}
+	if !contains(content, "http://localhost") {
+		t.Errorf("SaveConfigToPath lost base URL. Content:\n%s", content)
+	}
+}
+
+func TestLoadConfigFromPath_NotFound(t *testing.T) {
+	cfg, err := LoadConfigFromPath("/nonexistent/path/config.yaml")
+	if err != nil {
+		t.Fatalf("expected no error for missing file, got %v", err)
+	}
+	if cfg.API.Base != "" || cfg.API.Org != "" {
+		t.Errorf("expected empty config, got %+v", cfg)
+	}
+}
+
+func TestLoadConfigFromPath_Roundtrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	original := &ConfigFile{
+		API: ConfigAPI{
+			Base: "http://localhost:8388",
+			Org:  "test-org",
+			Name: "carbide",
+		},
+		Auth: ConfigAuth{
+			OIDC: &ConfigOIDC{
+				TokenURL:     "http://localhost:8080/realms/carbide-dev/protocol/openid-connect/token",
+				ClientID:     "carbide-api",
+				ClientSecret: "secret",
+				Token:        "eyJhbG...",
+				RefreshToken: "refresh...",
+				ExpiresAt:    "2026-01-01T00:00:00Z",
+			},
+		},
+	}
+
+	if err := SaveConfigToPath(original, path); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := LoadConfigFromPath(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if loaded.API.Base != original.API.Base {
+		t.Errorf("API.Base = %q, want %q", loaded.API.Base, original.API.Base)
+	}
+	if loaded.API.Org != original.API.Org {
+		t.Errorf("API.Org = %q, want %q", loaded.API.Org, original.API.Org)
+	}
+	if loaded.Auth.OIDC == nil {
+		t.Fatal("Auth.OIDC is nil after roundtrip")
+	}
+	if loaded.Auth.OIDC.Token != original.Auth.OIDC.Token {
+		t.Errorf("Auth.OIDC.Token = %q, want %q", loaded.Auth.OIDC.Token, original.Auth.OIDC.Token)
+	}
+	if loaded.Auth.OIDC.ClientSecret != original.Auth.OIDC.ClientSecret {
+		t.Errorf("Auth.OIDC.ClientSecret = %q, want %q", loaded.Auth.OIDC.ClientSecret, original.Auth.OIDC.ClientSecret)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/pkg/output.go
+++ b/cli/pkg/output.go
@@ -1,0 +1,118 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bmmcli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"gopkg.in/yaml.v3"
+)
+
+func FormatOutput(data []byte, format string) error {
+	switch format {
+	case "yaml":
+		return formatYAML(data)
+	case "table":
+		return formatTable(data)
+	default:
+		return formatJSON(data)
+	}
+}
+
+func formatJSON(data []byte) error {
+	var v interface{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		_, err = os.Stdout.Write(data)
+		return err
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+func formatYAML(data []byte) error {
+	var v interface{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		_, err = os.Stdout.Write(data)
+		return err
+	}
+	return yaml.NewEncoder(os.Stdout).Encode(v)
+}
+
+var tableFields = []string{"id", "name", "status", "created", "updated"}
+
+func formatTable(data []byte) error {
+	var raw interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		_, err = os.Stdout.Write(data)
+		return err
+	}
+
+	var items []map[string]interface{}
+	switch v := raw.(type) {
+	case []interface{}:
+		for _, item := range v {
+			if m, ok := item.(map[string]interface{}); ok {
+				items = append(items, m)
+			}
+		}
+	case map[string]interface{}:
+		items = append(items, v)
+	default:
+		return formatJSON(data)
+	}
+
+	if len(items) == 0 {
+		fmt.Println("(no results)")
+		return nil
+	}
+
+	var cols []string
+	for _, f := range tableFields {
+		if _, ok := items[0][f]; ok {
+			cols = append(cols, f)
+		}
+	}
+	if len(cols) == 0 {
+		return formatJSON(data)
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	for i, c := range cols {
+		if i > 0 {
+			fmt.Fprint(w, "\t")
+		}
+		fmt.Fprint(w, c)
+	}
+	fmt.Fprintln(w)
+
+	for _, item := range items {
+		for i, c := range cols {
+			if i > 0 {
+				fmt.Fprint(w, "\t")
+			}
+			fmt.Fprintf(w, "%v", item[c])
+		}
+		fmt.Fprintln(w)
+	}
+
+	return w.Flush()
+}

--- a/cli/pkg/spec.go
+++ b/cli/pkg/spec.go
@@ -1,0 +1,161 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bmmcli
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Spec struct {
+	Info       SpecInfo            `yaml:"info"`
+	Servers    []Server            `yaml:"servers"`
+	Tags       []Tag               `yaml:"tags"`
+	Paths      map[string]PathItem `yaml:"paths"`
+	Components Components          `yaml:"components"`
+}
+
+type SpecInfo struct {
+	Title   string `yaml:"title"`
+	Version string `yaml:"version"`
+}
+
+type Server struct {
+	URL         string `yaml:"url"`
+	Description string `yaml:"description"`
+}
+
+type Tag struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+}
+
+type PathItem struct {
+	Parameters []Parameter `yaml:"parameters"`
+	Get        *Operation  `yaml:"get"`
+	Post       *Operation  `yaml:"post"`
+	Patch      *Operation  `yaml:"patch"`
+	Put        *Operation  `yaml:"put"`
+	Delete     *Operation  `yaml:"delete"`
+}
+
+type Operation struct {
+	OperationID string       `yaml:"operationId"`
+	Summary     string       `yaml:"summary"`
+	Description string       `yaml:"description"`
+	Tags        []string     `yaml:"tags"`
+	Parameters  []Parameter  `yaml:"parameters"`
+	RequestBody *RequestBody `yaml:"requestBody"`
+}
+
+type Parameter struct {
+	Name        string  `yaml:"name"`
+	In          string  `yaml:"in"`
+	Required    bool    `yaml:"required"`
+	Description string  `yaml:"description"`
+	Schema      *Schema `yaml:"schema"`
+}
+
+type RequestBody struct {
+	Content map[string]MediaType `yaml:"content"`
+}
+
+type MediaType struct {
+	Schema *Schema `yaml:"schema"`
+}
+
+// SchemaType handles OpenAPI 3.1 type fields that can be a string or a list of strings.
+type SchemaType string
+
+func (t *SchemaType) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode {
+		*t = SchemaType(value.Value)
+		return nil
+	}
+	if value.Kind == yaml.SequenceNode {
+		for _, n := range value.Content {
+			if n.Value != "null" {
+				*t = SchemaType(n.Value)
+				return nil
+			}
+		}
+		*t = "string"
+		return nil
+	}
+	return fmt.Errorf("unexpected type node kind: %d", value.Kind)
+}
+
+type Schema struct {
+	Ref        string             `yaml:"$ref"`
+	Type       SchemaType         `yaml:"type"`
+	Format     string             `yaml:"format"`
+	Enum       []string           `yaml:"enum"`
+	Properties map[string]*Schema `yaml:"properties"`
+	Required   []string           `yaml:"required"`
+	Items      *Schema            `yaml:"items"`
+	MinLength  *int               `yaml:"minLength"`
+	MaxLength  *int               `yaml:"maxLength"`
+	Minimum    *int               `yaml:"minimum"`
+	Maximum    *int               `yaml:"maximum"`
+	Default    interface{}        `yaml:"default"`
+}
+
+type Components struct {
+	Schemas   map[string]*Schema     `yaml:"schemas"`
+	Responses map[string]interface{} `yaml:"responses"`
+}
+
+func ParseSpec(data []byte) (*Spec, error) {
+	var spec Spec
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		return nil, fmt.Errorf("parsing spec: %w", err)
+	}
+	return &spec, nil
+}
+
+func (s *Spec) ResolveRef(ref string) *Schema {
+	const prefix = "#/components/schemas/"
+	if !strings.HasPrefix(ref, prefix) {
+		return nil
+	}
+	name := ref[len(prefix):]
+	return s.Components.Schemas[name]
+}
+
+func (s *Spec) ResolveSchema(schema *Schema) *Schema {
+	if schema == nil {
+		return nil
+	}
+	if schema.Ref != "" {
+		return s.ResolveRef(schema.Ref)
+	}
+	return schema
+}
+
+func (s *Spec) RequestBodySchema(op *Operation) *Schema {
+	if op.RequestBody == nil {
+		return nil
+	}
+	mt, ok := op.RequestBody.Content["application/json"]
+	if !ok {
+		return nil
+	}
+	return s.ResolveSchema(mt.Schema)
+}

--- a/cli/pkg/spec_test.go
+++ b/cli/pkg/spec_test.go
@@ -1,0 +1,177 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bmmcli
+
+import (
+	"testing"
+
+	"github.com/nvidia/bare-metal-manager-rest/openapi"
+)
+
+func TestParseSpec_EmbeddedSpec(t *testing.T) {
+	spec, err := ParseSpec(openapi.Spec)
+	if err != nil {
+		t.Fatalf("ParseSpec failed: %v", err)
+	}
+	if spec.Info.Title == "" {
+		t.Error("spec.Info.Title is empty")
+	}
+	if len(spec.Paths) == 0 {
+		t.Error("spec.Paths is empty")
+	}
+	if len(spec.Tags) == 0 {
+		t.Error("spec.Tags is empty")
+	}
+}
+
+func TestParseSpec_SchemaTypeNullable(t *testing.T) {
+	yaml := `
+openapi: "3.1.0"
+info:
+  title: test
+  version: "1.0"
+paths: {}
+components:
+  schemas:
+    Test:
+      type: object
+      properties:
+        nullable_field:
+          type:
+            - string
+            - "null"
+        simple_field:
+          type: string
+`
+	spec, err := ParseSpec([]byte(yaml))
+	if err != nil {
+		t.Fatalf("ParseSpec failed: %v", err)
+	}
+	schema := spec.Components.Schemas["Test"]
+	if schema == nil {
+		t.Fatal("Test schema not found")
+	}
+
+	nullable := schema.Properties["nullable_field"]
+	if nullable == nil {
+		t.Fatal("nullable_field not found")
+	}
+	if nullable.Type != "string" {
+		t.Errorf("nullable_field type = %q, want %q", nullable.Type, "string")
+	}
+
+	simple := schema.Properties["simple_field"]
+	if simple == nil {
+		t.Fatal("simple_field not found")
+	}
+	if simple.Type != "string" {
+		t.Errorf("simple_field type = %q, want %q", simple.Type, "string")
+	}
+}
+
+func TestResolveRef(t *testing.T) {
+	spec := &Spec{
+		Components: Components{
+			Schemas: map[string]*Schema{
+				"SiteCreateRequest": {
+					Type: "object",
+					Properties: map[string]*Schema{
+						"name": {Type: "string"},
+					},
+				},
+			},
+		},
+	}
+
+	resolved := spec.ResolveRef("#/components/schemas/SiteCreateRequest")
+	if resolved == nil {
+		t.Fatal("ResolveRef returned nil")
+	}
+	if resolved.Type != "object" {
+		t.Errorf("resolved type = %q, want %q", resolved.Type, "object")
+	}
+
+	missing := spec.ResolveRef("#/components/schemas/NonExistent")
+	if missing != nil {
+		t.Error("ResolveRef should return nil for missing schema")
+	}
+
+	invalid := spec.ResolveRef("not-a-ref")
+	if invalid != nil {
+		t.Error("ResolveRef should return nil for non-ref string")
+	}
+}
+
+func TestResolveSchema(t *testing.T) {
+	spec := &Spec{
+		Components: Components{
+			Schemas: map[string]*Schema{
+				"Site": {Type: "object"},
+			},
+		},
+	}
+
+	// Follow $ref
+	refSchema := &Schema{Ref: "#/components/schemas/Site"}
+	resolved := spec.ResolveSchema(refSchema)
+	if resolved == nil || resolved.Type != "object" {
+		t.Error("ResolveSchema should follow $ref")
+	}
+
+	// Return direct schema
+	direct := &Schema{Type: "string"}
+	resolved = spec.ResolveSchema(direct)
+	if resolved != direct {
+		t.Error("ResolveSchema should return direct schema when no $ref")
+	}
+
+	// Nil input
+	resolved = spec.ResolveSchema(nil)
+	if resolved != nil {
+		t.Error("ResolveSchema(nil) should return nil")
+	}
+}
+
+func TestBuildCommands_EmbeddedSpec(t *testing.T) {
+	spec, err := ParseSpec(openapi.Spec)
+	if err != nil {
+		t.Fatalf("ParseSpec failed: %v", err)
+	}
+
+	commands := BuildCommands(spec)
+	if len(commands) == 0 {
+		t.Fatal("BuildCommands returned no commands")
+	}
+
+	// Verify expected resource commands exist.
+	cmdNames := make(map[string]bool)
+	for _, cmd := range commands {
+		cmdNames[cmd.Name] = true
+	}
+
+	expected := []string{
+		"site", "instance", "machine", "vpc", "subnet", "allocation",
+		"operating-system", "ssh-key", "ssh-key-group", "ip-block",
+		"infrastructure-provider", "tenant", "metadata", "user",
+	}
+	for _, name := range expected {
+		if !cmdNames[name] {
+			t.Errorf("missing expected command %q", name)
+		}
+	}
+}

--- a/openapi/embed.go
+++ b/openapi/embed.go
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package openapi embeds the OpenAPI spec so it can be imported by other
+// packages without requiring a build-time copy step.
+package openapi
+
+import _ "embed"
+
+//go:embed spec.yaml
+var Spec []byte


### PR DESCRIPTION
Dynamically builds urfave/cli/v2 commands from the embedded OpenAPI spec at startup, covering all 124 operations across 28 resource tags. Zero manual command code — the CLI stays in sync with spec changes automatically.

Features:
- Spec embedded via openapi/embed.go (no build-time copy step)
- Structured config at ~/.bmm/config.yaml with api/auth sections
- OIDC login (password grant, client credentials) with auto-refresh
- NGC API key exchange via --api-key
- Keycloak shorthand via --keycloak-url/--realm
- Sub-resource nesting (e.g., bmmcli allocation constraint create)
- Per-field flags with type-aware JSON serialization
- Auto-pagination (--all) and parsed pagination summaries
- JSON, YAML, and table output formats
- stdin support for --data-file -
- Shell completion (bash, zsh, fish)
- bmmcli init generates a sample config
- Configurable API path segment via api.name
- Config preserves unknown YAML keys on save

This provides the spec-driven command engine.