### PR TITLE
chore: Move dynamic TLS handler to common package

### DIFF
--- a/api/internal/config/temporal.go
+++ b/api/internal/config/temporal.go
@@ -21,7 +21,7 @@ import (
 	"crypto/tls"
 	"fmt"
 
-	"github.com/nvidia/bare-metal-manager-rest/cert-manager/pkg/core"
+	ctls "github.com/nvidia/bare-metal-manager-rest/common/pkg/tls"
 	cwfns "github.com/nvidia/bare-metal-manager-rest/workflow/pkg/namespace"
 )
 
@@ -35,7 +35,7 @@ type TemporalConfig struct {
 	EncryptionKey string
 	TLSenabled    bool
 	ClientTLSCfg  *tls.Config
-	dynTLS        *core.DynTLSCfg
+	dynTLS        *ctls.DynTLSCfg
 }
 
 // GetHostPort returns the concatenated host & port
@@ -51,13 +51,13 @@ func (tcfg *TemporalConfig) Close() {
 
 // NewTemporalConfig initializes and returns a configuration object for managing Temporal
 func NewTemporalConfig(host string, port int, serverName string, namespace string, queue string, encryptionKey string, tlsEnabled bool, certPath string, keyPath string, caPath string) (*TemporalConfig, error) {
-	var dynTLS *core.DynTLSCfg
+	var dynTLS *ctls.DynTLSCfg
 	var clientTLSCfg *tls.Config
 
 	if tlsEnabled {
 		var err error
 
-		dynTLS, err = core.NewDynTLSCfg(keyPath, certPath, caPath)
+		dynTLS, err = ctls.NewDynTLSCfg(keyPath, certPath, caPath)
 		if err != nil {
 			return nil, err
 		}

--- a/api/internal/config/temporal_test.go
+++ b/api/internal/config/temporal_test.go
@@ -23,8 +23,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/nvidia/bare-metal-manager-rest/cert-manager/pkg/core"
 	"github.com/stretchr/testify/assert"
+
+	ctls "github.com/nvidia/bare-metal-manager-rest/common/pkg/tls"
 )
 
 func TestNewTemporalConfig(t *testing.T) {
@@ -40,7 +41,7 @@ func TestNewTemporalConfig(t *testing.T) {
 	keyPath, certPath := SetupTestCerts(t)
 	defer os.Remove(keyPath)
 	defer os.Remove(certPath)
-	d, err := core.NewDynTLSCfg(keyPath, certPath, certPath)
+	d, err := ctls.NewDynTLSCfg(keyPath, certPath, certPath)
 	assert.NoError(t, err)
 	defer d.Close()
 

--- a/common/pkg/tls/dynamic.go
+++ b/common/pkg/tls/dynamic.go
@@ -15,13 +15,13 @@
  * limitations under the License.
  */
 
-package core
+package tls
 
 import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -65,7 +65,7 @@ func NewDynTLSCfg(keyPath, certPath, cacertPath string) (*DynTLSCfg, error) {
 		cacertPath: cacertPath,
 	}
 
-	caCert, err := ioutil.ReadFile(cacertPath)
+	caCert, err := os.ReadFile(cacertPath)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func (d *DynTLSCfg) ClientCfg() *tls.Config {
 		d.Lock()
 		defer d.Unlock()
 		if d.err != nil {
-			d.logger.Errorf("GetClientCertificate %v", d.err)
+			d.logger.Errorf("GetClientCertificate: %v", d.err)
 			return nil, d.err
 		}
 
@@ -171,10 +171,10 @@ func (d *DynTLSCfg) refresh() {
 	defer d.Unlock()
 
 	// read ca
-	caCert, err := ioutil.ReadFile(d.cacertPath)
+	caCert, err := os.ReadFile(d.cacertPath)
 	if err != nil {
 		d.err = err
-		d.logger.Errorf("Can't read ca  from %s - %v", d.cacertPath, err)
+		d.logger.Errorf("Failed to read CA certificate from %s - %v", d.cacertPath, err)
 		return
 	}
 
@@ -182,14 +182,14 @@ func (d *DynTLSCfg) refresh() {
 		if d.isClient {
 			// for client config, we don't have a way to update CA
 			// just log a warning
-			d.logger.Warnf("CA has changed, clients may not work without restart")
+			d.logger.Warn("CA has changed, clients will likely not work without restart")
 		} else {
 			caCertPool := x509.NewCertPool()
 			caCertPool.AppendCertsFromPEM(caCert)
 			d.caCertPool = caCertPool
 			d.cachedCa = caCert
 			d.cacheUpdated = true
-			d.logger.Infof("Updated server CA certificate")
+			d.logger.Info("Updated server CA certificate")
 		}
 	}
 
@@ -197,12 +197,12 @@ func (d *DynTLSCfg) refresh() {
 	cert, err := tls.LoadX509KeyPair(d.certPath, d.keyPath)
 	if err != nil {
 		d.err = err
-		d.logger.Errorf("Can't from %s, %s - %v", d.certPath, d.keyPath, err)
+		d.logger.Errorf("Failed to read certificate and key from %s, %s - %v", d.certPath, d.keyPath, err)
 		return
 	}
 
 	if !reflect.DeepEqual(&cert, d.cachedCert) {
-		d.logger.Infof("Updated certificate")
+		d.logger.Info("Updated certificate")
 		d.cachedCert = &cert
 		d.cacheUpdated = true
 	}

--- a/common/pkg/tls/dynamic_test.go
+++ b/common/pkg/tls/dynamic_test.go
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package core
+package tls
 
 import (
 	"crypto/tls"

--- a/workflow/internal/config/temporal.go
+++ b/workflow/internal/config/temporal.go
@@ -21,7 +21,7 @@ import (
 	"crypto/tls"
 	"fmt"
 
-	"github.com/nvidia/bare-metal-manager-rest/cert-manager/pkg/core"
+	ctls "github.com/nvidia/bare-metal-manager-rest/common/pkg/tls"
 	cwfns "github.com/nvidia/bare-metal-manager-rest/workflow/pkg/namespace"
 )
 
@@ -35,7 +35,7 @@ type TemporalConfig struct {
 	EncryptionKey string
 	TLSEnabled    bool
 	ClientTLSCfg  *tls.Config
-	dynTLS        *core.DynTLSCfg
+	dynTLS        *ctls.DynTLSCfg
 }
 
 // GetHostPort returns the concatenated host & port
@@ -51,13 +51,13 @@ func (tcfg *TemporalConfig) Close() {
 
 // NewTemporalConfig initializes and returns a configuration object for managing Temporal
 func NewTemporalConfig(host string, port int, serverName string, namespace string, queue string, encryptionKey string, tlsEnabled bool, certPath string, keyPath string, caPath string) (*TemporalConfig, error) {
-	var dynTLS *core.DynTLSCfg
+	var dynTLS *ctls.DynTLSCfg
 	var clientTLSCfg *tls.Config
 
 	if tlsEnabled {
 		var err error
 
-		dynTLS, err = core.NewDynTLSCfg(keyPath, certPath, caPath)
+		dynTLS, err = ctls.NewDynTLSCfg(keyPath, certPath, caPath)
 		if err != nil {
 			return nil, err
 		}

--- a/workflow/internal/config/temporal_test.go
+++ b/workflow/internal/config/temporal_test.go
@@ -23,8 +23,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/nvidia/bare-metal-manager-rest/cert-manager/pkg/core"
 	"github.com/stretchr/testify/assert"
+
+	ctls "github.com/nvidia/bare-metal-manager-rest/common/pkg/tls"
 )
 
 func TestNewTemporalConfig(t *testing.T) {
@@ -40,7 +41,7 @@ func TestNewTemporalConfig(t *testing.T) {
 	keyPath, certPath := SetupTestCerts(t)
 	defer os.Remove(keyPath)
 	defer os.Remove(certPath)
-	d, err := core.NewDynTLSCfg(keyPath, certPath, certPath)
+	d, err := ctls.NewDynTLSCfg(keyPath, certPath, certPath)
 	assert.NoError(t, err)
 	defer d.Close()
 


### PR DESCRIPTION
## Description
Moves dynamic TLS loader from Cert Manager to Common package. Dynamic TLS loader is used by API/Workflow and will be used by the next-gen Site Agent.

## Type of Change
- [ ] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [x] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in Github workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
- [x] **API** - API models or endpoints updated
- [x] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [x] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
None
