### PR TITLE
refactor: Create wrapped errors instead of formatted ones

### DIFF
--- a/auth/pkg/authentication/keycloak.go
+++ b/auth/pkg/authentication/keycloak.go
@@ -63,7 +63,7 @@ func (k *KeycloakAuthService) getIDPAliasForDomain(ctx context.Context, adminTok
 	// Get all identity providers for the realm
 	idps, err := k.client.GetIdentityProviders(ctx, adminToken, k.config.Realm)
 	if err != nil {
-		return "", fmt.Errorf("failed to get identity providers: %v", err)
+		return "", fmt.Errorf("failed to get identity providers: %w", err)
 	}
 
 	// Look for an IDP that matches the email domain
@@ -110,7 +110,7 @@ func (k *KeycloakAuthService) InitiateAuthFlow(ctx context.Context, email, redir
 	token, err := k.client.GetToken(ctx, k.config.Realm, tokenOptions)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to get admin token using client credentials")
-		return nil, fmt.Errorf("failed to get admin token using client credentials: %v", err)
+		return nil, fmt.Errorf("failed to get admin token using client credentials: %w", err)
 	}
 
 	adminToken := token.AccessToken
@@ -119,7 +119,7 @@ func (k *KeycloakAuthService) InitiateAuthFlow(ctx context.Context, email, redir
 	idpAlias, err := k.getIDPAliasForDomain(ctx, adminToken, emailDomain)
 	if err != nil {
 		log.Error().Err(err).Str("domain", emailDomain).Msg("Failed to find IDP alias for domain")
-		return nil, fmt.Errorf("failed to find identity provider for domain %s: %v", emailDomain, err)
+		return nil, fmt.Errorf("failed to find identity provider for domain %s: %w", emailDomain, err)
 	}
 
 	// Construct simplified Keycloak authorization URL with kc_idp_hint
@@ -162,7 +162,7 @@ func (k *KeycloakAuthService) ExchangeCodeForTokens(ctx context.Context, code st
 
 	tokens, err := k.client.GetToken(ctx, k.config.Realm, tokenOptions)
 	if err != nil {
-		return nil, fmt.Errorf("failed to exchange authorization code: %v", err)
+		return nil, fmt.Errorf("failed to exchange authorization code: %w", err)
 	}
 
 	return &model.APITokenResponse{
@@ -177,7 +177,7 @@ func (k *KeycloakAuthService) ExchangeCodeForTokens(ctx context.Context, code st
 func (k *KeycloakAuthService) GetUserInfo(ctx context.Context, accessToken string) (*gocloak.UserInfo, error) {
 	userInfo, err := k.client.GetUserInfo(ctx, accessToken, k.config.Realm)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get user info: %v", err)
+		return nil, fmt.Errorf("failed to get user info: %w", err)
 	}
 	return userInfo, nil
 }
@@ -192,7 +192,7 @@ func (k *KeycloakAuthService) RefreshAccessToken(ctx context.Context, refreshTok
 		k.config.Realm,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to refresh token: %v", err)
+		return nil, fmt.Errorf("failed to refresh token: %w", err)
 	}
 
 	return &model.APITokenResponse{
@@ -233,7 +233,7 @@ func (k *KeycloakAuthService) ClientCredentialsAuth(ctx context.Context, clientI
 			Err(err).
 			Str("client_id", clientID).
 			Msg("Failed to authenticate using client credentials")
-		return nil, fmt.Errorf("failed to authenticate using client credentials: %v", err)
+		return nil, fmt.Errorf("failed to authenticate using client credentials: %w", err)
 	}
 
 	return &model.APITokenResponse{

--- a/cert-manager/pkg/pki/issuer.go
+++ b/cert-manager/pkg/pki/issuer.go
@@ -72,7 +72,7 @@ func NewNativeCertificateIssuer(opts NativeCertificateIssuerOptions) (types.Cert
 			}, nil
 		}
 		if loadErr != nil {
-			loadErr = fmt.Errorf("%v; alternate path (%s): %w", loadErr, opts.AltCACertFile, err)
+			loadErr = fmt.Errorf("%w; alternate path (%s): %w", loadErr, opts.AltCACertFile, err)
 		} else {
 			loadErr = fmt.Errorf("alternate path (%s): %w", opts.AltCACertFile, err)
 		}

--- a/powershelf-manager/pkg/firmwaremanager/firmware_manager.go
+++ b/powershelf-manager/pkg/firmwaremanager/firmware_manager.go
@@ -247,7 +247,7 @@ func (manager *Manager) handleOnePmcUpdate(ctx context.Context, pmc *pmc.PMC, up
 		currentFwVersion, err := getFwVersion(ctx, pmc, update.Component)
 		if err != nil {
 			// Do not transition to a failed state here b/c this may be transient. instead, wait for the timeout to handle updating that transition
-			return powershelf.FirmwareStateVerifying, fmt.Errorf("failed to query fw version of %v on PMC %v: %v", update.Component, pmc, err)
+			return powershelf.FirmwareStateVerifying, fmt.Errorf("failed to query fw version of %v on PMC %v: %w", update.Component, pmc, err)
 		} else {
 			if currentFwVersion.String() == update.VersionTo {
 				log.Printf("successfully updated firmware of of component %v for powershelf with PMC MAC %v from %v to %v", update.Component, pmc, update.VersionFrom, update.VersionTo)

--- a/powershelf-manager/pkg/firmwaremanager/firmware_registry.go
+++ b/powershelf-manager/pkg/firmwaremanager/firmware_registry.go
@@ -47,7 +47,7 @@ func newRegistry(ctx context.Context, c cdb.Config) (*Registry, error) {
 	if err := migrations.MigrateWithDB(ctx, session.DB); err != nil {
 		session.Close()
 
-		return nil, fmt.Errorf("failed to run migrations: %v", err)
+		return nil, fmt.Errorf("failed to run migrations: %w", err)
 	}
 
 	return &Registry{session}, nil

--- a/powershelf-manager/pkg/pmcmanager/pmcmanager.go
+++ b/powershelf-manager/pkg/pmcmanager/pmcmanager.go
@@ -63,7 +63,7 @@ func (pm *PmcManager) Stop(ctx context.Context) error {
 
 func (pm *PmcManager) Register(ctx context.Context, pmc *pmc.PMC) error {
 	if err := pm.registry.RegisterPmc(ctx, pmc); err != nil {
-		return fmt.Errorf("failed to register PMC (%s): %v", pmc.GetMac().String(), err)
+		return fmt.Errorf("failed to register PMC (%s): %w", pmc.GetMac().String(), err)
 	}
 
 	return pm.credentialManager.Put(ctx, pmc.GetMac(), pmc.GetCredential())
@@ -73,12 +73,12 @@ func (pm *PmcManager) Register(ctx context.Context, pmc *pmc.PMC) error {
 func (pm *PmcManager) GetPmc(ctx context.Context, mac net.HardwareAddr) (*pmc.PMC, error) {
 	pmc, err := pm.registry.GetPmc(ctx, mac)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get PMC (%s) from registry: %v", mac.String(), err)
+		return nil, fmt.Errorf("failed to get PMC (%s) from registry: %w", mac.String(), err)
 	}
 
 	creds, err := pm.credentialManager.Get(context.Background(), mac)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get credentials for PMC (%s): %v", mac.String(), err)
+		return nil, fmt.Errorf("failed to get credentials for PMC (%s): %w", mac.String(), err)
 	}
 
 	pmc.SetCredential(creds)
@@ -89,13 +89,13 @@ func (pm *PmcManager) GetPmc(ctx context.Context, mac net.HardwareAddr) (*pmc.PM
 func (pm *PmcManager) GetAllPmcs(ctx context.Context) ([]*pmc.PMC, error) {
 	pmcs, err := pm.registry.GetAllPmcs(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get PMCs from registry: %v", err)
+		return nil, fmt.Errorf("failed to get PMCs from registry: %w", err)
 	}
 
 	for _, pmc := range pmcs {
 		creds, err := pm.credentialManager.Get(context.Background(), pmc.MAC)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get credentials for PMC (%s): %v", pmc.MAC.String(), err)
+			return nil, fmt.Errorf("failed to get credentials for PMC (%s): %w", pmc.MAC.String(), err)
 		}
 		pmc.SetCredential(creds)
 	}

--- a/powershelf-manager/pkg/pmcregistry/postgres.go
+++ b/powershelf-manager/pkg/pmcregistry/postgres.go
@@ -49,7 +49,7 @@ func newPostgresRegistry(ctx context.Context, c cdb.Config) (*PostgresPmcRegistr
 	if err := migrations.MigrateWithDB(ctx, session.DB); err != nil {
 		session.Close()
 
-		return nil, fmt.Errorf("failed to run migrations: %v", err)
+		return nil, fmt.Errorf("failed to run migrations: %w", err)
 	}
 
 	return &PostgresPmcRegistry{session}, nil

--- a/powershelf-manager/pkg/powershelfmanager/powershelfmanager.go
+++ b/powershelf-manager/pkg/powershelfmanager/powershelfmanager.go
@@ -43,7 +43,7 @@ type PowershelfManager struct {
 func New(ctx context.Context, c Config) (*PowershelfManager, error) {
 	credentialManager, err := credentials.New(ctx, &c.CredentialConf)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize credential manager (conf: %v): %v", c, err)
+		return nil, fmt.Errorf("failed to initialize credential manager (conf: %v): %w", c, err)
 	}
 
 	var registry pmcregistry.PmcRegistry
@@ -56,14 +56,14 @@ func New(ctx context.Context, c Config) (*PowershelfManager, error) {
 
 		registry, err = pmcregistry.New(ctx, &c.PmcRegistryConf)
 		if err != nil {
-			return nil, fmt.Errorf("failed to initialize persistent PMC registry (conf: %v): %v", c, err)
+			return nil, fmt.Errorf("failed to initialize persistent PMC registry (conf: %v): %w", c, err)
 		}
 	case DatastoreTypeInMemory:
 		log.Printf("Initializing Powershelf Manager with an in-memory PMC registry")
 
 		registry, err = pmcregistry.New(ctx, &c.PmcRegistryConf)
 		if err != nil {
-			return nil, fmt.Errorf("failed to initialize in-memory PMC registry (conf: %v): %v", c, err)
+			return nil, fmt.Errorf("failed to initialize in-memory PMC registry (conf: %v): %w", c, err)
 		}
 	default:
 		return nil, fmt.Errorf("unsupported PMC registry type %v", c.DSType)
@@ -72,7 +72,7 @@ func New(ctx context.Context, c Config) (*PowershelfManager, error) {
 	pmcManager := pmcmanager.New(registry, credentialManager)
 	firmwareManager, err := firmwaremanager.New(ctx, c.PmcRegistryConf.DSConf, pmcManager, false)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize firmware manager (conf: %v): %v", c, err)
+		return nil, fmt.Errorf("failed to initialize firmware manager (conf: %v): %w", c, err)
 	}
 
 	return &PowershelfManager{
@@ -123,7 +123,7 @@ func (pm *PowershelfManager) RegisterPmc(ctx context.Context, pmc *pmc.PMC) erro
 func (pm *PowershelfManager) ListAvailableFirmware(ctx context.Context, mac net.HardwareAddr) ([]firmwaremanager.FirmwareUpgrade, error) {
 	pmc, err := pm.GetPmc(ctx, mac)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get query PMC (%s): %v", mac.String(), err)
+		return nil, fmt.Errorf("failed to get query PMC (%s): %w", mac.String(), err)
 	}
 
 	return pm.FirmwareManager.ListAvailableFirmware(ctx, pmc)
@@ -134,7 +134,7 @@ func (pm *PowershelfManager) ListAvailableFirmware(ctx context.Context, mac net.
 func (pm *PowershelfManager) UpgradeFirmware(ctx context.Context, mac net.HardwareAddr, component powershelf.Component, targetFwVersion string) error {
 	pmc, err := pm.GetPmc(ctx, mac)
 	if err != nil {
-		return fmt.Errorf("failed to get query PMC (%s): %v", mac.String(), err)
+		return fmt.Errorf("failed to get query PMC (%s): %w", mac.String(), err)
 	}
 
 	return pm.FirmwareManager.Upgrade(ctx, pmc, component, targetFwVersion)

--- a/rla/internal/carbideapi/grpc.go
+++ b/rla/internal/carbideapi/grpc.go
@@ -66,7 +66,7 @@ func NewClient(grpcTimeout time.Duration) (Client, error) {
 
 	conn, err := grpc.NewClient(carbideURL, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 	if err != nil {
-		return nil, fmt.Errorf("Unable to connect to carbide-api: %v", err)
+		return nil, fmt.Errorf("Unable to connect to carbide-api: %w", err)
 	}
 
 	return &grpcClient{gclient: pb.NewForgeClient(conn), grpcTimeout: grpcTimeout}, nil

--- a/rla/internal/certs/certs.go
+++ b/rla/internal/certs/certs.go
@@ -41,12 +41,12 @@ func TLSConfig() (tlsConfig *tls.Config, certDir string, err error) {
 
 	clientCert, err := tls.LoadX509KeyPair(certDir+"/tls.crt", certDir+"/tls.key")
 	if err != nil {
-		return nil, certDir, fmt.Errorf("Invalid certs present: %v", err)
+		return nil, certDir, fmt.Errorf("Invalid certs present: %w", err)
 	}
 
 	certPool := x509.NewCertPool()
 	if !certPool.AppendCertsFromPEM(caCert) {
-		return nil, certDir, fmt.Errorf("Invalid CA cert present: %v", err)
+		return nil, certDir, fmt.Errorf("Invalid CA cert present: %w", err)
 	}
 
 	return &tls.Config{

--- a/rla/internal/inventorysync/inventory.go
+++ b/rla/internal/inventorysync/inventory.go
@@ -330,7 +330,7 @@ func syncMachineIDs(ctx context.Context, config *config.Config, pool *cdb.Sessio
 		if err := pool.RunInTx(ctx, func(ctx context.Context, tx bun.Tx) error {
 			for _, cur := range toUpdate {
 				if err := cur.SetComponentIDBySerial(ctx, tx); err != nil {
-					return fmt.Errorf("Unable to update machine ID: %v", err)
+					return fmt.Errorf("Unable to update machine ID: %w", err)
 				}
 			}
 			return nil
@@ -369,7 +369,7 @@ func syncPowerStates(ctx context.Context, pool *cdb.Session, carbideClient carbi
 		if err := pool.RunInTx(ctx, func(ctx context.Context, tx bun.Tx) error {
 			for _, cur := range toUpdate {
 				if err := cur.SetPowerStateByComponentID(ctx, tx); err != nil {
-					return fmt.Errorf("Unable to update power state: %v", err)
+					return fmt.Errorf("Unable to update power state: %w", err)
 				}
 			}
 			return nil

--- a/rla/internal/nsmapi/grpc.go
+++ b/rla/internal/nsmapi/grpc.go
@@ -55,7 +55,7 @@ func NewClient(grpcTimeout time.Duration) (Client, error) {
 
 	conn, err := grpc.NewClient(nsmURL, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 	if err != nil {
-		return nil, fmt.Errorf("Unable to connect to NV-Switch Manager: %v", err)
+		return nil, fmt.Errorf("Unable to connect to NV-Switch Manager: %w", err)
 	}
 
 	return &grpcClient{

--- a/rla/internal/psmapi/grpc.go
+++ b/rla/internal/psmapi/grpc.go
@@ -66,7 +66,7 @@ func NewClient(grpcTimeout time.Duration) (Client, error) {
 
 	conn, err := grpc.NewClient(psmURL, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 	if err != nil {
-		return nil, fmt.Errorf("Unable to connect to PSM: %v", err)
+		return nil, fmt.Errorf("Unable to connect to PSM: %w", err)
 	}
 
 	return &grpcClient{

--- a/rla/internal/service/server_impl.go
+++ b/rla/internal/service/server_impl.go
@@ -411,14 +411,14 @@ func (rs *RLAServerImpl) GetListOfRacks(
 ) (*pb.GetListOfRacksResponse, error) {
 	pg := protobuf.PaginationFrom(req.GetPagination())
 	if err := pg.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid pagination information: %v", err)
+		return nil, fmt.Errorf("invalid pagination information: %w", err)
 	}
 
 	var orderBy *dbquery.OrderBy
 	if req.GetOrderBy() != nil {
 		orderBy = protobuf.OrderByFrom(req.GetOrderBy())
 		if err := orderBy.Validate(); err != nil {
-			return nil, fmt.Errorf("invalid order by: %v", err)
+			return nil, fmt.Errorf("invalid order by: %w", err)
 		}
 	}
 
@@ -434,7 +434,7 @@ func (rs *RLAServerImpl) GetListOfRacks(
 			}
 			fieldName, queryInfo, err := protobuf.FilterFrom(filter)
 			if err != nil {
-				return nil, fmt.Errorf("invalid filter: %v", err)
+				return nil, fmt.Errorf("invalid filter: %w", err)
 			}
 			if queryInfo == nil {
 				continue
@@ -544,7 +544,7 @@ func (rs *RLAServerImpl) GetListOfNVLDomains(
 ) (*pb.GetListOfNVLDomainsResponse, error) {
 	pg := protobuf.PaginationFrom(req.GetPagination())
 	if err := pg.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid pagination information: %v", err)
+		return nil, fmt.Errorf("invalid pagination information: %w", err)
 	}
 
 	if req.GetInfo() == nil {
@@ -881,7 +881,7 @@ func (rs *RLAServerImpl) ListTasks(
 
 	pagination := protobuf.PaginationFrom(req.GetPagination())
 	if err := pagination.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid pagination information: %v", err)
+		return nil, fmt.Errorf("invalid pagination information: %w", err)
 	}
 
 	tasks, total, err := rs.taskStore.ListTasks(ctx, options, pagination)
@@ -1260,14 +1260,14 @@ func (rs *RLAServerImpl) GetComponents(
 ) (*pb.GetComponentsResponse, error) {
 	pg := protobuf.PaginationFrom(req.GetPagination())
 	if err := pg.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid pagination information: %v", err)
+		return nil, fmt.Errorf("invalid pagination information: %w", err)
 	}
 
 	var orderBy *dbquery.OrderBy
 	if req.GetOrderBy() != nil {
 		orderBy = protobuf.OrderByFrom(req.GetOrderBy())
 		if err := orderBy.Validate(); err != nil {
-			return nil, fmt.Errorf("invalid order by: %v", err)
+			return nil, fmt.Errorf("invalid order by: %w", err)
 		}
 	}
 
@@ -1284,7 +1284,7 @@ func (rs *RLAServerImpl) GetComponents(
 			}
 			fieldName, queryInfo, err := protobuf.FilterFrom(filter)
 			if err != nil {
-				return nil, fmt.Errorf("invalid filter: %v", err)
+				return nil, fmt.Errorf("invalid filter: %w", err)
 			}
 			if queryInfo == nil {
 				continue
@@ -1411,14 +1411,14 @@ func (rs *RLAServerImpl) ValidateComponents(
 ) (*pb.ValidateComponentsResponse, error) {
 	pg := protobuf.PaginationFrom(req.GetPagination())
 	if err := pg.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid pagination information: %v", err)
+		return nil, fmt.Errorf("invalid pagination information: %w", err)
 	}
 
 	var orderBy *dbquery.OrderBy
 	if req.GetOrderBy() != nil {
 		orderBy = protobuf.OrderByFrom(req.GetOrderBy())
 		if err := orderBy.Validate(); err != nil {
-			return nil, fmt.Errorf("invalid order by: %v", err)
+			return nil, fmt.Errorf("invalid order by: %w", err)
 		}
 	}
 
@@ -1435,7 +1435,7 @@ func (rs *RLAServerImpl) ValidateComponents(
 			}
 			fieldName, queryInfo, err := protobuf.FilterFrom(filter)
 			if err != nil {
-				return nil, fmt.Errorf("invalid filter: %v", err)
+				return nil, fmt.Errorf("invalid filter: %w", err)
 			}
 			if queryInfo == nil {
 				continue

--- a/rla/internal/service/service.go
+++ b/rla/internal/service/service.go
@@ -51,14 +51,14 @@ func New(ctx context.Context, c Config) (*Service, error) {
 	// 1. Create shared PostgreSQL connection
 	session, err := cdb.NewSessionFromConfig(ctx, c.DBConf)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create database connection: %v", err)
+		return nil, fmt.Errorf("failed to create database connection: %w", err)
 	}
 
 	// Run migrations
 	if err := migrations.MigrateWithDB(ctx, session.DB); err != nil {
 		session.Close()
 
-		return nil, fmt.Errorf("failed to run migrations: %v", err)
+		return nil, fmt.Errorf("failed to run migrations: %w", err)
 	}
 
 	// 2. Create stores (Storage Layer)
@@ -101,14 +101,14 @@ func (s *Service) Start(ctx context.Context) error {
 	log.Info().Msg("Rule resolver ready (will query DB for operation rules)")
 
 	if err := s.inventoryManager.Start(ctx); err != nil {
-		return fmt.Errorf("failed to start inventory manager: %v", err)
+		return fmt.Errorf("failed to start inventory manager: %w", err)
 	}
 
 	log.Info().Msg("Inventory manager started")
 
 	if s.taskManager != nil {
 		if err := s.taskManager.Start(ctx); err != nil {
-			return fmt.Errorf("failed to start task manager: %v", err)
+			return fmt.Errorf("failed to start task manager: %w", err)
 		}
 
 		log.Info().Msg("Task manager started")

--- a/rla/internal/task/executor/temporalworkflow/activity/activity.go
+++ b/rla/internal/task/executor/temporalworkflow/activity/activity.go
@@ -201,7 +201,7 @@ func validAndGetComponentManager(
 	target common.Target,
 ) (componentmanager.ComponentManager, error) {
 	if err := target.Validate(); err != nil {
-		return nil, fmt.Errorf("target is invalid: %v", err)
+		return nil, fmt.Errorf("target is invalid: %w", err)
 	}
 
 	return GetComponentManager(target.Type), nil

--- a/rla/internal/task/executor/temporalworkflow/manager/helpers.go
+++ b/rla/internal/task/executor/temporalworkflow/manager/helpers.go
@@ -76,7 +76,7 @@ func executeWorkflow(
 		params.info,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to execute workflow: %v", err)
+		return nil, fmt.Errorf("failed to execute workflow: %w", err)
 	}
 
 	executionID := &common.ExecutionID{
@@ -89,14 +89,14 @@ func executeWorkflow(
 	encodedExecutionID, err := executionID.Encode()
 	if err != nil {
 		return nil, fmt.Errorf(
-			"failed to encode execution ID %s: %v", executionID.String(), err,
+			"failed to encode execution ID %s: %w", executionID.String(), err,
 		)
 	}
 
 	if !params.req.Async {
 		// For synchronous requests, block until the workflow is completed.
 		if err := r.Get(ctx, nil); err != nil {
-			return nil, fmt.Errorf("failed to get workflow result: %v", err)
+			return nil, fmt.Errorf("failed to get workflow result: %w", err)
 		}
 	}
 

--- a/rla/internal/task/executor/temporalworkflow/manager/manager.go
+++ b/rla/internal/task/executor/temporalworkflow/manager/manager.go
@@ -119,7 +119,7 @@ func (m *Manager) Start(ctx context.Context) error {
 	for queue, worker := range m.workers {
 		log.Info().Msgf("Starting temporal worker for queue %s", queue)
 		if err := worker.Start(); err != nil {
-			return fmt.Errorf("failed to start temporal worker: %v", err)
+			return fmt.Errorf("failed to start temporal worker: %w", err)
 		}
 		log.Info().Msgf("Temporal worker started for queue %s", queue)
 	}

--- a/rla/internal/task/executor/temporalworkflow/workflow/helpers.go
+++ b/rla/internal/task/executor/temporalworkflow/workflow/helpers.go
@@ -84,7 +84,7 @@ func updateFinishedTaskStatus(
 	}
 
 	if lerr := workflow.ExecuteActivity(ctx, "UpdateTaskStatus", arg).Get(ctx, nil); lerr != nil { //nolint
-		return errors.Join(err, fmt.Errorf("failed to update task status: %v", lerr))
+		return errors.Join(err, fmt.Errorf("failed to update task status: %w", lerr))
 	}
 
 	return err


### PR DESCRIPTION
## Description

I noticed there was a bit of each throughout the codebase. Sometimes we'll create a new error formatted from another one with `%v`, and other times we'll create a wrapped one with `%w`. Using `%w` gives us the same formatted message we'd get from if we just did `%v`, while also letting us look inside the error with things like `errors.Is()` and `errors.As()`. Nothing super crazy. I just noticed a bit of both and figured it would be good to standardize and make the benefits available.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [x] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in Github workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [ ] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
