### PR TITLE
feat: Add Go sub-module for SDK at sdk/standard/

### DIFF
--- a/sdk/standard/go.mod
+++ b/sdk/standard/go.mod
@@ -1,0 +1,3 @@
+module github.com/nvidia/bare-metal-manager-rest/sdk/standard
+
+go 1.25


### PR DESCRIPTION
## Summary
- Adds a standalone `go.mod` at `sdk/standard/` so the openapi-generator SDK can be imported independently
- Downstream providers (cloud-provider, machine-api-provider, cluster-api-provider) can depend on `github.com/nvidia/bare-metal-manager-rest/sdk/standard` without pulling in the full module's heavy dependencies (Postgres, Redis, Temporal, etc.)
- The SDK uses only standard library imports — no external dependencies needed

## Test plan
- [x] `go build ./...` in `sdk/standard/` compiles cleanly
- [x] Verified downstream providers can import and build against the sub-module

🤖 Generated with [Claude Code](https://claude.com/claude-code)