### PR TITLE
fix: Correct NSM binary path in Dockerfile for CI extraction

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,6 +21,7 @@
 - [ ] **Site Agent** - Site Agent updated
 - [ ] **RLA** - RLA service updated
 - [ ] **Powershelf Manager** - Powershelf Manager updated
+- [ ] **NVSwitch Manager** - NVSwitch Manager updated
 
 ## Related Issues (Optional)
 <!-- If applicable, provide GitHub Issue. -->

--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -241,7 +241,7 @@ jobs:
       runner: ${{ inputs.runner }}
       service_name: carbide-nsm
       binary_name: nsm
-      binary_path: /opt/nvswitch-manager/nsm
+      binary_path: /app/nsm
       dockerfile: ./docker/production/Dockerfile.carbide-nsm
       semantic_version: ${{ inputs.semantic_version }}
       short_sha: ${{ inputs.short_sha }}

--- a/docker/local/Dockerfile.carbide-nsm
+++ b/docker/local/Dockerfile.carbide-nsm
@@ -59,7 +59,7 @@ RUN addgroup -S nvs && adduser -S nvs -G nvs
 
 WORKDIR /opt/nvswitch-manager
 
-COPY --from=builder --chown=nvs:nvs /app/nsm ./nsm
+COPY --from=builder --chown=nvs:nvs /app/nsm /app/nsm
 COPY --chown=nvs:nvs nvswitch-manager/scripts/ ./scripts/
 COPY --chown=nvs:nvs nvswitch-manager/firmware/ ./firmware/
 
@@ -69,4 +69,4 @@ USER nvs
 
 EXPOSE 50051
 
-ENTRYPOINT ["./nsm", "serve"]
+ENTRYPOINT ["/app/nsm", "serve"]

--- a/docker/production/Dockerfile.carbide-nsm
+++ b/docker/production/Dockerfile.carbide-nsm
@@ -59,7 +59,7 @@ RUN addgroup -S nvs && adduser -S nvs -G nvs
 
 WORKDIR /opt/nvswitch-manager
 
-COPY --from=builder --chown=nvs:nvs /app/nsm ./nsm
+COPY --from=builder --chown=nvs:nvs /app/nsm /app/nsm
 COPY --chown=nvs:nvs nvswitch-manager/scripts/ ./scripts/
 COPY --chown=nvs:nvs nvswitch-manager/firmware/ ./firmware/
 
@@ -69,4 +69,4 @@ USER nvs
 
 EXPOSE 50051
 
-ENTRYPOINT ["./nsm", "serve"]
+ENTRYPOINT ["/app/nsm", "serve"]


### PR DESCRIPTION
## Description
Fix CI NSM error, example https://github.com/NVIDIA/bare-metal-manager-rest/actions/runs/22965072584/job/66667399951

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [x] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [x] **CI** - Changes in Github workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [ ] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
