### PR TITLE
chore: Improved handling of a few swallowed errors

### DIFF
--- a/cli/pkg/commands.go
+++ b/cli/pkg/commands.go
@@ -597,7 +597,11 @@ func clientFromContext(c *cli.Context) (*Client, error) {
 	if token == "" {
 		token = GetAuthToken(cfg)
 		if token == "" {
-			token, _ = AutoRefreshToken(cfg)
+			var refreshErr error
+			token, refreshErr = AutoRefreshToken(cfg)
+			if refreshErr != nil {
+				fmt.Fprintf(os.Stderr, "Warning: auto-refresh token failed: %v\n", refreshErr)
+			}
 		}
 	}
 

--- a/cli/tui/repl.go
+++ b/cli/tui/repl.go
@@ -317,7 +317,11 @@ func readLineWithSuggestions(s *Session, cmdNames []string) (string, error) {
 				fmt.Print("\r" + prompt + line + "\r\n")
 				restore()
 				chosen := selectFromHistory()
-				restore, _ = RawMode()
+				var rawErr error
+				restore, rawErr = RawMode()
+				if rawErr != nil {
+					fmt.Fprintf(os.Stderr, "Warning: failed to enter raw mode: %v\n", rawErr)
+				}
 				if chosen != "" {
 					line = chosen
 				}

--- a/rla/internal/task/executor/temporalworkflow/workflow/actions.go
+++ b/rla/internal/task/executor/temporalworkflow/workflow/actions.go
@@ -413,7 +413,9 @@ func executeWaitBringUpAction(actx actionExecutionContext) error {
 			)
 		}
 
-		_ = workflow.Sleep(ctx, pollInterval)
+		if err := workflow.Sleep(ctx, pollInterval); err != nil {
+			return fmt.Errorf("workflow sleep interrupted: %w", err)
+		}
 
 		var result activity.GetBringUpStateResult
 		err := workflow.ExecuteActivity(

--- a/workflow/pkg/activity/subnet/subnet.go
+++ b/workflow/pkg/activity/subnet/subnet.go
@@ -159,7 +159,9 @@ func (ms ManageSubnet) CreateSubnetViaSiteAgent(ctx context.Context, subnetID uu
 		statusMessage = "Failed to initiate Subnet provisioning on Site"
 	}
 
-	_ = ms.updateSubnetStatusInDB(ctx, nil, subnetID, &status, &statusMessage)
+	if updateErr := ms.updateSubnetStatusInDB(ctx, nil, subnetID, &status, &statusMessage); updateErr != nil {
+		logger.Warn().Err(updateErr).Msg("failed to update Subnet status in DB")
+	}
 
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to trigger site agent create Subnet workflow")
@@ -240,7 +242,9 @@ func (ms ManageSubnet) DeleteSubnetViaSiteAgent(ctx context.Context, subnetID uu
 
 	status := cdbm.SubnetStatusDeleting
 	statusMessage := "Deletion request was sent to the Site"
-	_ = ms.updateSubnetStatusInDB(ctx, nil, subnetID, &status, &statusMessage)
+	if updateErr := ms.updateSubnetStatusInDB(ctx, nil, subnetID, &status, &statusMessage); updateErr != nil {
+		logger.Warn().Err(updateErr).Msg("failed to update Subnet status in DB")
+	}
 
 	logger.Info().Str("Workflow ID", we.GetID()).Msg("triggered Site agent workflow to delete Subnet")
 


### PR DESCRIPTION
## Description

Also noticed this and wanted to take a peek. I think there miiight be a few swallowed errors that would be worth addressing (or at least logging?), but I'm not 100% sure how people feel about it.

**For `updateSubnetStatusInDB`**, it seemed like it would be good to log if we failed updating the subnet status (mainly for troubleshooting), so that gets logged now. **On line 346, we actually log AND roll back if `updateSubnetStatusInDB` failed, but I'm not sure if we want that behavior here too?**

**For the CLI**, it seemed like it would be good to let the user know that a token refresh failed (and why), BUT, it could also introduce additional noise in the CLI that we might not want?

**For the TUI**, we'd ignore if `RawMode()` fails, and the REPL would suddenly get wonky without any feedback to the user. Now it at least logs that it failed, so when things get wonky, the user knows why. I think we could even make `restore = func() {}` instead of `nil` to avoid an eventual panic if we wanted to.

**For `workflow/actions.go`**, we're ignoring errors from `workflow.Sleep` in one case, but checking for them in another case (line 230). In the case of us ignoring them (which could be a timeout, cancellation, shutdown, etc), it would of course mean the workflow will keep polling, even if it is supposed to have stopped, and might cause some unhappy side effects.

If we ignored `workflow.Sleep` on line 230 as well, I'd think maybe we didn't care, but I'm wondering if this is just a whoops, and we would want to capture the error here and return (so we could react to things like in the case of a cancellation or shutdown)?

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [x] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in Github workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [ ] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
