### PR TITLE
fix: Require Site ID in validation when creating ExpectedMachine

### DIFF
--- a/api/pkg/api/model/expectedmachine.go
+++ b/api/pkg/api/model/expectedmachine.go
@@ -59,7 +59,8 @@ type APIExpectedMachineCreateRequest struct {
 func (emcr *APIExpectedMachineCreateRequest) Validate() error {
 	err := validation.ValidateStruct(emcr,
 		validation.Field(&emcr.SiteID,
-			validation.When(emcr.SiteID != "", validationis.UUID.Error(validationErrorInvalidUUID))),
+			validation.Required.Error(validationErrorValueRequired),
+			validationis.UUID.Error(validationErrorInvalidUUID)),
 		validation.Field(&emcr.BmcMacAddress,
 			validation.Required.Error(validationErrorValueRequired),
 			validationis.MAC),

--- a/api/pkg/api/model/expectedmachine_test.go
+++ b/api/pkg/api/model/expectedmachine_test.go
@@ -44,6 +44,7 @@ func TestAPIExpectedMachineCreateRequest_Validate(t *testing.T) {
 		{
 			desc: "ok when all required fields are provided",
 			obj: APIExpectedMachineCreateRequest{
+				SiteID:              "550e8400-e29b-41d4-a716-446655440000",
 				BmcMacAddress:       "00:11:22:33:44:55",
 				DefaultBmcUsername:  &validUsername,
 				DefaultBmcPassword:  &validPassword,
@@ -54,6 +55,7 @@ func TestAPIExpectedMachineCreateRequest_Validate(t *testing.T) {
 		{
 			desc: "ok when required fields and optional fields are provided",
 			obj: APIExpectedMachineCreateRequest{
+				SiteID:                   "550e8400-e29b-41d4-a716-446655440000",
 				BmcMacAddress:            "00:11:22:33:44:55",
 				DefaultBmcUsername:       &validUsername,
 				DefaultBmcPassword:       &validPassword,
@@ -106,6 +108,7 @@ func TestAPIExpectedMachineCreateRequest_Validate(t *testing.T) {
 		{
 			desc: "ok when BMC username is exactly 16 characters",
 			obj: APIExpectedMachineCreateRequest{
+				SiteID:              "550e8400-e29b-41d4-a716-446655440000",
 				BmcMacAddress:       "00:11:22:33:44:55",
 				DefaultBmcUsername:  cdb.GetStrPtr(strings.Repeat("a", 16)),
 				DefaultBmcPassword:  &validPassword,
@@ -127,6 +130,7 @@ func TestAPIExpectedMachineCreateRequest_Validate(t *testing.T) {
 		{
 			desc: "ok when BMC password is exactly 20 characters",
 			obj: APIExpectedMachineCreateRequest{
+				SiteID:              "550e8400-e29b-41d4-a716-446655440000",
 				BmcMacAddress:       "00:11:22:33:44:55",
 				DefaultBmcUsername:  &validUsername,
 				DefaultBmcPassword:  cdb.GetStrPtr(strings.Repeat("a", 20)),
@@ -148,6 +152,7 @@ func TestAPIExpectedMachineCreateRequest_Validate(t *testing.T) {
 		{
 			desc: "ok when chassis serial number is exactly 32 characters",
 			obj: APIExpectedMachineCreateRequest{
+				SiteID:              "550e8400-e29b-41d4-a716-446655440000",
 				BmcMacAddress:       "00:11:22:33:44:55",
 				DefaultBmcUsername:  &validUsername,
 				DefaultBmcPassword:  &validPassword,
@@ -168,6 +173,7 @@ func TestAPIExpectedMachineCreateRequest_Validate(t *testing.T) {
 		{
 			desc: "ok when optional fields are empty",
 			obj: APIExpectedMachineCreateRequest{
+				SiteID:                   "550e8400-e29b-41d4-a716-446655440000",
 				BmcMacAddress:            "00:11:22:33:44:55",
 				DefaultBmcUsername:       &emptyString,
 				DefaultBmcPassword:       &emptyString,
@@ -178,7 +184,7 @@ func TestAPIExpectedMachineCreateRequest_Validate(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			desc: "ok when SiteID is empty string",
+			desc: "error when SiteID is empty string",
 			obj: APIExpectedMachineCreateRequest{
 				SiteID:              "",
 				BmcMacAddress:       "00:11:22:33:44:55",
@@ -186,7 +192,7 @@ func TestAPIExpectedMachineCreateRequest_Validate(t *testing.T) {
 				DefaultBmcPassword:  &validPassword,
 				ChassisSerialNumber: validChassisSerial,
 			},
-			expectErr: false,
+			expectErr: true,
 		},
 		{
 			desc: "ok when SiteID is valid UUID",


### PR DESCRIPTION
## Description

In working on https://github.com/NVIDIA/bare-metal-manager-rest/pull/220, I had this same bug, because I was pattern matching against it. It looks like this was the only case of it, and everything else does this correctly.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [x] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in Github workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
