### PR TITLE
fix: updated stats pagination limit, maxAllocatable formula, and decommissioned machine handling

### DIFF
--- a/api/pkg/api/handler/stats.go
+++ b/api/pkg/api/handler/stats.go
@@ -185,7 +185,7 @@ func (gtitsh GetTenantInstanceTypeStatsHandler) Handle(c echo.Context) error {
 	// 1. Fetch all instance types for the site
 	itDAO := cdbm.NewInstanceTypeDAO(gtitsh.dbSession)
 	instanceTypes, _, err := itDAO.GetAll(ctx, nil, cdbm.InstanceTypeFilterInput{SiteIDs: siteIDs},
-		nil, nil, nil, nil)
+		nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("error retrieving instance types")
 		return cerr.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve instance types", nil)
@@ -271,17 +271,24 @@ func (gtitsh GetTenantInstanceTypeStatsHandler) Handle(c echo.Context) error {
 		tenantITAllocs[tID][itID] = append(tenantITAllocs[tID][itID], ac)
 	}
 
-	// Healthy (non-error) machines per instance type for maxAllocatable
-	healthyAssignedMachines := lo.Filter(machines, func(m cdbm.Machine, _ int) bool {
-		return m.InstanceTypeID != nil && m.Status != cdbm.MachineStatusError && m.Status != cdbm.MachineStatusMaintenance
+	// Ready assigned machines per instance type
+	readyAssignedMachines := lo.Filter(machines, func(m cdbm.Machine, _ int) bool {
+		return m.InstanceTypeID != nil && m.Status == cdbm.MachineStatusReady
 	})
-	healthyMachineCountByIT := lo.CountValuesBy(healthyAssignedMachines, func(m cdbm.Machine) uuid.UUID { return *m.InstanceTypeID })
+	readyMachineCountByIT := lo.CountValuesBy(readyAssignedMachines, func(m cdbm.Machine) uuid.UUID { return *m.InstanceTypeID })
 
-	// Used machines per instance type across all tenants (in any state)
-	usedMachinesByIT := make(map[uuid.UUID]int)
-	for _, itMap := range tenantITUsed {
-		for itID, stats := range itMap {
-			usedMachinesByIT[itID] += stats.Total
+	// Calculate total allocated per instance type across all tenants
+	totalAllocatedByIT := lo.Reduce(constraints, func(acc map[uuid.UUID]int, ac cdbm.AllocationConstraint, _ int) map[uuid.UUID]int {
+		acc[ac.ResourceTypeID] += ac.ConstraintValue
+		return acc
+	}, make(map[uuid.UUID]int))
+
+	// Calculate total machines in use per instance type across all tenants
+	// This counts machines with running instances regardless of their status
+	totalInUseByIT := make(map[uuid.UUID]int)
+	for _, itUsageMap := range tenantITUsed {
+		for itID, breakdown := range itUsageMap {
+			totalInUseByIT[itID] += breakdown.Total
 		}
 	}
 
@@ -329,10 +336,8 @@ func (gtitsh GetTenantInstanceTypeStatsHandler) Handle(c echo.Context) error {
 				used = *tenantITUsed[tID][itID]
 			}
 
-			maxAlloc := healthyMachineCountByIT[itID] - usedMachinesByIT[itID]
-			if maxAlloc < 0 {
-				maxAlloc = 0
-			}
+			// ready machines minus those already reserved (allocated but not yet in use)
+			maxAlloc := max(0, readyMachineCountByIT[itID]-(totalAllocatedByIT[itID]-totalInUseByIT[itID]))
 
 			ts.InstanceTypes = append(ts.InstanceTypes, model.APITenantInstanceTypeStatsEntry{
 				ID:               it.ID.String(),
@@ -499,7 +504,7 @@ func (gmitsh GetMachineInstanceTypeStatsHandler) Handle(c echo.Context) error {
 	// 1. Fetch all instance types for the site
 	itDAO := cdbm.NewInstanceTypeDAO(gmitsh.dbSession)
 	instanceTypes, _, err := itDAO.GetAll(ctx, nil, cdbm.InstanceTypeFilterInput{SiteIDs: siteIDs},
-		nil, nil, nil, nil)
+		nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("error retrieving instance types")
 		return cerr.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve instance types", nil)

--- a/api/pkg/api/handler/stats_test.go
+++ b/api/pkg/api/handler/stats_test.go
@@ -253,36 +253,40 @@ func testStatsSetupEchoContext(t *testing.T, org, siteID string, user *cdbm.User
 
 // ~~~~~ Test Data Setup ~~~~~ //
 //
-// Test scenario:
+//
 //   1 Infrastructure Provider (org: "stats-org")
 //   1 Site
-//   2 Tenants: "tenant-a" (org: "tenant-a-org", display: "Tenant A Org") and "tenant-b" (org: "tenant-b-org", display: "Tenant B Org")
-//   4 Instance Types: "cpu.x100", "gpu.a100", "gpu.h100", "storage.hdd"
+//   3 Tenants: alpha, beta, gamma
+//   3 Instance Types: gpu-large, gpu-small, cpu-standard
 //
-//   Machines (20 total across instance types + 3 unassigned):
-//     cpu.x100: 8 machines (5 ready, 1 inUse, 1 error, 1 maintenance) - 2 degraded
-//     gpu.a100: 5 machines (2 ready, 2 inUse, 1 error) - 1 degraded
-//     gpu.h100: 4 machines (3 ready, 1 maintenance)
-//     storage.hdd: 3 machines (3 ready)
-//     unassigned: 3 machines (2 ready, 1 unknown)
+//   Machines (29 assigned + 8 unassigned = 37 total):
+//     gpu-large:    12 (1 Init, 5 Ready, 2 InUse, 1 Error, 1 Maint, 1 Unknown, 1 Decom)
+//     gpu-small:    12 (1 Init, 4 Ready, 3 InUse, 1 Error, 1 Maint, 1 Unknown, 1 Reset)
+//     cpu-standard:  5 (3 Ready, 1 InUse, 1 Error)
+//     unassigned:    8 (2 Ready, 1 Error, 1 Maint, 1 Unknown, 1 Decom, 2 Reset)
 //
 //   GPU Capabilities:
-//     gpu.a100 machines: each has "NVIDIA A100 PCIe" GPU with count=8
-//     gpu.h100 machines: each has "NVIDIA H100 PCIe" GPU with count=8
+//     gpu-large: "NVIDIA H100 SXM5 80GB" count=8 per machine, except 1 with count=4 (11×8 + 1×4 = 92)
+//     gpu-small: "NVIDIA A100 SXM4 80GB" count=8 per machine, except 1 with count=4 (11×8 + 1×4 = 92)
 //
-//   Allocations:
-//     Tenant A: 2 allocations
-//       alloc-a-1: cpu.x100 constraint=20, gpu.a100 constraint=3
-//       alloc-a-2: cpu.x100 constraint=10
-//     Tenant B: 1 allocation
-//       alloc-b-1: cpu.x100 constraint=15, gpu.h100 constraint=2
+//   Allocations (4 allocations, 7 constraints):
+//     alpha: training-reserved (gpu-large:4, gpu-small:3), inference-ondemand (gpu-large:2)
+//     beta:  simulation-pool (gpu-large:1, gpu-small:3)
+//     gamma: general-compute (gpu-small:2, cpu:1)
+//     Totals per IT: gpu-large=7, gpu-small=8, cpu=1
 //
-//   Instances (machines in use by tenants):
-//     Tenant A:
-//       3 instances on cpu.x100 machines (1 on error machine, 1 on maintenance machine, 1 on inUse machine)
-//       2 instances on gpu.a100 machines (both on inUse machines)
-//     Tenant B:
-//       1 instance on gpu.h100 machine (on maintenance machine)
+//   Instances (12 total — machines in use by tenants, status reflects machine state):
+//     alpha: gpu-large×4 (2 InUse→Ready, 1 Error→Error, 1 Init→Provisioning)
+//            gpu-small×2 (2 InUse→Ready)
+//     beta:  gpu-large×1 (Maintenance→Ready)
+//            gpu-small×3 (1 Error→Error, 1 Maintenance→Ready, 1 Init→Provisioning)
+//     gamma: gpu-small×1 (InUse→Ready), cpu×1 (InUse→Ready)
+//     Used per IT:  gpu-large=5, gpu-small=6, cpu=1
+//
+//   MaxAllocatable = max(0, ready - (allocated - used)):
+//     gpu-large: max(0, 5-(7-5)) = 3
+//     gpu-small: max(0, 4-(8-6)) = 2
+//     cpu:       max(0, 3-(1-1)) = 3
 
 func TestStatsHandlers(t *testing.T) {
 	dbSession := testStatsInitDB(t)
@@ -300,96 +304,130 @@ func TestStatsHandlers(t *testing.T) {
 	site := testStatsBuildSite(t, dbSession, ip, "stats-site")
 
 	// Tenants
-	tenantA := testStatsBuildTenant(t, dbSession, "tenant-a-org", "tenant-a", "Tenant A Org")
-	tenantB := testStatsBuildTenant(t, dbSession, "tenant-b-org", "tenant-b", "Tenant B Org")
+	tenantAlpha := testStatsBuildTenant(t, dbSession, "alpha-org", "alpha", "Alpha Corp")
+	tenantBeta := testStatsBuildTenant(t, dbSession, "beta-org", "beta", "Beta Labs")
+	tenantGamma := testStatsBuildTenant(t, dbSession, "gamma-org", "gamma", "Gamma Dev")
 
 	// Instance Types
-	itCPU := testStatsBuildInstanceType(t, dbSession, ip, site, "cpu.x100")
-	itA100 := testStatsBuildInstanceType(t, dbSession, ip, site, "gpu.a100")
-	itH100 := testStatsBuildInstanceType(t, dbSession, ip, site, "gpu.h100")
-	itStorage := testStatsBuildInstanceType(t, dbSession, ip, site, "storage.hdd")
+	itGPULarge := testStatsBuildInstanceType(t, dbSession, ip, site, "gpu-large")
+	itGPUSmall := testStatsBuildInstanceType(t, dbSession, ip, site, "gpu-small")
+	itCPU := testStatsBuildInstanceType(t, dbSession, ip, site, "cpu-standard")
 
 	// ~~~~~ Machines ~~~~~ //
 
-	// cpu.x100 machines (8 total)
-	cpuMachines := make([]*cdbm.Machine, 8)
-	cpuMachines[0] = testStatsBuildMachine(t, dbSession, ip, site, &itCPU.ID, cdbm.MachineStatusReady, false)
-	cpuMachines[1] = testStatsBuildMachine(t, dbSession, ip, site, &itCPU.ID, cdbm.MachineStatusReady, false)
-	cpuMachines[2] = testStatsBuildMachine(t, dbSession, ip, site, &itCPU.ID, cdbm.MachineStatusReady, true) // degraded
-	cpuMachines[3] = testStatsBuildMachine(t, dbSession, ip, site, &itCPU.ID, cdbm.MachineStatusReady, true) // degraded
-	cpuMachines[4] = testStatsBuildMachine(t, dbSession, ip, site, &itCPU.ID, cdbm.MachineStatusReady, false)
-	cpuMachines[5] = testStatsBuildMachine(t, dbSession, ip, site, &itCPU.ID, cdbm.MachineStatusInUse, false)
-	cpuMachines[6] = testStatsBuildMachine(t, dbSession, ip, site, &itCPU.ID, cdbm.MachineStatusError, false)
-	cpuMachines[7] = testStatsBuildMachine(t, dbSession, ip, site, &itCPU.ID, cdbm.MachineStatusMaintenance, false)
+	// gpu-large: 12 machines (1 Init, 5 Ready, 2 InUse, 1 Error, 1 Maint, 1 Unknown, 1 Decom)
+	gpuL := make([]*cdbm.Machine, 12)
+	gpuL[0] = testStatsBuildMachine(t, dbSession, ip, site, &itGPULarge.ID, cdbm.MachineStatusInitializing, false)
+	gpuL[1] = testStatsBuildMachine(t, dbSession, ip, site, &itGPULarge.ID, cdbm.MachineStatusReady, false)
+	gpuL[2] = testStatsBuildMachine(t, dbSession, ip, site, &itGPULarge.ID, cdbm.MachineStatusReady, false)
+	gpuL[3] = testStatsBuildMachine(t, dbSession, ip, site, &itGPULarge.ID, cdbm.MachineStatusReady, false)
+	gpuL[4] = testStatsBuildMachine(t, dbSession, ip, site, &itGPULarge.ID, cdbm.MachineStatusReady, false)
+	gpuL[5] = testStatsBuildMachine(t, dbSession, ip, site, &itGPULarge.ID, cdbm.MachineStatusReady, false)
+	gpuL[6] = testStatsBuildMachine(t, dbSession, ip, site, &itGPULarge.ID, cdbm.MachineStatusInUse, false)
+	gpuL[7] = testStatsBuildMachine(t, dbSession, ip, site, &itGPULarge.ID, cdbm.MachineStatusInUse, false)
+	gpuL[8] = testStatsBuildMachine(t, dbSession, ip, site, &itGPULarge.ID, cdbm.MachineStatusError, false)
+	gpuL[9] = testStatsBuildMachine(t, dbSession, ip, site, &itGPULarge.ID, cdbm.MachineStatusMaintenance, false)
+	gpuL[10] = testStatsBuildMachine(t, dbSession, ip, site, &itGPULarge.ID, cdbm.MachineStatusUnknown, false)
+	gpuL[11] = testStatsBuildMachine(t, dbSession, ip, site, &itGPULarge.ID, cdbm.MachineStatusDecommissioned, false)
 
-	// gpu.a100 machines (5 total)
-	a100Machines := make([]*cdbm.Machine, 5)
-	a100Machines[0] = testStatsBuildMachine(t, dbSession, ip, site, &itA100.ID, cdbm.MachineStatusReady, false)
-	a100Machines[1] = testStatsBuildMachine(t, dbSession, ip, site, &itA100.ID, cdbm.MachineStatusReady, false)
-	a100Machines[2] = testStatsBuildMachine(t, dbSession, ip, site, &itA100.ID, cdbm.MachineStatusInUse, false)
-	a100Machines[3] = testStatsBuildMachine(t, dbSession, ip, site, &itA100.ID, cdbm.MachineStatusInUse, false)
-	a100Machines[4] = testStatsBuildMachine(t, dbSession, ip, site, &itA100.ID, cdbm.MachineStatusError, true) // degraded
+	// gpu-small: 12 machines (1 Init, 4 Ready, 3 InUse, 1 Error, 1 Maint, 1 Unknown, 1 Reset)
+	gpuS := make([]*cdbm.Machine, 12)
+	gpuS[0] = testStatsBuildMachine(t, dbSession, ip, site, &itGPUSmall.ID, cdbm.MachineStatusInitializing, false)
+	gpuS[1] = testStatsBuildMachine(t, dbSession, ip, site, &itGPUSmall.ID, cdbm.MachineStatusReady, false)
+	gpuS[2] = testStatsBuildMachine(t, dbSession, ip, site, &itGPUSmall.ID, cdbm.MachineStatusReady, false)
+	gpuS[3] = testStatsBuildMachine(t, dbSession, ip, site, &itGPUSmall.ID, cdbm.MachineStatusReady, false)
+	gpuS[4] = testStatsBuildMachine(t, dbSession, ip, site, &itGPUSmall.ID, cdbm.MachineStatusReady, false)
+	gpuS[5] = testStatsBuildMachine(t, dbSession, ip, site, &itGPUSmall.ID, cdbm.MachineStatusInUse, false)
+	gpuS[6] = testStatsBuildMachine(t, dbSession, ip, site, &itGPUSmall.ID, cdbm.MachineStatusInUse, false)
+	gpuS[7] = testStatsBuildMachine(t, dbSession, ip, site, &itGPUSmall.ID, cdbm.MachineStatusInUse, false)
+	gpuS[8] = testStatsBuildMachine(t, dbSession, ip, site, &itGPUSmall.ID, cdbm.MachineStatusError, false)
+	gpuS[9] = testStatsBuildMachine(t, dbSession, ip, site, &itGPUSmall.ID, cdbm.MachineStatusMaintenance, false)
+	gpuS[10] = testStatsBuildMachine(t, dbSession, ip, site, &itGPUSmall.ID, cdbm.MachineStatusUnknown, false)
+	gpuS[11] = testStatsBuildMachine(t, dbSession, ip, site, &itGPUSmall.ID, cdbm.MachineStatusReset, false)
 
-	// gpu.h100 machines (4 total)
-	h100Machines := make([]*cdbm.Machine, 4)
-	h100Machines[0] = testStatsBuildMachine(t, dbSession, ip, site, &itH100.ID, cdbm.MachineStatusReady, false)
-	h100Machines[1] = testStatsBuildMachine(t, dbSession, ip, site, &itH100.ID, cdbm.MachineStatusReady, false)
-	h100Machines[2] = testStatsBuildMachine(t, dbSession, ip, site, &itH100.ID, cdbm.MachineStatusReady, false)
-	h100Machines[3] = testStatsBuildMachine(t, dbSession, ip, site, &itH100.ID, cdbm.MachineStatusMaintenance, false)
+	// cpu-standard: 5 machines (3 Ready, 1 InUse, 1 Error)
+	cpu := make([]*cdbm.Machine, 5)
+	cpu[0] = testStatsBuildMachine(t, dbSession, ip, site, &itCPU.ID, cdbm.MachineStatusReady, false)
+	cpu[1] = testStatsBuildMachine(t, dbSession, ip, site, &itCPU.ID, cdbm.MachineStatusReady, false)
+	cpu[2] = testStatsBuildMachine(t, dbSession, ip, site, &itCPU.ID, cdbm.MachineStatusReady, false)
+	cpu[3] = testStatsBuildMachine(t, dbSession, ip, site, &itCPU.ID, cdbm.MachineStatusInUse, false)
+	cpu[4] = testStatsBuildMachine(t, dbSession, ip, site, &itCPU.ID, cdbm.MachineStatusError, false)
 
-	// storage.hdd machines (3 total)
-	testStatsBuildMachine(t, dbSession, ip, site, &itStorage.ID, cdbm.MachineStatusReady, false)
-	testStatsBuildMachine(t, dbSession, ip, site, &itStorage.ID, cdbm.MachineStatusReady, false)
-	testStatsBuildMachine(t, dbSession, ip, site, &itStorage.ID, cdbm.MachineStatusReady, false)
-
-	// Unassigned machines (3 total)
+	// unassigned: 8 machines (2 Ready, 1 Error, 1 Maint, 1 Unknown, 1 Decom, 2 Reset)
 	testStatsBuildMachine(t, dbSession, ip, site, nil, cdbm.MachineStatusReady, false)
 	testStatsBuildMachine(t, dbSession, ip, site, nil, cdbm.MachineStatusReady, false)
+	testStatsBuildMachine(t, dbSession, ip, site, nil, cdbm.MachineStatusError, false)
+	testStatsBuildMachine(t, dbSession, ip, site, nil, cdbm.MachineStatusMaintenance, false)
 	testStatsBuildMachine(t, dbSession, ip, site, nil, cdbm.MachineStatusUnknown, false)
+	testStatsBuildMachine(t, dbSession, ip, site, nil, cdbm.MachineStatusDecommissioned, false)
+	testStatsBuildMachine(t, dbSession, ip, site, nil, cdbm.MachineStatusReset, false)
+	testStatsBuildMachine(t, dbSession, ip, site, nil, cdbm.MachineStatusReset, false)
 
 	// ~~~~~ GPU Capabilities ~~~~~ //
 
-	for _, m := range a100Machines {
-		testStatsBuildMachineCapability(t, dbSession, m.ID, cdbm.MachineCapabilityTypeGPU, "NVIDIA A100 PCIe", 8)
+	for i, m := range gpuL {
+		count := 8
+		if i == 11 { // Decommissioned machine has only 4 GPUs (partially populated)
+			count = 4
+		}
+		testStatsBuildMachineCapability(t, dbSession, m.ID, cdbm.MachineCapabilityTypeGPU, "NVIDIA H100 SXM5 80GB", count)
 	}
-	for _, m := range h100Machines {
-		testStatsBuildMachineCapability(t, dbSession, m.ID, cdbm.MachineCapabilityTypeGPU, "NVIDIA H100 PCIe", 8)
+	for i, m := range gpuS {
+		count := 8
+		if i == 11 { // Reset machine has only 4 GPUs
+			count = 4
+		}
+		testStatsBuildMachineCapability(t, dbSession, m.ID, cdbm.MachineCapabilityTypeGPU, "NVIDIA A100 SXM4 80GB", count)
 	}
 
 	// ~~~~~ Allocations & Constraints ~~~~~ //
 
-	allocA1 := testStatsBuildAllocation(t, dbSession, ip, tenantA, site, "alloc-a-1")
-	testStatsBuildAllocationConstraint(t, dbSession, allocA1, itCPU.ID, 20) // 20 cpu.x100 for Tenant A alloc-1
-	testStatsBuildAllocationConstraint(t, dbSession, allocA1, itA100.ID, 3) // 3 gpu.a100 for Tenant A alloc-1
+	allocTraining := testStatsBuildAllocation(t, dbSession, ip, tenantAlpha, site, "training-reserved")
+	testStatsBuildAllocationConstraint(t, dbSession, allocTraining, itGPULarge.ID, 4)
+	testStatsBuildAllocationConstraint(t, dbSession, allocTraining, itGPUSmall.ID, 3)
 
-	allocA2 := testStatsBuildAllocation(t, dbSession, ip, tenantA, site, "alloc-a-2")
-	testStatsBuildAllocationConstraint(t, dbSession, allocA2, itCPU.ID, 10) // 10 cpu.x100 for Tenant A alloc-2
+	allocInference := testStatsBuildAllocation(t, dbSession, ip, tenantAlpha, site, "inference-ondemand")
+	testStatsBuildAllocationConstraint(t, dbSession, allocInference, itGPULarge.ID, 2)
 
-	allocB1 := testStatsBuildAllocation(t, dbSession, ip, tenantB, site, "alloc-b-1")
-	testStatsBuildAllocationConstraint(t, dbSession, allocB1, itCPU.ID, 15) // 15 cpu.x100 for Tenant B alloc-1
-	testStatsBuildAllocationConstraint(t, dbSession, allocB1, itH100.ID, 2) // 2 gpu.h100 for Tenant B alloc-1
+	allocSimulation := testStatsBuildAllocation(t, dbSession, ip, tenantBeta, site, "simulation-pool")
+	testStatsBuildAllocationConstraint(t, dbSession, allocSimulation, itGPULarge.ID, 1)
+	testStatsBuildAllocationConstraint(t, dbSession, allocSimulation, itGPUSmall.ID, 3)
 
-	// ~~~~~ Instances (machines associated with tenant instances) ~~~~~ //
+	allocGeneral := testStatsBuildAllocation(t, dbSession, ip, tenantGamma, site, "general-compute")
+	testStatsBuildAllocationConstraint(t, dbSession, allocGeneral, itGPUSmall.ID, 2)
+	testStatsBuildAllocationConstraint(t, dbSession, allocGeneral, itCPU.ID, 1)
 
-	// VPCs needed for instances
-	vpcA := testStatsBuildVpc(t, dbSession, ip, site, tenantA, "vpc-a")
-	vpcB := testStatsBuildVpc(t, dbSession, ip, site, tenantB, "vpc-b")
+	// ~~~~~ Instances ~~~~~ //
 
-	// Tenant A instances on cpu.x100: 3 instances
-	testStatsBuildInstance(t, dbSession, ip, site, tenantA, vpcA, &itCPU.ID, &cpuMachines[5].ID, &allocA1.ID, nil, "a-cpu-inst-1", cdbm.InstanceStatusReady) // on inUse machine
-	testStatsBuildInstance(t, dbSession, ip, site, tenantA, vpcA, &itCPU.ID, &cpuMachines[6].ID, &allocA1.ID, nil, "a-cpu-inst-2", cdbm.InstanceStatusReady) // on error machine
-	testStatsBuildInstance(t, dbSession, ip, site, tenantA, vpcA, &itCPU.ID, &cpuMachines[7].ID, &allocA2.ID, nil, "a-cpu-inst-3", cdbm.InstanceStatusReady) // on maintenance machine
+	vpcAlpha := testStatsBuildVpc(t, dbSession, ip, site, tenantAlpha, "vpc-alpha")
+	vpcBeta := testStatsBuildVpc(t, dbSession, ip, site, tenantBeta, "vpc-beta")
+	vpcGamma := testStatsBuildVpc(t, dbSession, ip, site, tenantGamma, "vpc-gamma")
 
-	// Tenant A instances on gpu.a100: 2 instances
-	testStatsBuildInstance(t, dbSession, ip, site, tenantA, vpcA, &itA100.ID, &a100Machines[2].ID, &allocA1.ID, nil, "a-a100-inst-1", cdbm.InstanceStatusReady) // on inUse machine
-	testStatsBuildInstance(t, dbSession, ip, site, tenantA, vpcA, &itA100.ID, &a100Machines[3].ID, &allocA1.ID, nil, "a-a100-inst-2", cdbm.InstanceStatusReady) // on inUse machine
+	// alpha: 4 instances on gpu-large (2 InUse→Ready, 1 Error→Error, 1 Initializing→Provisioning)
+	testStatsBuildInstance(t, dbSession, ip, site, tenantAlpha, vpcAlpha, &itGPULarge.ID, &gpuL[6].ID, &allocTraining.ID, nil, "alpha-gpuL-1", cdbm.InstanceStatusReady)        // machine InUse
+	testStatsBuildInstance(t, dbSession, ip, site, tenantAlpha, vpcAlpha, &itGPULarge.ID, &gpuL[7].ID, &allocTraining.ID, nil, "alpha-gpuL-2", cdbm.InstanceStatusReady)        // machine InUse
+	testStatsBuildInstance(t, dbSession, ip, site, tenantAlpha, vpcAlpha, &itGPULarge.ID, &gpuL[8].ID, &allocInference.ID, nil, "alpha-gpuL-3", cdbm.InstanceStatusError)       // machine Error
+	testStatsBuildInstance(t, dbSession, ip, site, tenantAlpha, vpcAlpha, &itGPULarge.ID, &gpuL[0].ID, &allocTraining.ID, nil, "alpha-gpuL-4", cdbm.InstanceStatusProvisioning) // machine Initializing
 
-	// Tenant B instances on gpu.h100: 1 instance
-	testStatsBuildInstance(t, dbSession, ip, site, tenantB, vpcB, &itH100.ID, &h100Machines[3].ID, &allocB1.ID, nil, "b-h100-inst-1", cdbm.InstanceStatusReady) // on maintenance machine
+	// alpha: 2 instances on gpu-small (2 InUse→Ready)
+	testStatsBuildInstance(t, dbSession, ip, site, tenantAlpha, vpcAlpha, &itGPUSmall.ID, &gpuS[5].ID, &allocTraining.ID, nil, "alpha-gpuS-1", cdbm.InstanceStatusReady) // machine InUse
+	testStatsBuildInstance(t, dbSession, ip, site, tenantAlpha, vpcAlpha, &itGPUSmall.ID, &gpuS[6].ID, &allocTraining.ID, nil, "alpha-gpuS-2", cdbm.InstanceStatusReady) // machine InUse
+
+	// beta: 1 instance on gpu-large (Maintenance→Ready)
+	testStatsBuildInstance(t, dbSession, ip, site, tenantBeta, vpcBeta, &itGPULarge.ID, &gpuL[9].ID, &allocSimulation.ID, nil, "beta-gpuL-1", cdbm.InstanceStatusReady) // machine Maintenance
+
+	// beta: 3 instances on gpu-small (1 Error→Error, 1 Maintenance→Ready, 1 Initializing→Provisioning)
+	testStatsBuildInstance(t, dbSession, ip, site, tenantBeta, vpcBeta, &itGPUSmall.ID, &gpuS[8].ID, &allocSimulation.ID, nil, "beta-gpuS-1", cdbm.InstanceStatusError)        // machine Error
+	testStatsBuildInstance(t, dbSession, ip, site, tenantBeta, vpcBeta, &itGPUSmall.ID, &gpuS[9].ID, &allocSimulation.ID, nil, "beta-gpuS-2", cdbm.InstanceStatusReady)        // machine Maintenance
+	testStatsBuildInstance(t, dbSession, ip, site, tenantBeta, vpcBeta, &itGPUSmall.ID, &gpuS[0].ID, &allocSimulation.ID, nil, "beta-gpuS-3", cdbm.InstanceStatusProvisioning) // machine Initializing
+
+	// gamma: 1 instance on gpu-small (InUse→Ready), 1 on cpu (InUse→Ready)
+	testStatsBuildInstance(t, dbSession, ip, site, tenantGamma, vpcGamma, &itGPUSmall.ID, &gpuS[7].ID, &allocGeneral.ID, nil, "gamma-gpuS-1", cdbm.InstanceStatusReady) // machine InUse
+	testStatsBuildInstance(t, dbSession, ip, site, tenantGamma, vpcGamma, &itCPU.ID, &cpu[3].ID, &allocGeneral.ID, nil, "gamma-cpu-1", cdbm.InstanceStatusReady)        // machine InUse
 
 	cfg := common.GetTestConfig()
 
-	// ~~~~~ Test: Machine GPU Stats ~~~~~ //
+	// ~~~~~ Test: 3.1 Machine GPU Stats ~~~~~ //
 
 	t.Run("GetMachineGPUStats", func(t *testing.T) {
 		ec, rec := testStatsSetupEchoContext(t, org, site.ID.String(), providerUser)
@@ -403,7 +441,6 @@ func TestStatsHandlers(t *testing.T) {
 		err = json.Unmarshal(rec.Body.Bytes(), &result)
 		require.Nil(t, err)
 
-		// Should have 2 GPU types: NVIDIA A100 PCIe and NVIDIA H100 PCIe
 		assert.Equal(t, 2, len(result))
 
 		gpuByName := make(map[string]model.APIMachineGPUStats)
@@ -411,18 +448,16 @@ func TestStatsHandlers(t *testing.T) {
 			gpuByName[g.Name] = g
 		}
 
-		// A100: 5 machines x 8 GPUs each = 40 GPUs
-		a100Stats := gpuByName["NVIDIA A100 PCIe"]
-		assert.Equal(t, 40, a100Stats.GPUs)
-		assert.Equal(t, 5, a100Stats.Machines)
+		h100Stats := gpuByName["NVIDIA H100 SXM5 80GB"]
+		assert.Equal(t, 92, h100Stats.GPUs) // 11×8 + 1×4
+		assert.Equal(t, 12, h100Stats.Machines)
 
-		// H100: 4 machines x 8 GPUs each = 32 GPUs
-		h100Stats := gpuByName["NVIDIA H100 PCIe"]
-		assert.Equal(t, 32, h100Stats.GPUs)
-		assert.Equal(t, 4, h100Stats.Machines)
+		a100Stats := gpuByName["NVIDIA A100 SXM4 80GB"]
+		assert.Equal(t, 92, a100Stats.GPUs) // 11×8 + 1×4
+		assert.Equal(t, 12, a100Stats.Machines)
 	})
 
-	// ~~~~~ Test: Machine Instance Type Summary ~~~~~ //
+	// ~~~~~ Test: 3.2 Machine Instance Type Summary ~~~~~ //
 
 	t.Run("GetMachineInstanceTypeSummary", func(t *testing.T) {
 		ec, rec := testStatsSetupEchoContext(t, org, site.ID.String(), providerUser)
@@ -436,24 +471,28 @@ func TestStatsHandlers(t *testing.T) {
 		err = json.Unmarshal(rec.Body.Bytes(), &result)
 		require.Nil(t, err)
 
-		// Assigned: 8 cpu + 5 a100 + 4 h100 + 3 storage = 20 machines
-		assert.Equal(t, 20, result.Assigned.Total)
-		assert.Equal(t, 13, result.Assigned.Ready)      // 5 cpu + 2 a100 + 3 h100 + 3 storage
-		assert.Equal(t, 3, result.Assigned.InUse)       // 1 cpu + 2 a100
-		assert.Equal(t, 2, result.Assigned.Error)       // 1 cpu + 1 a100
-		assert.Equal(t, 2, result.Assigned.Maintenance) // 1 cpu + 1 h100
-		assert.Equal(t, 0, result.Assigned.Unknown)
+		// Assigned: 12 gpu-large + 12 gpu-small + 5 cpu = 29
+		assert.Equal(t, 29, result.Assigned.Total)
+		assert.Equal(t, 2, result.Assigned.Initializing) // 1 gpuL + 1 gpuS
+		assert.Equal(t, 12, result.Assigned.Ready)       // 5 gpuL + 4 gpuS + 3 cpu
+		assert.Equal(t, 6, result.Assigned.InUse)        // 2 gpuL + 3 gpuS + 1 cpu
+		assert.Equal(t, 3, result.Assigned.Error)        // 1 gpuL + 1 gpuS + 1 cpu
+		assert.Equal(t, 2, result.Assigned.Maintenance)  // 1 gpuL + 1 gpuS
+		assert.Equal(t, 2, result.Assigned.Unknown)      // 1 gpuL + 1 gpuS
+		// 29 > 2+12+6+3+2+2=27 because 1 Decom (gpuL) + 1 Reset (gpuS) = 2 untracked
 
-		// Unassigned: 3 machines (2 ready, 1 unknown)
-		assert.Equal(t, 3, result.Unassigned.Total)
+		// Unassigned: 8 machines
+		assert.Equal(t, 8, result.Unassigned.Total)
+		assert.Equal(t, 0, result.Unassigned.Initializing)
 		assert.Equal(t, 2, result.Unassigned.Ready)
 		assert.Equal(t, 0, result.Unassigned.InUse)
-		assert.Equal(t, 0, result.Unassigned.Error)
-		assert.Equal(t, 0, result.Unassigned.Maintenance)
+		assert.Equal(t, 1, result.Unassigned.Error)
+		assert.Equal(t, 1, result.Unassigned.Maintenance)
 		assert.Equal(t, 1, result.Unassigned.Unknown)
+		// 8 > 0+2+0+1+1+1=5 because 1 Decom + 2 Reset = 3 untracked
 	})
 
-	// ~~~~~ Test: Machine Instance Type Stats (detailed) ~~~~~ //
+	// ~~~~~ Test: 3.3 Machine Instance Type Stats (Detailed) ~~~~~ //
 
 	t.Run("GetMachineInstanceTypeStats", func(t *testing.T) {
 		ec, rec := testStatsSetupEchoContext(t, org, site.ID.String(), providerUser)
@@ -467,71 +506,123 @@ func TestStatsHandlers(t *testing.T) {
 		err = json.Unmarshal(rec.Body.Bytes(), &result)
 		require.Nil(t, err)
 
-		// Should have 4 instance types
-		assert.Equal(t, 4, len(result))
+		assert.Equal(t, 3, len(result))
 
 		statsByName := make(map[string]model.APIMachineInstanceTypeStats)
 		for _, s := range result {
 			statsByName[s.Name] = s
 		}
 
-		// cpu.x100: 8 assigned (5 Ready, 1 InUse, 1 Error, 1 Maintenance), 3 used, maxAllocatable=(7 healthy)-(3 used)=4
-		cpuStats := statsByName["cpu.x100"]
+		// --- gpu-large ---
+		gpuLStats := statsByName["gpu-large"]
+		assert.Equal(t, itGPULarge.ID.String(), gpuLStats.ID)
+		assert.Equal(t, "gpu-large", gpuLStats.Name)
+		// assigned: 12 total (1 Init, 5 Ready, 2 InUse, 1 Error, 1 Maint, 1 Unknown, 1 Decom)
+		assert.Equal(t, 12, gpuLStats.AssignedMachineStats.Total)
+		assert.Equal(t, 1, gpuLStats.AssignedMachineStats.Initializing)
+		assert.Equal(t, 5, gpuLStats.AssignedMachineStats.Ready)
+		assert.Equal(t, 2, gpuLStats.AssignedMachineStats.InUse)
+		assert.Equal(t, 1, gpuLStats.AssignedMachineStats.Error)
+		assert.Equal(t, 1, gpuLStats.AssignedMachineStats.Maintenance)
+		assert.Equal(t, 1, gpuLStats.AssignedMachineStats.Unknown)
+		assert.Equal(t, 7, gpuLStats.Allocated)      // 4+2 alpha + 1 beta
+		assert.Equal(t, 3, gpuLStats.MaxAllocatable) // max(0, 5-(7-5))
+		// used: 5 machines (alpha: 2 InUse + 1 Error + 1 Init, beta: 1 Maint)
+		assert.Equal(t, 5, gpuLStats.UsedMachineStats.Total)
+		assert.Equal(t, 2, gpuLStats.UsedMachineStats.InUse)
+		assert.Equal(t, 1, gpuLStats.UsedMachineStats.Error)
+		assert.Equal(t, 1, gpuLStats.UsedMachineStats.Maintenance)
+		assert.Equal(t, 1, gpuLStats.UsedMachineStats.Initializing)
+		assert.Equal(t, 0, gpuLStats.UsedMachineStats.Unknown)
+		assert.Equal(t, 2, len(gpuLStats.Tenants)) // alpha, beta
+
+		gpuLTenantByName := make(map[string]model.APIMachineInstanceTypeTenant)
+		for _, tn := range gpuLStats.Tenants {
+			gpuLTenantByName[tn.Name] = tn
+		}
+		alphaGpuL := gpuLTenantByName["alpha-org"]
+		assert.Equal(t, tenantAlpha.ID.String(), alphaGpuL.ID)
+		assert.Equal(t, 6, alphaGpuL.Allocated) // training:4 + inference:2
+		assert.Equal(t, 4, alphaGpuL.UsedMachineStats.Total)
+		assert.Equal(t, 1, alphaGpuL.UsedMachineStats.Initializing)
+		assert.Equal(t, 2, alphaGpuL.UsedMachineStats.InUse)
+		assert.Equal(t, 1, alphaGpuL.UsedMachineStats.Error)
+		assert.Equal(t, 2, len(alphaGpuL.Allocations))
+
+		betaGpuL := gpuLTenantByName["beta-org"]
+		assert.Equal(t, tenantBeta.ID.String(), betaGpuL.ID)
+		assert.Equal(t, 1, betaGpuL.Allocated) // simulation:1
+		assert.Equal(t, 1, betaGpuL.UsedMachineStats.Total)
+		assert.Equal(t, 1, betaGpuL.UsedMachineStats.Maintenance)
+		assert.Equal(t, 1, len(betaGpuL.Allocations))
+
+		// --- gpu-small ---
+		gpuSStats := statsByName["gpu-small"]
+		assert.Equal(t, itGPUSmall.ID.String(), gpuSStats.ID)
+		// assigned: 12 total (1 Init, 4 Ready, 3 InUse, 1 Error, 1 Maint, 1 Unknown, 1 Reset)
+		assert.Equal(t, 12, gpuSStats.AssignedMachineStats.Total)
+		assert.Equal(t, 1, gpuSStats.AssignedMachineStats.Initializing)
+		assert.Equal(t, 4, gpuSStats.AssignedMachineStats.Ready)
+		assert.Equal(t, 3, gpuSStats.AssignedMachineStats.InUse)
+		assert.Equal(t, 1, gpuSStats.AssignedMachineStats.Error)
+		assert.Equal(t, 1, gpuSStats.AssignedMachineStats.Maintenance)
+		assert.Equal(t, 1, gpuSStats.AssignedMachineStats.Unknown)
+		assert.Equal(t, 8, gpuSStats.Allocated)      // 3 alpha + 3 beta + 2 gamma
+		assert.Equal(t, 2, gpuSStats.MaxAllocatable) // max(0, 4-(8-6))
+		// used: 6 machines (alpha: 2 InUse, beta: 1 Error + 1 Maint + 1 Init, gamma: 1 InUse)
+		assert.Equal(t, 6, gpuSStats.UsedMachineStats.Total)
+		assert.Equal(t, 3, gpuSStats.UsedMachineStats.InUse)
+		assert.Equal(t, 1, gpuSStats.UsedMachineStats.Error)
+		assert.Equal(t, 1, gpuSStats.UsedMachineStats.Maintenance)
+		assert.Equal(t, 1, gpuSStats.UsedMachineStats.Initializing)
+		assert.Equal(t, 3, len(gpuSStats.Tenants)) // alpha, beta, gamma
+
+		gpuSTenantByName := make(map[string]model.APIMachineInstanceTypeTenant)
+		for _, tn := range gpuSStats.Tenants {
+			gpuSTenantByName[tn.Name] = tn
+		}
+		alphaGpuS := gpuSTenantByName["alpha-org"]
+		assert.Equal(t, 3, alphaGpuS.Allocated)
+		assert.Equal(t, 2, alphaGpuS.UsedMachineStats.Total)
+		assert.Equal(t, 2, alphaGpuS.UsedMachineStats.InUse)
+		assert.Equal(t, 1, len(alphaGpuS.Allocations))
+
+		betaGpuS := gpuSTenantByName["beta-org"]
+		assert.Equal(t, 3, betaGpuS.Allocated)
+		assert.Equal(t, 3, betaGpuS.UsedMachineStats.Total)
+		assert.Equal(t, 1, betaGpuS.UsedMachineStats.Initializing)
+		assert.Equal(t, 1, betaGpuS.UsedMachineStats.Error)
+		assert.Equal(t, 1, betaGpuS.UsedMachineStats.Maintenance)
+		assert.Equal(t, 1, len(betaGpuS.Allocations))
+
+		gammaGpuS := gpuSTenantByName["gamma-org"]
+		assert.Equal(t, 2, gammaGpuS.Allocated)
+		assert.Equal(t, 1, gammaGpuS.UsedMachineStats.Total)
+		assert.Equal(t, 1, gammaGpuS.UsedMachineStats.InUse)
+		assert.Equal(t, 1, len(gammaGpuS.Allocations))
+
+		// --- cpu-standard ---
+		cpuStats := statsByName["cpu-standard"]
 		assert.Equal(t, itCPU.ID.String(), cpuStats.ID)
-		// assignedMachineStats: all 8 machines assigned to this IT
-		assert.Equal(t, 8, cpuStats.AssignedMachineStats.Total)
+		// assigned: 5 total (3 Ready, 1 InUse, 1 Error)
+		assert.Equal(t, 5, cpuStats.AssignedMachineStats.Total)
+		assert.Equal(t, 0, cpuStats.AssignedMachineStats.Initializing)
+		assert.Equal(t, 3, cpuStats.AssignedMachineStats.Ready)
+		assert.Equal(t, 1, cpuStats.AssignedMachineStats.InUse)
 		assert.Equal(t, 1, cpuStats.AssignedMachineStats.Error)
-		assert.Equal(t, 1, cpuStats.AssignedMachineStats.Maintenance)
-		assert.Equal(t, 45, cpuStats.Allocated)     // 20 + 10 (Tenant A) + 15 (Tenant B)
-		assert.Equal(t, 3, cpuStats.MaxAllocatable) // (8 - 1 error - 1 maintenance) - 3 used = 3
-		// usedMachineStats: 3 total (Tenant A: 3), 1 error, 1 maintenance
-		assert.Equal(t, 3, cpuStats.UsedMachineStats.Total)
-		assert.Equal(t, 1, cpuStats.UsedMachineStats.Error)
-		assert.Equal(t, 1, cpuStats.UsedMachineStats.Maintenance)
-		// 2 tenants for cpu.x100
-		assert.Equal(t, 2, len(cpuStats.Tenants))
-
-		// gpu.a100: 5 assigned (2 Ready, 2 InUse, 1 Error), 2 used, maxAllocatable=(4 healthy)-(2 used)=2
-		a100Stats := statsByName["gpu.a100"]
-		// assignedMachineStats: all 5 machines
-		assert.Equal(t, 5, a100Stats.AssignedMachineStats.Total)
-		assert.Equal(t, 1, a100Stats.AssignedMachineStats.Error)
-		assert.Equal(t, 0, a100Stats.AssignedMachineStats.Maintenance)
-		assert.Equal(t, 3, a100Stats.Allocated)      // 3 from Tenant A
-		assert.Equal(t, 2, a100Stats.MaxAllocatable) // (5 - 1 error) - 2 used = 2
-		assert.Equal(t, 2, a100Stats.UsedMachineStats.Total)
-		assert.Equal(t, 0, a100Stats.UsedMachineStats.Error)
-		assert.Equal(t, 0, a100Stats.UsedMachineStats.Maintenance)
-		// 1 tenant for gpu.a100
-		assert.Equal(t, 1, len(a100Stats.Tenants))
-
-		// gpu.h100: 4 assigned (3 Ready, 1 Maintenance), 1 used, maxAllocatable=(4 - 0 error - 1 maintenance)-(1 used)=2
-		h100Stats := statsByName["gpu.h100"]
-		// assignedMachineStats: all 4 machines
-		assert.Equal(t, 4, h100Stats.AssignedMachineStats.Total)
-		assert.Equal(t, 0, h100Stats.AssignedMachineStats.Error)
-		assert.Equal(t, 1, h100Stats.AssignedMachineStats.Maintenance)
-		assert.Equal(t, 2, h100Stats.Allocated)      // 2 from Tenant B
-		assert.Equal(t, 2, h100Stats.MaxAllocatable) // (4 - 0 error - 1 maintenance) - 1 used = 2
-		assert.Equal(t, 1, h100Stats.UsedMachineStats.Total)
-		assert.Equal(t, 0, h100Stats.UsedMachineStats.Error)
-		assert.Equal(t, 1, h100Stats.UsedMachineStats.Maintenance) // Tenant B instance on maintenance machine
-		// 1 tenant for gpu.h100
-		assert.Equal(t, 1, len(h100Stats.Tenants))
-
-		// storage.hdd: 3 assigned (3 Ready), 0 allocated, maxAllocatable=3
-		storageStats := statsByName["storage.hdd"]
-		// assignedMachineStats: all 3 machines, all ready
-		assert.Equal(t, 3, storageStats.AssignedMachineStats.Total)
-		assert.Equal(t, 0, storageStats.AssignedMachineStats.Error)
-		assert.Equal(t, 0, storageStats.AssignedMachineStats.Maintenance)
-		assert.Equal(t, 0, storageStats.Allocated)
-		assert.Equal(t, 3, storageStats.MaxAllocatable) // 3 - 0 = 3
-		assert.Equal(t, 0, storageStats.UsedMachineStats.Total)
-		assert.Equal(t, 0, len(storageStats.Tenants))
+		assert.Equal(t, 0, cpuStats.AssignedMachineStats.Maintenance)
+		assert.Equal(t, 0, cpuStats.AssignedMachineStats.Unknown)
+		assert.Equal(t, 1, cpuStats.Allocated)      // general-compute:1
+		assert.Equal(t, 3, cpuStats.MaxAllocatable) // max(0, 3-(1-1))
+		// used: 1 machine (gamma: 1 InUse)
+		assert.Equal(t, 1, cpuStats.UsedMachineStats.Total)
+		assert.Equal(t, 1, cpuStats.UsedMachineStats.InUse)
+		assert.Equal(t, 0, cpuStats.UsedMachineStats.Error)
+		assert.Equal(t, 0, cpuStats.UsedMachineStats.Maintenance)
+		assert.Equal(t, 1, len(cpuStats.Tenants)) // gamma only
 	})
 
-	// ~~~~~ Test: Tenant Instance Type Stats ~~~~~ //
+	// ~~~~~ Test: 3.4 Tenant Instance Type Stats ~~~~~ //
 
 	t.Run("GetTenantInstanceTypeStats", func(t *testing.T) {
 		ec, rec := testStatsSetupEchoContext(t, org, site.ID.String(), providerUser)
@@ -545,67 +636,94 @@ func TestStatsHandlers(t *testing.T) {
 		err = json.Unmarshal(rec.Body.Bytes(), &result)
 		require.Nil(t, err)
 
-		// Should have 2 tenants
-		assert.Equal(t, 2, len(result))
+		assert.Equal(t, 3, len(result))
 
 		tenantByOrg := make(map[string]model.APITenantInstanceTypeStats)
 		for _, ts := range result {
 			tenantByOrg[ts.Org] = ts
 		}
 
-		// Tenant A
-		tenantAStats := tenantByOrg["tenant-a-org"]
-		assert.Equal(t, tenantA.ID.String(), tenantAStats.ID)
-		assert.Equal(t, "Tenant A Org", tenantAStats.OrgDisplayName)
-		// Tenant A has allocations for cpu.x100 and gpu.a100
-		assert.Equal(t, 2, len(tenantAStats.InstanceTypes))
+		// --- alpha ---
+		alphaStats := tenantByOrg["alpha-org"]
+		assert.Equal(t, tenantAlpha.ID.String(), alphaStats.ID)
+		assert.Equal(t, "Alpha Corp", alphaStats.OrgDisplayName)
+		assert.Equal(t, 2, len(alphaStats.InstanceTypes)) // gpu-large, gpu-small
 
-		tenantAByIT := make(map[string]model.APITenantInstanceTypeStatsEntry)
-		for _, it := range tenantAStats.InstanceTypes {
-			tenantAByIT[it.Name] = it
+		alphaByIT := make(map[string]model.APITenantInstanceTypeStatsEntry)
+		for _, it := range alphaStats.InstanceTypes {
+			alphaByIT[it.Name] = it
 		}
 
-		// Tenant A cpu.x100: allocated=30 (20+10), used=3 (1 error, 1 maintenance), 2 allocations
-		tenantACPU := tenantAByIT["cpu.x100"]
-		assert.Equal(t, 30, tenantACPU.Allocated)
-		assert.Equal(t, 3, tenantACPU.UsedMachineStats.Total)
-		assert.Equal(t, 1, tenantACPU.UsedMachineStats.Error)
-		assert.Equal(t, 1, tenantACPU.UsedMachineStats.Maintenance)
-		assert.Equal(t, 2, len(tenantACPU.Allocations))
+		alphaGpuLEntry := alphaByIT["gpu-large"]
+		assert.Equal(t, itGPULarge.ID.String(), alphaGpuLEntry.ID)
+		assert.Equal(t, 6, alphaGpuLEntry.Allocated)      // 4+2
+		assert.Equal(t, 3, alphaGpuLEntry.MaxAllocatable) // global gpu-large maxAlloc
+		assert.Equal(t, 4, alphaGpuLEntry.UsedMachineStats.Total)
+		assert.Equal(t, 1, alphaGpuLEntry.UsedMachineStats.Initializing)
+		assert.Equal(t, 2, alphaGpuLEntry.UsedMachineStats.InUse)
+		assert.Equal(t, 1, alphaGpuLEntry.UsedMachineStats.Error)
+		assert.Equal(t, 0, alphaGpuLEntry.UsedMachineStats.Maintenance)
+		assert.Equal(t, 2, len(alphaGpuLEntry.Allocations)) // training, inference
 
-		// Tenant A gpu.a100: allocated=3, used=2, 1 allocation
-		tenantAA100 := tenantAByIT["gpu.a100"]
-		assert.Equal(t, 3, tenantAA100.Allocated)
-		assert.Equal(t, 2, tenantAA100.UsedMachineStats.Total)
-		assert.Equal(t, 0, tenantAA100.UsedMachineStats.Error)
-		assert.Equal(t, 0, tenantAA100.UsedMachineStats.Maintenance)
-		assert.Equal(t, 1, len(tenantAA100.Allocations))
+		alphaGpuSEntry := alphaByIT["gpu-small"]
+		assert.Equal(t, 3, alphaGpuSEntry.Allocated)
+		assert.Equal(t, 2, alphaGpuSEntry.MaxAllocatable) // global gpu-small maxAlloc
+		assert.Equal(t, 2, alphaGpuSEntry.UsedMachineStats.Total)
+		assert.Equal(t, 2, alphaGpuSEntry.UsedMachineStats.InUse)
+		assert.Equal(t, 1, len(alphaGpuSEntry.Allocations))
 
-		// Tenant B
-		tenantBStats := tenantByOrg["tenant-b-org"]
-		assert.Equal(t, tenantB.ID.String(), tenantBStats.ID)
-		assert.Equal(t, "Tenant B Org", tenantBStats.OrgDisplayName)
-		// Tenant B has allocations for cpu.x100 and gpu.h100
-		assert.Equal(t, 2, len(tenantBStats.InstanceTypes))
+		// --- beta ---
+		betaStats := tenantByOrg["beta-org"]
+		assert.Equal(t, tenantBeta.ID.String(), betaStats.ID)
+		assert.Equal(t, "Beta Labs", betaStats.OrgDisplayName)
+		assert.Equal(t, 2, len(betaStats.InstanceTypes)) // gpu-large, gpu-small
 
-		tenantBByIT := make(map[string]model.APITenantInstanceTypeStatsEntry)
-		for _, it := range tenantBStats.InstanceTypes {
-			tenantBByIT[it.Name] = it
+		betaByIT := make(map[string]model.APITenantInstanceTypeStatsEntry)
+		for _, it := range betaStats.InstanceTypes {
+			betaByIT[it.Name] = it
 		}
 
-		// Tenant B cpu.x100: allocated=15, used=0 (no instances), 1 allocation
-		tenantBCPU := tenantBByIT["cpu.x100"]
-		assert.Equal(t, 15, tenantBCPU.Allocated)
-		assert.Equal(t, 0, tenantBCPU.UsedMachineStats.Total)
-		assert.Equal(t, 1, len(tenantBCPU.Allocations))
+		betaGpuLEntry := betaByIT["gpu-large"]
+		assert.Equal(t, 1, betaGpuLEntry.Allocated)
+		assert.Equal(t, 3, betaGpuLEntry.MaxAllocatable)
+		assert.Equal(t, 1, betaGpuLEntry.UsedMachineStats.Total)
+		assert.Equal(t, 0, betaGpuLEntry.UsedMachineStats.InUse)
+		assert.Equal(t, 1, betaGpuLEntry.UsedMachineStats.Maintenance)
+		assert.Equal(t, 1, len(betaGpuLEntry.Allocations))
 
-		// Tenant B gpu.h100: allocated=2, used=1 (maintenance), 1 allocation
-		tenantBH100 := tenantBByIT["gpu.h100"]
-		assert.Equal(t, 2, tenantBH100.Allocated)
-		assert.Equal(t, 1, tenantBH100.UsedMachineStats.Total)
-		assert.Equal(t, 0, tenantBH100.UsedMachineStats.Error)
-		assert.Equal(t, 1, tenantBH100.UsedMachineStats.Maintenance)
-		assert.Equal(t, 1, len(tenantBH100.Allocations))
+		betaGpuSEntry := betaByIT["gpu-small"]
+		assert.Equal(t, 3, betaGpuSEntry.Allocated)
+		assert.Equal(t, 2, betaGpuSEntry.MaxAllocatable)
+		assert.Equal(t, 3, betaGpuSEntry.UsedMachineStats.Total)
+		assert.Equal(t, 1, betaGpuSEntry.UsedMachineStats.Initializing)
+		assert.Equal(t, 1, betaGpuSEntry.UsedMachineStats.Error)
+		assert.Equal(t, 1, betaGpuSEntry.UsedMachineStats.Maintenance)
+		assert.Equal(t, 1, len(betaGpuSEntry.Allocations))
+
+		// --- gamma ---
+		gammaStats := tenantByOrg["gamma-org"]
+		assert.Equal(t, tenantGamma.ID.String(), gammaStats.ID)
+		assert.Equal(t, "Gamma Dev", gammaStats.OrgDisplayName)
+		assert.Equal(t, 2, len(gammaStats.InstanceTypes)) // gpu-small, cpu
+
+		gammaByIT := make(map[string]model.APITenantInstanceTypeStatsEntry)
+		for _, it := range gammaStats.InstanceTypes {
+			gammaByIT[it.Name] = it
+		}
+
+		gammaGpuSEntry := gammaByIT["gpu-small"]
+		assert.Equal(t, 2, gammaGpuSEntry.Allocated)
+		assert.Equal(t, 2, gammaGpuSEntry.MaxAllocatable)
+		assert.Equal(t, 1, gammaGpuSEntry.UsedMachineStats.Total)
+		assert.Equal(t, 1, gammaGpuSEntry.UsedMachineStats.InUse)
+		assert.Equal(t, 1, len(gammaGpuSEntry.Allocations))
+
+		gammaCPUEntry := gammaByIT["cpu-standard"]
+		assert.Equal(t, 1, gammaCPUEntry.Allocated)
+		assert.Equal(t, 3, gammaCPUEntry.MaxAllocatable) // global cpu maxAlloc
+		assert.Equal(t, 1, gammaCPUEntry.UsedMachineStats.Total)
+		assert.Equal(t, 1, gammaCPUEntry.UsedMachineStats.InUse)
+		assert.Equal(t, 1, len(gammaCPUEntry.Allocations))
 	})
 
 	// ~~~~~ Test: Auth - Tenant user should be denied ~~~~~ //
@@ -627,7 +745,7 @@ func TestStatsHandlers(t *testing.T) {
 		ctx = context.WithValue(ctx, otelecho.TracerKey, tracer)
 
 		e := echo.New()
-		req := httptest.NewRequest(http.MethodGet, "/", nil) // no siteId
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 		rec := httptest.NewRecorder()
 
@@ -687,5 +805,4 @@ func TestStatsHandlers(t *testing.T) {
 		assert.Equal(t, 0, result.Unassigned.Total)
 	})
 
-	_ = tenantUser // used above
 }

--- a/api/pkg/api/model/stats.go
+++ b/api/pkg/api/model/stats.go
@@ -138,7 +138,7 @@ type APIMachineStatusBreakdown struct {
 	Unknown int `json:"unknown"`
 }
 
-// AddMachineStatusCounts increments counters based on machine status
+// AddMachineStatusCounts increments counters based on machine status.
 func (amsb *APIMachineStatusBreakdown) AddMachineStatusCounts(m cdbm.Machine) {
 	amsb.Total++
 	switch m.Status {
@@ -224,11 +224,8 @@ func NewAPIMachineInstanceTypeStats(
 		used = *itUsed[it.ID]
 	}
 
-	maxAlloc := (assignedStats.Total - assignedStats.Error - assignedStats.Maintenance) - used.Total
-
-	if maxAlloc < 0 {
-		maxAlloc = 0
-	}
+	// ready machines minus those already reserved (allocated but not yet in use)
+	maxAlloc := max(0, assignedStats.Ready-(allocated-used.Total))
 
 	tenantMap := make(map[uuid.UUID]*APIMachineInstanceTypeTenant)
 	for _, ac := range itConstraints {

--- a/api/pkg/api/model/stats_test.go
+++ b/api/pkg/api/model/stats_test.go
@@ -27,9 +27,9 @@ import (
 
 func TestAPIMachineGPUStats_JSON(t *testing.T) {
 	stats := APIMachineGPUStats{
-		Name:     "NVIDIA A100 PCIe",
-		GPUs:     40,
-		Machines: 5,
+		Name:     "NVIDIA H100 SXM5 80GB",
+		GPUs:     92,
+		Machines: 12,
 	}
 
 	data, err := json.Marshal(stats)
@@ -39,9 +39,9 @@ func TestAPIMachineGPUStats_JSON(t *testing.T) {
 	err = json.Unmarshal(data, &parsed)
 	require.Nil(t, err)
 
-	assert.Equal(t, "NVIDIA A100 PCIe", parsed["name"])
-	assert.Equal(t, float64(40), parsed["gpus"])
-	assert.Equal(t, float64(5), parsed["machines"])
+	assert.Equal(t, "NVIDIA H100 SXM5 80GB", parsed["name"])
+	assert.Equal(t, float64(92), parsed["gpus"])
+	assert.Equal(t, float64(12), parsed["machines"])
 
 	var roundTrip APIMachineGPUStats
 	err = json.Unmarshal(data, &roundTrip)
@@ -66,13 +66,13 @@ func TestAPIMachineGPUStats_ZeroValues(t *testing.T) {
 
 func TestAPIMachineStatusBreakdown_JSON(t *testing.T) {
 	bd := APIMachineStatusBreakdown{
-		Total:        23,
+		Total:        12,
 		Initializing: 1,
-		Ready:        12,
-		InUse:        3,
-		Error:        2,
-		Maintenance:  2,
-		Unknown:      3,
+		Ready:        5,
+		InUse:        2,
+		Error:        1,
+		Maintenance:  1,
+		Unknown:      1,
 	}
 
 	data, err := json.Marshal(bd)
@@ -82,13 +82,13 @@ func TestAPIMachineStatusBreakdown_JSON(t *testing.T) {
 	err = json.Unmarshal(data, &parsed)
 	require.Nil(t, err)
 
-	assert.Equal(t, float64(23), parsed["total"])
+	assert.Equal(t, float64(12), parsed["total"])
 	assert.Equal(t, float64(1), parsed["initializing"])
-	assert.Equal(t, float64(12), parsed["ready"])
-	assert.Equal(t, float64(3), parsed["inUse"])
-	assert.Equal(t, float64(2), parsed["error"])
-	assert.Equal(t, float64(2), parsed["maintenance"])
-	assert.Equal(t, float64(3), parsed["unknown"])
+	assert.Equal(t, float64(5), parsed["ready"])
+	assert.Equal(t, float64(2), parsed["inUse"])
+	assert.Equal(t, float64(1), parsed["error"])
+	assert.Equal(t, float64(1), parsed["maintenance"])
+	assert.Equal(t, float64(1), parsed["unknown"])
 
 	var roundTrip APIMachineStatusBreakdown
 	err = json.Unmarshal(data, &roundTrip)
@@ -99,10 +99,10 @@ func TestAPIMachineStatusBreakdown_JSON(t *testing.T) {
 func TestAPIMachineInstanceTypeSummary_JSON(t *testing.T) {
 	summary := APIMachineInstanceTypeSummary{
 		Assigned: APIMachineStatusBreakdown{
-			Total: 20, Ready: 13, InUse: 3, Error: 2, Maintenance: 2,
+			Total: 29, Initializing: 2, Ready: 12, InUse: 6, Error: 3, Maintenance: 2, Unknown: 2,
 		},
 		Unassigned: APIMachineStatusBreakdown{
-			Total: 3, Ready: 2, Unknown: 1,
+			Total: 8, Ready: 2, Error: 1, Maintenance: 1, Unknown: 1,
 		},
 	}
 
@@ -114,11 +114,11 @@ func TestAPIMachineInstanceTypeSummary_JSON(t *testing.T) {
 	require.Nil(t, err)
 
 	assigned := parsed["assigned"].(map[string]interface{})
-	assert.Equal(t, float64(20), assigned["total"])
-	assert.Equal(t, float64(13), assigned["ready"])
+	assert.Equal(t, float64(29), assigned["total"])
+	assert.Equal(t, float64(12), assigned["ready"])
 
 	unassigned := parsed["unassigned"].(map[string]interface{})
-	assert.Equal(t, float64(3), unassigned["total"])
+	assert.Equal(t, float64(8), unassigned["total"])
 	assert.Equal(t, float64(1), unassigned["unknown"])
 
 	var roundTrip APIMachineInstanceTypeSummary
@@ -129,36 +129,38 @@ func TestAPIMachineInstanceTypeSummary_JSON(t *testing.T) {
 
 func TestAPIMachineInstanceTypeStats_JSON(t *testing.T) {
 	stats := APIMachineInstanceTypeStats{
-		ID:   "it-123",
-		Name: "cpu.x100",
+		ID:   "it-gpu-large",
+		Name: "gpu-large",
 		AssignedMachineStats: APIMachineStatusBreakdown{
-			Total: 8, Ready: 5, InUse: 1, Error: 1, Maintenance: 1,
+			Total: 12, Initializing: 1, Ready: 5, InUse: 2, Error: 1, Maintenance: 1, Unknown: 1,
 		},
-		Allocated:      45,
-		MaxAllocatable: 0,
+		Allocated:      7,
+		MaxAllocatable: 2,
 		UsedMachineStats: APIMachineStatusBreakdown{
-			Total: 3, InUse: 1, Error: 1, Maintenance: 1,
+			Total: 4, InUse: 2, Error: 1, Maintenance: 1,
 		},
 		Tenants: []APIMachineInstanceTypeTenant{
 			{
-				ID:        "t-1",
-				Name:      "tenant-a-org",
-				Allocated: 30,
+				ID:        "t-alpha",
+				Name:      "alpha-org",
+				Allocated: 6,
 				UsedMachineStats: APIMachineStatusBreakdown{
-					Total: 3, InUse: 1, Error: 1, Maintenance: 1,
+					Total: 3, InUse: 2, Error: 1,
 				},
 				Allocations: []APIMachineInstanceTypeTenantAllocation{
-					{ID: "a-1", Name: "alloc-a-1", Allocated: 20},
-					{ID: "a-2", Name: "alloc-a-2", Allocated: 10},
+					{ID: "a-1", Name: "training-reserved", Allocated: 4},
+					{ID: "a-2", Name: "inference-ondemand", Allocated: 2},
 				},
 			},
 			{
-				ID:               "t-2",
-				Name:             "tenant-b-org",
-				Allocated:        15,
-				UsedMachineStats: APIMachineStatusBreakdown{},
+				ID:        "t-beta",
+				Name:      "beta-org",
+				Allocated: 1,
+				UsedMachineStats: APIMachineStatusBreakdown{
+					Total: 1, Maintenance: 1,
+				},
 				Allocations: []APIMachineInstanceTypeTenantAllocation{
-					{ID: "b-1", Name: "alloc-b-1", Allocated: 15},
+					{ID: "a-3", Name: "simulation-pool", Allocated: 1},
 				},
 			},
 		},
@@ -171,39 +173,39 @@ func TestAPIMachineInstanceTypeStats_JSON(t *testing.T) {
 	err = json.Unmarshal(data, &parsed)
 	require.Nil(t, err)
 
-	assert.Equal(t, "it-123", parsed["id"])
-	assert.Equal(t, "cpu.x100", parsed["name"])
-	assert.Equal(t, float64(45), parsed["allocated"])
-	assert.Equal(t, float64(0), parsed["maxAllocatable"])
+	assert.Equal(t, "it-gpu-large", parsed["id"])
+	assert.Equal(t, "gpu-large", parsed["name"])
+	assert.Equal(t, float64(7), parsed["allocated"])
+	assert.Equal(t, float64(2), parsed["maxAllocatable"])
 
 	assignedStats := parsed["assignedMachineStats"].(map[string]interface{})
-	assert.Equal(t, float64(8), assignedStats["total"])
+	assert.Equal(t, float64(12), assignedStats["total"])
 	assert.Equal(t, float64(5), assignedStats["ready"])
-	assert.Equal(t, float64(1), assignedStats["inUse"])
+	assert.Equal(t, float64(2), assignedStats["inUse"])
 	assert.Equal(t, float64(1), assignedStats["error"])
 	assert.Equal(t, float64(1), assignedStats["maintenance"])
 
 	usedStats := parsed["usedMachineStats"].(map[string]interface{})
-	assert.Equal(t, float64(3), usedStats["total"])
-	assert.Equal(t, float64(1), usedStats["inUse"])
+	assert.Equal(t, float64(4), usedStats["total"])
+	assert.Equal(t, float64(2), usedStats["inUse"])
 	assert.Equal(t, float64(1), usedStats["error"])
 	assert.Equal(t, float64(1), usedStats["maintenance"])
 
 	tenants := parsed["tenants"].([]interface{})
 	assert.Equal(t, 2, len(tenants))
 
-	tenantA := tenants[0].(map[string]interface{})
-	assert.Equal(t, "tenant-a-org", tenantA["name"])
-	assert.Equal(t, float64(30), tenantA["allocated"])
+	alphaTenant := tenants[0].(map[string]interface{})
+	assert.Equal(t, "alpha-org", alphaTenant["name"])
+	assert.Equal(t, float64(6), alphaTenant["allocated"])
 
-	tenantAUsed := tenantA["usedMachineStats"].(map[string]interface{})
-	assert.Equal(t, float64(3), tenantAUsed["total"])
-	assert.Equal(t, float64(1), tenantAUsed["inUse"])
+	alphaUsed := alphaTenant["usedMachineStats"].(map[string]interface{})
+	assert.Equal(t, float64(3), alphaUsed["total"])
+	assert.Equal(t, float64(2), alphaUsed["inUse"])
 
-	allocs := tenantA["allocations"].([]interface{})
+	allocs := alphaTenant["allocations"].([]interface{})
 	assert.Equal(t, 2, len(allocs))
-	assert.Equal(t, "alloc-a-1", allocs[0].(map[string]interface{})["name"])
-	assert.Equal(t, float64(20), allocs[0].(map[string]interface{})["allocated"])
+	assert.Equal(t, "training-reserved", allocs[0].(map[string]interface{})["name"])
+	assert.Equal(t, float64(4), allocs[0].(map[string]interface{})["allocated"])
 
 	var roundTrip APIMachineInstanceTypeStats
 	err = json.Unmarshal(data, &roundTrip)
@@ -233,33 +235,33 @@ func TestAPIMachineInstanceTypeStats_EmptyTenants(t *testing.T) {
 
 func TestAPITenantInstanceTypeStats_JSON(t *testing.T) {
 	stats := APITenantInstanceTypeStats{
-		ID:             "tenant-1",
-		Org:            "tenant-a-org",
-		OrgDisplayName: "Tenant A Org",
+		ID:             "t-alpha",
+		Org:            "alpha-org",
+		OrgDisplayName: "Alpha Corp",
 		InstanceTypes: []APITenantInstanceTypeStatsEntry{
 			{
-				ID:        "it-1",
-				Name:      "cpu.x100",
-				Allocated: 30,
+				ID:        "it-gpu-large",
+				Name:      "gpu-large",
+				Allocated: 6,
 				UsedMachineStats: APIMachineStatusBreakdown{
-					Total: 3, InUse: 1, Error: 1, Maintenance: 1,
+					Total: 3, InUse: 2, Error: 1,
 				},
-				MaxAllocatable: 0,
+				MaxAllocatable: 2,
 				Allocations: []APITenantInstanceTypeAllocation{
-					{ID: "a-1", Name: "alloc-a-1", Total: 20},
-					{ID: "a-2", Name: "alloc-a-2", Total: 10},
+					{ID: "a-1", Name: "training-reserved", Total: 4},
+					{ID: "a-2", Name: "inference-ondemand", Total: 2},
 				},
 			},
 			{
-				ID:        "it-2",
-				Name:      "gpu.a100",
+				ID:        "it-gpu-small",
+				Name:      "gpu-small",
 				Allocated: 3,
 				UsedMachineStats: APIMachineStatusBreakdown{
 					Total: 2, InUse: 2,
 				},
-				MaxAllocatable: 2,
+				MaxAllocatable: 1,
 				Allocations: []APITenantInstanceTypeAllocation{
-					{ID: "a-1", Name: "alloc-a-1", Total: 3},
+					{ID: "a-1", Name: "training-reserved", Total: 3},
 				},
 			},
 		},
@@ -272,34 +274,33 @@ func TestAPITenantInstanceTypeStats_JSON(t *testing.T) {
 	err = json.Unmarshal(data, &parsed)
 	require.Nil(t, err)
 
-	assert.Equal(t, "tenant-1", parsed["id"])
-	assert.Equal(t, "tenant-a-org", parsed["org"])
-	assert.Equal(t, "Tenant A Org", parsed["orgDisplayName"])
+	assert.Equal(t, "t-alpha", parsed["id"])
+	assert.Equal(t, "alpha-org", parsed["org"])
+	assert.Equal(t, "Alpha Corp", parsed["orgDisplayName"])
 
 	instanceTypes := parsed["instanceTypes"].([]interface{})
 	assert.Equal(t, 2, len(instanceTypes))
 
-	cpuEntry := instanceTypes[0].(map[string]interface{})
-	assert.Equal(t, "cpu.x100", cpuEntry["name"])
-	assert.Equal(t, float64(30), cpuEntry["allocated"])
-	assert.Equal(t, float64(0), cpuEntry["maxAllocatable"])
+	gpuLEntry := instanceTypes[0].(map[string]interface{})
+	assert.Equal(t, "gpu-large", gpuLEntry["name"])
+	assert.Equal(t, float64(6), gpuLEntry["allocated"])
+	assert.Equal(t, float64(2), gpuLEntry["maxAllocatable"])
 
-	cpuUsed := cpuEntry["usedMachineStats"].(map[string]interface{})
-	assert.Equal(t, float64(3), cpuUsed["total"])
-	assert.Equal(t, float64(1), cpuUsed["inUse"])
-	assert.Equal(t, float64(1), cpuUsed["error"])
-	assert.Equal(t, float64(1), cpuUsed["maintenance"])
+	gpuLUsed := gpuLEntry["usedMachineStats"].(map[string]interface{})
+	assert.Equal(t, float64(3), gpuLUsed["total"])
+	assert.Equal(t, float64(2), gpuLUsed["inUse"])
+	assert.Equal(t, float64(1), gpuLUsed["error"])
 
-	gpuEntry := instanceTypes[1].(map[string]interface{})
-	assert.Equal(t, "gpu.a100", gpuEntry["name"])
-	gpuUsed := gpuEntry["usedMachineStats"].(map[string]interface{})
-	assert.Equal(t, float64(2), gpuUsed["total"])
-	assert.Equal(t, float64(2), gpuUsed["inUse"])
+	gpuSEntry := instanceTypes[1].(map[string]interface{})
+	assert.Equal(t, "gpu-small", gpuSEntry["name"])
+	gpuSUsed := gpuSEntry["usedMachineStats"].(map[string]interface{})
+	assert.Equal(t, float64(2), gpuSUsed["total"])
+	assert.Equal(t, float64(2), gpuSUsed["inUse"])
 
-	cpuAllocs := cpuEntry["allocations"].([]interface{})
-	assert.Equal(t, 2, len(cpuAllocs))
-	assert.Equal(t, "alloc-a-1", cpuAllocs[0].(map[string]interface{})["name"])
-	assert.Equal(t, float64(20), cpuAllocs[0].(map[string]interface{})["total"])
+	gpuLAllocs := gpuLEntry["allocations"].([]interface{})
+	assert.Equal(t, 2, len(gpuLAllocs))
+	assert.Equal(t, "training-reserved", gpuLAllocs[0].(map[string]interface{})["name"])
+	assert.Equal(t, float64(4), gpuLAllocs[0].(map[string]interface{})["total"])
 
 	var roundTrip APITenantInstanceTypeStats
 	err = json.Unmarshal(data, &roundTrip)


### PR DESCRIPTION

Fixes
#182 - Machine instance type stats endpoint only returns first 20 objects Fixes 
#183 - Per-tenant instance type allocation stats only includes partial list Fixes 
#184 - Per-instance-type machines stats treats decommissioned as allocatable

Changes:
- Fix pagination issue where instance type stats only returned first 20 results by explicitly using TotalLimit instead of default limit