### PR TITLE
chore: Add Helm umbrella chart with API, DB, site-agent, workflow sub-charts

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -133,7 +133,49 @@ jobs:
       NVCR_USERNAME: ${{ secrets.NVCR_STG_USERNAME }}
       NVCR_TOKEN: ${{ secrets.NVCR_STG_TOKEN }}
 
-  # Step 6: Promote to release candidate
+  # Step 6: Validate Helm chart
+  build-validate-helm-chart:
+    name: Validate Helm Chart
+    needs:
+      - prepare
+    if: ${{ !cancelled() && needs.prepare.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate Helm chart
+        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
+        with:
+          chart-path: helm
+          lint: 'true'
+          template: 'true'
+
+  # Step 7: Package and push Helm chart to NGC
+  build-push-helm-chart:
+    name: Package and Push Helm Chart
+    needs:
+      - prepare
+      - build-and-push
+      - build-validate-helm-chart
+    if: ${{ !cancelled() && needs.prepare.result == 'success' && needs.build-validate-helm-chart.result == 'success' && !contains(github.ref, 'pull-request/') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Package and push Helm chart to NGC
+        uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@94bde998f5d7965576b0c663db7d5d709c918167
+        with:
+          chart-path: helm
+          chart-version: ${{ needs.prepare.outputs.helm_version }}
+          app-version: ${{ needs.prepare.outputs.semantic_version }}
+          lint: 'false'
+          ngc-key: ${{ secrets.NVCR_STG_TOKEN }}
+          ngc-path: 0837451325059433/carbide-dev
+          ngc-duplicate: fail
+
+  # Step 8: Promote to release candidate
   promote-carbide-rest-to-release-candidate:
     name: Promote Carbide REST to Release Candidate
     needs:

--- a/.github/workflows/prepare-build-info.yml
+++ b/.github/workflows/prepare-build-info.yml
@@ -51,6 +51,9 @@ on:
       push_requested:
         description: "Whether a push request was made using commit message"
         value: ${{ jobs.prepare.outputs.push_requested }}
+      helm_version:
+        description: "Helm chart version (SemVer with commit SHA suffix)"
+        value: ${{ jobs.prepare.outputs.helm_version }}
 
 jobs:
   prepare:
@@ -67,6 +70,7 @@ jobs:
       is_main_branch: ${{ steps.generate-version.outputs.is_main_branch }}
       release_tag: ${{ steps.generate-version.outputs.release_tag }}
       push_requested: ${{ steps.generate-version.outputs.push_requested }}
+      helm_version: ${{ steps.generate-version.outputs.helm_version }}
 
     steps:
       - name: Checkout code
@@ -136,6 +140,10 @@ jobs:
           echo "release_tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
           echo "push_requested=$PUSH_REQUESTED" >> $GITHUB_OUTPUT
 
+          # Helm chart version: semantic version + commit SHA suffix
+          HELM_VERSION="${SEMANTIC_VERSION}+${SHORT_SHA}"
+          echo "helm_version=$HELM_VERSION" >> $GITHUB_OUTPUT
+
           # Print for logs
           echo "Generated build information:"
           echo "  SEMANTIC_VERSION: $SEMANTIC_VERSION"
@@ -147,6 +155,7 @@ jobs:
           echo "  IS_MAIN_BRANCH: $IS_MAIN_BRANCH"
           echo "  RELEASE_TAG: $RELEASE_TAG"
           echo "  PUSH_REQUESTED: $PUSH_REQUESTED"
+          echo "  HELM_VERSION: $HELM_VERSION"
       - name: Generate build summary
         run: |
           echo "# Build Information Generated" >> $GITHUB_STEP_SUMMARY
@@ -161,4 +170,5 @@ jobs:
           echo "- **Is Main Branch**: \`${{ steps.generate-version.outputs.is_main_branch }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Release Tag**: \`${{ steps.generate-version.outputs.release_tag }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Push Requested**: \`${{ steps.generate-version.outputs.push_requested }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Helm Version**: \`${{ steps.generate-version.outputs.helm_version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Target Registry**: \`${{ steps.generate-version.outputs.target_registry }}\`" >> $GITHUB_STEP_SUMMARY

--- a/helm/.helmignore
+++ b/helm/.helmignore
@@ -1,0 +1,5 @@
+.git
+.gitignore
+.helmignore
+*.md
+examples/

--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -1,0 +1,18 @@
+dependencies:
+- name: carbide-rest-api
+  repository: ""
+  version: 0.1.0
+- name: carbide-rest-workflow
+  repository: ""
+  version: 0.1.0
+- name: carbide-rest-site-agent
+  repository: ""
+  version: 0.1.0
+- name: carbide-rest-site-manager
+  repository: ""
+  version: 0.1.0
+- name: carbide-rest-db
+  repository: ""
+  version: 0.1.0
+digest: sha256:410fc92a54bda03d2a5673d7db82312fde8c9dbd5a989cbc7fd53f221b8c4d00
+generated: "2026-03-02T18:15:37.508005+08:00"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: carbide-rest
+description: Umbrella chart for the Carbide REST API platform
+type: application
+version: 0.1.0
+appVersion: "latest"
+keywords:
+  - bare-metal-manager-rest
+
+dependencies:
+  - name: carbide-rest-api
+    version: "0.1.0"
+    condition: carbide-rest-api.enabled
+  - name: carbide-rest-workflow
+    version: "0.1.0"
+    condition: carbide-rest-workflow.enabled
+  - name: carbide-rest-site-agent
+    version: "0.1.0"
+    condition: carbide-rest-site-agent.enabled
+  - name: carbide-rest-site-manager
+    version: "0.1.0"
+    condition: carbide-rest-site-manager.enabled
+  - name: carbide-rest-db
+    version: "0.1.0"
+    condition: carbide-rest-db.enabled

--- a/helm/charts/carbide-rest-api/Chart.yaml
+++ b/helm/charts/carbide-rest-api/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: carbide-rest-api
+description: Helm chart for the Carbide REST API server
+type: application
+version: 0.1.0
+appVersion: "latest"
+keywords:
+  - carbide
+  - rest
+  - api

--- a/helm/charts/carbide-rest-api/templates/_helpers.tpl
+++ b/helm/charts/carbide-rest-api/templates/_helpers.tpl
@@ -1,0 +1,28 @@
+{{- define "carbide-rest-api.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "carbide-rest-api.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "carbide-rest-api.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "carbide-rest-api.labels" -}}
+helm.sh/chart: {{ include "carbide-rest-api.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: carbide-rest
+app.kubernetes.io/name: carbide-rest-api
+app.kubernetes.io/component: api
+{{- end }}
+
+{{- define "carbide-rest-api.selectorLabels" -}}
+app.kubernetes.io/name: carbide-rest-api
+app.kubernetes.io/component: api
+{{- end }}
+
+{{- define "carbide-rest-api.image" -}}
+{{ .Values.global.image.repository }}/{{ .Values.image.name }}:{{ .Values.global.image.tag }}
+{{- end }}

--- a/helm/charts/carbide-rest-api/templates/configmap.yaml
+++ b/helm/charts/carbide-rest-api/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "carbide-rest-api.name" . }}-config
+  namespace: {{ include "carbide-rest-api.namespace" . }}
+  labels:
+    {{- include "carbide-rest-api.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{- .Values.config | toYaml | nindent 4 }}

--- a/helm/charts/carbide-rest-api/templates/deployment.yaml
+++ b/helm/charts/carbide-rest-api/templates/deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "carbide-rest-api.name" . }}
+  namespace: {{ include "carbide-rest-api.namespace" . }}
+  labels:
+    {{- include "carbide-rest-api.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "carbide-rest-api.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "carbide-rest-api.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: api
+          image: "{{ include "carbide-rest-api.image" . }}"
+          imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+              name: http
+            - containerPort: {{ .Values.service.metricsPort }}
+              name: metrics
+          env:
+            - name: CONFIG_FILE_PATH
+              value: /app/config.yaml
+          volumeMounts:
+            - name: config
+              mountPath: /app/config.yaml
+              subPath: config.yaml
+            - name: keycloak-secret
+              mountPath: /var/secrets/keycloak
+              readOnly: true
+            - name: temporal-encryption-key
+              mountPath: /var/secrets/temporal
+              readOnly: true
+            - name: temporal-tls-certs
+              mountPath: /var/secrets/temporal/certs
+              readOnly: true
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: {{ .Values.service.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.service.port }}
+            initialDelaySeconds: 30
+            periodSeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "carbide-rest-api.name" . }}-config
+        - name: keycloak-secret
+          secret:
+            secretName: {{ .Values.secrets.carbideSecrets }}
+            items:
+              - key: keycloak-client-secret
+                path: client-secret
+        - name: temporal-encryption-key
+          secret:
+            secretName: {{ .Values.secrets.carbideSecrets }}
+            items:
+              - key: temporal-encryption-key
+                path: encryption-key
+        - name: temporal-tls-certs
+          secret:
+            secretName: {{ .Values.secrets.temporalClientCerts }}

--- a/helm/charts/carbide-rest-api/templates/service.yaml
+++ b/helm/charts/carbide-rest-api/templates/service.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "carbide-rest-api.name" . }}
+  namespace: {{ include "carbide-rest-api.namespace" . }}
+  labels:
+    {{- include "carbide-rest-api.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      name: http
+    - port: {{ .Values.service.metricsPort }}
+      targetPort: {{ .Values.service.metricsPort }}
+      name: metrics
+  selector:
+    {{- include "carbide-rest-api.selectorLabels" . | nindent 4 }}
+{{- if .Values.nodePort.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "carbide-rest-api.name" . }}-nodeport
+  namespace: {{ include "carbide-rest-api.namespace" . }}
+  labels:
+    {{- include "carbide-rest-api.labels" . | nindent 4 }}
+spec:
+  type: NodePort
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      nodePort: {{ .Values.nodePort.port }}
+      name: http
+  selector:
+    {{- include "carbide-rest-api.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/charts/carbide-rest-api/values.yaml
+++ b/helm/charts/carbide-rest-api/values.yaml
@@ -1,0 +1,82 @@
+replicaCount: 1
+
+nameOverride: ""
+namespaceOverride: ""
+
+image:
+  name: carbide-rest-api
+
+service:
+  type: ClusterIP
+  port: 8388
+  metricsPort: 9360
+
+nodePort:
+  enabled: false
+  port: 30388
+
+resources:
+  requests:
+    memory: "128Mi"
+    cpu: "100m"
+  limits:
+    memory: "512Mi"
+    cpu: "500m"
+
+secrets:
+  carbideSecrets: carbide-secrets
+  temporalClientCerts: temporal-client-certs
+
+config:
+  env:
+    dev: true
+    disconnected: true
+  api:
+    name: carbide
+    route:
+      version: v2
+  log:
+    level: debug
+    sentry:
+      dsn: ""
+  db:
+    host: postgres
+    port: 5432
+    name: forge
+    user: forge
+    password: forge
+  temporal:
+    host: temporal-frontend.temporal
+    port: 7233
+    serverName: server.temporal.local
+    namespace: cloud
+    queue: cloud
+    tls:
+      enabled: true
+      certPath: /var/secrets/temporal/certs/tls.crt
+      keyPath: /var/secrets/temporal/certs/tls.key
+      caPath: /var/secrets/temporal/certs/ca.crt
+      disableHostVerification: false
+    encryptionKeyPath: /var/secrets/temporal/encryption-key
+  siteManager:
+    enabled: true
+    svcEndpoint: "https://carbide-rest-site-manager:8100/v1/site"
+  metrics:
+    enabled: true
+    port: 9360
+  tracing:
+    enabled: false
+    serviceName: cloud-api
+  keycloak:
+    enabled: true
+    baseURL: http://keycloak:8080
+    externalBaseURL: http://localhost:8080
+    realm: carbide-dev
+    clientID: carbide-api
+    clientSecretPath: /var/secrets/keycloak/client-secret
+    serviceAccount: true
+  rateLimiter:
+    enabled: false
+    rate: 10.0
+    burst: 30
+    expiresIn: 180

--- a/helm/charts/carbide-rest-db/Chart.yaml
+++ b/helm/charts/carbide-rest-db/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: carbide-rest-db
+description: Helm chart for the Carbide REST database migrations
+type: application
+version: 0.1.0
+appVersion: "latest"
+keywords:
+  - carbide
+  - rest
+  - database
+  - migrations

--- a/helm/charts/carbide-rest-db/templates/_helpers.tpl
+++ b/helm/charts/carbide-rest-db/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{- define "carbide-rest-db.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "carbide-rest-db.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "carbide-rest-db.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "carbide-rest-db.labels" -}}
+helm.sh/chart: {{ include "carbide-rest-db.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: carbide-rest
+app.kubernetes.io/name: carbide-rest-db
+app.kubernetes.io/component: migrations
+{{- end }}
+
+{{- define "carbide-rest-db.image" -}}
+{{ .Values.global.image.repository }}/{{ .Values.image.name }}:{{ .Values.global.image.tag }}
+{{- end }}

--- a/helm/charts/carbide-rest-db/templates/migration-job.yaml
+++ b/helm/charts/carbide-rest-db/templates/migration-job.yaml
@@ -1,0 +1,56 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "carbide-rest-db.name" . }}-migrations
+  namespace: {{ include "carbide-rest-db.namespace" . }}
+  labels:
+    {{- include "carbide-rest-db.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "-5"
+spec:
+  ttlSecondsAfterFinished: {{ .Values.ttlSecondsAfterFinished }}
+  backoffLimit: {{ .Values.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        {{- include "carbide-rest-db.labels" . | nindent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+        - name: wait-for-postgres
+          image: {{ .Values.waitForPostgres.image }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              until pg_isready -h {{ .Values.db.host }} -p {{ .Values.db.port }} -U {{ .Values.db.user }}; do
+                echo "Waiting for PostgreSQL..."
+                sleep 2
+              done
+              echo "PostgreSQL is ready!"
+      containers:
+        - name: migrations
+          image: "{{ include "carbide-rest-db.image" . }}"
+          imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          env:
+            - name: PGHOST
+              value: {{ .Values.db.host }}
+            - name: PGPORT
+              value: {{ .Values.db.port | quote }}
+            - name: PGDATABASE
+              value: {{ .Values.db.name }}
+            - name: PGUSER
+              value: {{ .Values.db.user }}
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.carbideSecrets }}
+                  key: db-password
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/helm/charts/carbide-rest-db/values.yaml
+++ b/helm/charts/carbide-rest-db/values.yaml
@@ -1,0 +1,28 @@
+nameOverride: ""
+namespaceOverride: ""
+
+image:
+  name: carbide-rest-db
+
+waitForPostgres:
+  image: postgres:14.4-alpine
+
+db:
+  host: postgres
+  port: "5432"
+  name: forge
+  user: forge
+
+secrets:
+  carbideSecrets: carbide-secrets
+
+resources:
+  requests:
+    memory: "64Mi"
+    cpu: "50m"
+  limits:
+    memory: "128Mi"
+    cpu: "100m"
+
+ttlSecondsAfterFinished: 300
+backoffLimit: 3

--- a/helm/charts/carbide-rest-site-agent/Chart.yaml
+++ b/helm/charts/carbide-rest-site-agent/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: carbide-rest-site-agent
+description: Helm chart for the Carbide REST site agent (Elektra)
+type: application
+version: 0.1.0
+appVersion: "latest"
+keywords:
+  - carbide
+  - rest
+  - site-agent
+  - elektra

--- a/helm/charts/carbide-rest-site-agent/templates/_helpers.tpl
+++ b/helm/charts/carbide-rest-site-agent/templates/_helpers.tpl
@@ -1,0 +1,28 @@
+{{- define "carbide-rest-site-agent.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "carbide-rest-site-agent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "carbide-rest-site-agent.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "carbide-rest-site-agent.labels" -}}
+helm.sh/chart: {{ include "carbide-rest-site-agent.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: carbide-rest
+app.kubernetes.io/name: carbide-rest-site-agent
+app.kubernetes.io/component: site-agent
+{{- end }}
+
+{{- define "carbide-rest-site-agent.selectorLabels" -}}
+app.kubernetes.io/name: carbide-rest-site-agent
+app.kubernetes.io/component: site-agent
+{{- end }}
+
+{{- define "carbide-rest-site-agent.image" -}}
+{{ .Values.global.image.repository }}/{{ .Values.image.name }}:{{ .Values.global.image.tag }}
+{{- end }}

--- a/helm/charts/carbide-rest-site-agent/templates/certificate.yaml
+++ b/helm/charts/carbide-rest-site-agent/templates/certificate.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.certificate.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "carbide-rest-site-agent.name" . }}-grpc-client-cert
+  namespace: {{ include "carbide-rest-site-agent.namespace" . }}
+  labels:
+    {{- include "carbide-rest-site-agent.labels" . | nindent 4 }}
+spec:
+  secretName: {{ .Values.certificate.secretName }}
+  duration: {{ .Values.certificate.duration }}
+  renewBefore: {{ .Values.certificate.renewBefore }}
+  subject:
+    organizations:
+      - Nvidia
+  isCA: false
+  privateKey:
+    algorithm: {{ .Values.certificate.privateKey.algorithm }}
+    size: {{ .Values.certificate.privateKey.size }}
+  usages:
+    - client auth
+  dnsNames:
+    - {{ include "carbide-rest-site-agent.name" . }}
+    - {{ include "carbide-rest-site-agent.name" . }}.{{ include "carbide-rest-site-agent.namespace" . }}
+    - {{ include "carbide-rest-site-agent.name" . }}.{{ include "carbide-rest-site-agent.namespace" . }}.svc.cluster.local
+  uris:
+    - spiffe://carbide.local/{{ include "carbide-rest-site-agent.namespace" . }}/sa/{{ include "carbide-rest-site-agent.name" . }}
+  issuerRef:
+    name: {{ .Values.global.certificate.issuerRef.name }}
+    kind: {{ .Values.global.certificate.issuerRef.kind }}
+    group: {{ .Values.global.certificate.issuerRef.group }}
+{{- end }}

--- a/helm/charts/carbide-rest-site-agent/templates/configmap.yaml
+++ b/helm/charts/carbide-rest-site-agent/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "carbide-rest-site-agent.name" . }}-config
+  namespace: {{ include "carbide-rest-site-agent.namespace" . }}
+  labels:
+    {{- include "carbide-rest-site-agent.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.envConfig }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/helm/charts/carbide-rest-site-agent/templates/deployment.yaml
+++ b/helm/charts/carbide-rest-site-agent/templates/deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "carbide-rest-site-agent.name" . }}
+  namespace: {{ include "carbide-rest-site-agent.namespace" . }}
+  labels:
+    {{- include "carbide-rest-site-agent.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "carbide-rest-site-agent.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "carbide-rest-site-agent.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: site-agent
+          image: "{{ include "carbide-rest-site-agent.image" . }}"
+          imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+              name: http
+            - containerPort: {{ .Values.service.metricsPort }}
+              name: metrics
+          envFrom:
+            - configMapRef:
+                name: {{ include "carbide-rest-site-agent.name" . }}-config
+          env:
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.carbideSecrets }}
+                  key: db-password
+          volumeMounts:
+            - name: site-registration
+              mountPath: /etc/sitereg
+              readOnly: true
+            - name: carbide-certs
+              mountPath: /etc/carbide
+              readOnly: true
+            - name: temporal-certs
+              mountPath: /etc/temporal-certs
+              readOnly: true
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: site-registration
+          secret:
+            secretName: {{ .Values.secrets.siteRegistration }}
+        - name: carbide-certs
+          secret:
+            secretName: {{ .Values.secrets.carbideTlsCerts }}
+            optional: true
+        - name: temporal-certs
+          secret:
+            secretName: {{ .Values.secrets.temporalClientCerts }}
+            optional: true
+            items:
+              - key: ca.crt
+                path: ca/ca.crt
+              - key: tls.crt
+                path: client/tls.crt
+              - key: tls.key
+                path: client/tls.key

--- a/helm/charts/carbide-rest-site-agent/templates/service.yaml
+++ b/helm/charts/carbide-rest-site-agent/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "carbide-rest-site-agent.name" . }}
+  namespace: {{ include "carbide-rest-site-agent.namespace" . }}
+  labels:
+    {{- include "carbide-rest-site-agent.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      name: http
+    - port: {{ .Values.service.metricsPort }}
+      targetPort: {{ .Values.service.metricsPort }}
+      name: metrics
+  selector:
+    {{- include "carbide-rest-site-agent.selectorLabels" . | nindent 4 }}

--- a/helm/charts/carbide-rest-site-agent/values.yaml
+++ b/helm/charts/carbide-rest-site-agent/values.yaml
@@ -1,0 +1,62 @@
+replicaCount: 1
+
+nameOverride: ""
+namespaceOverride: ""
+
+image:
+  name: carbide-rest-site-agent
+
+service:
+  type: ClusterIP
+  port: 8080
+  metricsPort: 2112
+
+resources:
+  requests:
+    memory: "128Mi"
+    cpu: "100m"
+  limits:
+    memory: "512Mi"
+    cpu: "500m"
+
+secrets:
+  carbideSecrets: carbide-secrets
+  siteRegistration: site-registration
+  carbideTlsCerts: carbide-tls-certs
+  temporalClientCerts: temporal-client-certs
+
+certificate:
+  enabled: true
+  secretName: carbide-tls-certs
+  duration: 720h
+  renewBefore: 360h
+  privateKey:
+    algorithm: ECDSA
+    size: 384
+
+envConfig:
+  ESA_PORT: "8080"
+  CARBIDE_ADDRESS: ""
+  CARBIDE_SEC_OPT: "0"
+  CLUSTER_ID: ""
+  TEMPORAL_HOST: "temporal-frontend.temporal"
+  TEMPORAL_PORT: "7233"
+  TEMPORAL_SERVER_NAME: "server.temporal.local"
+  TEMPORAL_PUBLISH_NAMESPACE: "site"
+  TEMPORAL_PUBLISH_QUEUE: "site"
+  TEMPORAL_SUBSCRIBE_NAMESPACE: ""
+  TEMPORAL_SUBSCRIBE_QUEUE: ""
+  DEV_MODE: "false"
+  ENABLE_DEBUG: "false"
+  ENABLE_TLS: "true"
+  POD_NAME: "carbide-rest-site-agent-0"
+  POD_NAMESPACE: ""
+  METRICS_PORT: "2112"
+  DB_ADDR: "postgres"
+  DB_USER: "forge"
+  DB_DATABASE: "elektratest"
+  DB_PORT: "5432"
+  OTEL_EXPORTER_OTLP_SPAN_INSECURE: "true"
+  OTEL_EXPORTER_OTLP_SPAN_ENDPOINT: ""
+  TEMPORAL_CERT_PATH: "/etc/temporal-certs"
+  DISABLE_BOOTSTRAP: "true"

--- a/helm/charts/carbide-rest-site-manager/Chart.yaml
+++ b/helm/charts/carbide-rest-site-manager/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: carbide-rest-site-manager
+description: Helm chart for the Carbide REST site lifecycle manager
+type: application
+version: 0.1.0
+appVersion: "latest"
+keywords:
+  - carbide
+  - rest
+  - site-manager

--- a/helm/charts/carbide-rest-site-manager/templates/_helpers.tpl
+++ b/helm/charts/carbide-rest-site-manager/templates/_helpers.tpl
@@ -1,0 +1,28 @@
+{{- define "carbide-rest-site-manager.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "carbide-rest-site-manager.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "carbide-rest-site-manager.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "carbide-rest-site-manager.labels" -}}
+helm.sh/chart: {{ include "carbide-rest-site-manager.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: carbide-rest
+app.kubernetes.io/name: carbide-rest-site-manager
+app.kubernetes.io/component: site-manager
+{{- end }}
+
+{{- define "carbide-rest-site-manager.selectorLabels" -}}
+app.kubernetes.io/name: carbide-rest-site-manager
+app.kubernetes.io/component: site-manager
+{{- end }}
+
+{{- define "carbide-rest-site-manager.image" -}}
+{{ .Values.global.image.repository }}/{{ .Values.image.name }}:{{ .Values.global.image.tag }}
+{{- end }}

--- a/helm/charts/carbide-rest-site-manager/templates/certificate.yaml
+++ b/helm/charts/carbide-rest-site-manager/templates/certificate.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.certificate.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.certificate.secretName }}
+  namespace: {{ include "carbide-rest-site-manager.namespace" . }}
+  labels:
+    {{- include "carbide-rest-site-manager.labels" . | nindent 4 }}
+spec:
+  secretName: {{ .Values.certificate.secretName }}
+  duration: {{ .Values.certificate.duration }}
+  renewBefore: {{ .Values.certificate.renewBefore }}
+  subject:
+    organizations:
+      - Nvidia
+  commonName: {{ .Values.certificate.commonName }}
+  isCA: false
+  privateKey:
+    algorithm: {{ .Values.certificate.privateKey.algorithm }}
+    encoding: {{ .Values.certificate.privateKey.encoding }}
+    size: {{ .Values.certificate.privateKey.size }}
+  usages:
+    - server auth
+    - client auth
+  dnsNames:
+    - {{ include "carbide-rest-site-manager.name" . }}
+    - {{ include "carbide-rest-site-manager.name" . }}.{{ include "carbide-rest-site-manager.namespace" . }}
+    - {{ include "carbide-rest-site-manager.name" . }}.{{ include "carbide-rest-site-manager.namespace" . }}.svc.cluster.local
+    - localhost
+  issuerRef:
+    name: {{ .Values.global.certificate.issuerRef.name }}
+    kind: {{ .Values.global.certificate.issuerRef.kind }}
+    group: {{ .Values.global.certificate.issuerRef.group }}
+{{- end }}

--- a/helm/charts/carbide-rest-site-manager/templates/deployment.yaml
+++ b/helm/charts/carbide-rest-site-manager/templates/deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "carbide-rest-site-manager.name" . }}
+  namespace: {{ include "carbide-rest-site-manager.namespace" . }}
+  labels:
+    {{- include "carbide-rest-site-manager.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "carbide-rest-site-manager.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "carbide-rest-site-manager.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "carbide-rest-site-manager.name" . }}
+      containers:
+        - name: site-manager
+          image: "{{ include "carbide-rest-site-manager.image" . }}"
+          imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          args:
+            - --listen-port={{ .Values.args.listenPort }}
+            - --creds-manager-url={{ .Values.args.credsManagerUrl }}
+            - --tls-cert-path={{ .Values.args.tlsCertPath }}
+            - --tls-key-path={{ .Values.args.tlsKeyPath }}
+            - --namespace={{ include "carbide-rest-site-manager.namespace" . }}
+            {{- if .Values.args.debug }}
+            - --debug
+            {{- end }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+              name: https
+          volumeMounts:
+            - name: tls-certs
+              mountPath: /etc/tls
+              readOnly: true
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.service.port }}
+              scheme: HTTPS
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.service.port }}
+              scheme: HTTPS
+            initialDelaySeconds: 30
+            periodSeconds: 15
+      volumes:
+        - name: tls-certs
+          secret:
+            secretName: {{ .Values.certificate.secretName }}

--- a/helm/charts/carbide-rest-site-manager/templates/rbac.yaml
+++ b/helm/charts/carbide-rest-site-manager/templates/rbac.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.rbac.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "carbide-rest-site-manager.name" . }}
+  namespace: {{ include "carbide-rest-site-manager.namespace" . }}
+  labels:
+    {{- include "carbide-rest-site-manager.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "carbide-rest-site-manager.name" . }}
+  namespace: {{ include "carbide-rest-site-manager.namespace" . }}
+  labels:
+    {{- include "carbide-rest-site-manager.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["forge.nvidia.io"]
+    resources: ["sites"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["forge.nvidia.io"]
+    resources: ["sites/status"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "carbide-rest-site-manager.name" . }}
+  namespace: {{ include "carbide-rest-site-manager.namespace" . }}
+  labels:
+    {{- include "carbide-rest-site-manager.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "carbide-rest-site-manager.name" . }}
+roleRef:
+  kind: Role
+  name: {{ include "carbide-rest-site-manager.name" . }}
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "carbide-rest-site-manager.name" . }}
+  labels:
+    {{- include "carbide-rest-site-manager.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["forge.nvidia.io"]
+    resources: ["sites"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["forge.nvidia.io"]
+    resources: ["sites/status"]
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "carbide-rest-site-manager.name" . }}
+  labels:
+    {{- include "carbide-rest-site-manager.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "carbide-rest-site-manager.name" . }}
+    namespace: {{ include "carbide-rest-site-manager.namespace" . }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "carbide-rest-site-manager.name" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/helm/charts/carbide-rest-site-manager/templates/service.yaml
+++ b/helm/charts/carbide-rest-site-manager/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "carbide-rest-site-manager.name" . }}
+  namespace: {{ include "carbide-rest-site-manager.namespace" . }}
+  labels:
+    {{- include "carbide-rest-site-manager.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      name: https
+  selector:
+    {{- include "carbide-rest-site-manager.selectorLabels" . | nindent 4 }}

--- a/helm/charts/carbide-rest-site-manager/values.yaml
+++ b/helm/charts/carbide-rest-site-manager/values.yaml
@@ -1,0 +1,40 @@
+replicaCount: 1
+
+nameOverride: ""
+namespaceOverride: ""
+
+image:
+  name: carbide-rest-site-manager
+
+service:
+  type: ClusterIP
+  port: 8100
+
+args:
+  listenPort: 8100
+  credsManagerUrl: "https://carbide-rest-cert-manager:8000"
+  tlsCertPath: /etc/tls/tls.crt
+  tlsKeyPath: /etc/tls/tls.key
+  debug: true
+
+resources:
+  requests:
+    memory: "64Mi"
+    cpu: "50m"
+  limits:
+    memory: "256Mi"
+    cpu: "250m"
+
+certificate:
+  enabled: true
+  secretName: site-manager-tls
+  duration: 2160h
+  renewBefore: 360h
+  commonName: carbide-rest-site-manager
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048
+
+rbac:
+  create: true

--- a/helm/charts/carbide-rest-workflow/Chart.yaml
+++ b/helm/charts/carbide-rest-workflow/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: carbide-rest-workflow
+description: Helm chart for the Carbide REST Temporal workflow workers
+type: application
+version: 0.1.0
+appVersion: "latest"
+keywords:
+  - carbide
+  - rest
+  - workflow
+  - temporal

--- a/helm/charts/carbide-rest-workflow/templates/_helpers.tpl
+++ b/helm/charts/carbide-rest-workflow/templates/_helpers.tpl
@@ -1,0 +1,22 @@
+{{- define "carbide-rest-workflow.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "carbide-rest-workflow.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "carbide-rest-workflow.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "carbide-rest-workflow.labels" -}}
+helm.sh/chart: {{ include "carbide-rest-workflow.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: carbide-rest
+app.kubernetes.io/name: carbide-rest-workflow
+{{- end }}
+
+{{- define "carbide-rest-workflow.image" -}}
+{{ .Values.global.image.repository }}/{{ .Values.image.name }}:{{ .Values.global.image.tag }}
+{{- end }}

--- a/helm/charts/carbide-rest-workflow/templates/configmap.yaml
+++ b/helm/charts/carbide-rest-workflow/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "carbide-rest-workflow.name" . }}-config
+  namespace: {{ include "carbide-rest-workflow.namespace" . }}
+  labels:
+    {{- include "carbide-rest-workflow.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{- .Values.config | toYaml | nindent 4 }}

--- a/helm/charts/carbide-rest-workflow/templates/deployment-cloud-worker.yaml
+++ b/helm/charts/carbide-rest-workflow/templates/deployment-cloud-worker.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloud-worker
+  namespace: {{ include "carbide-rest-workflow.namespace" . }}
+  labels:
+    {{- include "carbide-rest-workflow.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cloud-worker
+spec:
+  replicas: {{ .Values.cloudWorker.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: carbide-rest-workflow
+      app.kubernetes.io/component: cloud-worker
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: carbide-rest-workflow
+        app.kubernetes.io/component: cloud-worker
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: cloud-worker
+          image: "{{ include "carbide-rest-workflow.image" . }}"
+          imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.config.metrics.port }}
+              name: metrics
+          env:
+            - name: CONFIG_FILE_PATH
+              value: /app/config.yaml
+            - name: TEMPORAL_NAMESPACE
+              value: cloud
+            - name: TEMPORAL_QUEUE
+              value: cloud
+          volumeMounts:
+            - name: config
+              mountPath: /app/config.yaml
+              subPath: config.yaml
+            - name: temporal-encryption-key
+              mountPath: /var/secrets/temporal
+              readOnly: true
+            - name: temporal-tls-certs
+              mountPath: /var/secrets/temporal/certs
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8899
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8899
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.cloudWorker.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - NET_RAW
+      securityContext:
+        runAsNonRoot: false
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "carbide-rest-workflow.name" . }}-config
+        - name: temporal-encryption-key
+          secret:
+            secretName: {{ .Values.secrets.carbideSecrets }}
+            items:
+              - key: temporal-encryption-key
+                path: encryption-key
+        - name: temporal-tls-certs
+          secret:
+            secretName: {{ .Values.secrets.temporalClientCerts }}

--- a/helm/charts/carbide-rest-workflow/templates/deployment-site-worker.yaml
+++ b/helm/charts/carbide-rest-workflow/templates/deployment-site-worker.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: site-worker
+  namespace: {{ include "carbide-rest-workflow.namespace" . }}
+  labels:
+    {{- include "carbide-rest-workflow.labels" . | nindent 4 }}
+    app.kubernetes.io/component: site-worker
+spec:
+  replicas: {{ .Values.siteWorker.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: carbide-rest-workflow
+      app.kubernetes.io/component: site-worker
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: carbide-rest-workflow
+        app.kubernetes.io/component: site-worker
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: site-worker
+          image: "{{ include "carbide-rest-workflow.image" . }}"
+          imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.config.metrics.port }}
+              name: metrics
+          env:
+            - name: CONFIG_FILE_PATH
+              value: /app/config.yaml
+            - name: TEMPORAL_NAMESPACE
+              value: site
+            - name: TEMPORAL_QUEUE
+              value: site
+          volumeMounts:
+            - name: config
+              mountPath: /app/config.yaml
+              subPath: config.yaml
+            - name: temporal-encryption-key
+              mountPath: /var/secrets/temporal
+              readOnly: true
+            - name: temporal-tls-certs
+              mountPath: /var/secrets/temporal/certs
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8899
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8899
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.siteWorker.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - NET_RAW
+      securityContext:
+        runAsNonRoot: false
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "carbide-rest-workflow.name" . }}-config
+        - name: temporal-encryption-key
+          secret:
+            secretName: {{ .Values.secrets.carbideSecrets }}
+            items:
+              - key: temporal-encryption-key
+                path: encryption-key
+        - name: temporal-tls-certs
+          secret:
+            secretName: {{ .Values.secrets.temporalClientCerts }}

--- a/helm/charts/carbide-rest-workflow/values.yaml
+++ b/helm/charts/carbide-rest-workflow/values.yaml
@@ -1,0 +1,66 @@
+nameOverride: ""
+namespaceOverride: ""
+
+image:
+  name: carbide-rest-workflow
+
+cloudWorker:
+  replicaCount: 1
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+
+siteWorker:
+  replicaCount: 1
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+
+secrets:
+  carbideSecrets: carbide-secrets
+  temporalClientCerts: temporal-client-certs
+
+config:
+  env:
+    dev: true
+  log:
+    level: debug
+  db:
+    host: postgres
+    port: 5432
+    name: forge
+    user: forge
+    password: forge
+  temporal:
+    host: temporal-frontend.temporal
+    port: 7233
+    serverName: server.temporal.local
+    namespace: cloud
+    queue: cloud
+    tls:
+      enabled: true
+      certPath: /var/secrets/temporal/certs/tls.crt
+      keyPath: /var/secrets/temporal/certs/tls.key
+      caPath: /var/secrets/temporal/certs/ca.crt
+      disableHostVerification: false
+    encryptionKeyPath: /var/secrets/temporal/encryption-key
+  ngc:
+    api:
+      baseUrl: ""
+  notifications:
+    slack:
+      webhookURL: ""
+  metrics:
+    enabled: true
+    port: 9360
+  tracing:
+    enabled: false
+    serviceName: cloud-workflow

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,0 +1,24 @@
+Carbide REST has been installed.
+
+Components deployed:
+{{- if index .Values "carbide-rest-api" "enabled" }}
+  - carbide-rest-api (REST API server, port 8388)
+{{- end }}
+{{- if index .Values "carbide-rest-workflow" "enabled" }}
+  - carbide-rest-workflow (cloud-worker + site-worker)
+{{- end }}
+{{- if index .Values "carbide-rest-site-agent" "enabled" }}
+  - carbide-rest-site-agent (Elektra site agent)
+{{- end }}
+{{- if index .Values "carbide-rest-site-manager" "enabled" }}
+  - carbide-rest-site-manager (site lifecycle manager, port 8100)
+{{- end }}
+{{- if index .Values "carbide-rest-db" "enabled" }}
+  - carbide-rest-db (database migrations)
+{{- end }}
+
+Prerequisites (must exist before install):
+  - PostgreSQL database
+  - Temporal server
+  - cert-manager with ClusterIssuer "{{ .Values.global.certificate.issuerRef.name }}"
+  - Secrets: carbide-secrets, temporal-client-certs, site-registration

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,55 @@
+## =============================================================================
+## Carbide REST — Umbrella Helm Chart
+## =============================================================================
+## IMPORTANT: You MUST set global.image.repository and global.image.tag before
+## installing. They default to empty strings and the chart will not render
+## valid manifests without them.
+## =============================================================================
+
+global:
+  image:
+    repository: ""
+    tag: ""
+    pullPolicy: IfNotPresent
+
+  imagePullSecrets: []
+
+  certificate:
+    issuerRef:
+      kind: ClusterIssuer
+      name: carbide-ca-issuer
+      group: cert-manager.io
+
+  labels:
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: carbide-rest
+
+## ---------------------------------------------------------------------------
+## carbide-rest-api
+## ---------------------------------------------------------------------------
+carbide-rest-api:
+  enabled: true
+
+## ---------------------------------------------------------------------------
+## carbide-rest-workflow
+## ---------------------------------------------------------------------------
+carbide-rest-workflow:
+  enabled: true
+
+## ---------------------------------------------------------------------------
+## carbide-rest-site-agent
+## ---------------------------------------------------------------------------
+carbide-rest-site-agent:
+  enabled: true
+
+## ---------------------------------------------------------------------------
+## carbide-rest-site-manager
+## ---------------------------------------------------------------------------
+carbide-rest-site-manager:
+  enabled: true
+
+## ---------------------------------------------------------------------------
+## carbide-rest-db (migrations)
+## ---------------------------------------------------------------------------
+carbide-rest-db:
+  enabled: true


### PR DESCRIPTION
### Changes

- **Helm chart** (`helm/`): Added an umbrella chart with 5 sub-charts converted from `deploy/kustomize/base/`:
  - `carbide-rest-api`, `carbide-rest-workflow` (cloud + site workers), `carbide-rest-site-agent`, `carbide-rest-site-manager`, `carbide-rest-db` (migration job with Helm hooks)
- **CI** (`prepare-build-info.yml`, `main-build.yml`):
  - `helm_version` output: `{semantic_version}+{short_sha}`
  - `build-validate-helm-chart`: helm lint + template
  - `build-push-helm-chart`: package + push to NGC

Infrastructure (PostgreSQL, Keycloak, Temporal, cert-manager) intentionally excluded.

### Kustomize vs Helm diff

| Category | Count | Status |
|----------|-------|--------|
| Deployments | 5 | No functional diff |
| ConfigMaps (api, workflow) | 2 | No functional diff |
| Services | 3 | Selector labels migrated to `app.kubernetes.io/*` |
| ConfigMap (site-agent) | 1 | Dev defaults replaced with empty production defaults |
| Renamed resources | 2 | `db` → `carbide-rest-db-migrations`, cert name prefixed |

All diffs are intentional (label convention, production defaults). No regressions.