### PR TITLE
fix: Use proto field getters in Site workflow logs to prevent nil panics

### DIFF
--- a/site-workflow/pkg/workflow/expectedmachine.go
+++ b/site-workflow/pkg/workflow/expectedmachine.go
@@ -66,7 +66,7 @@ func DiscoverExpectedMachineInventory(ctx workflow.Context) error {
 
 // CreateExpectedMachine is a workflow to create new Expected Machines using the CreateExpectedMachineOnSite activity
 func CreateExpectedMachine(ctx workflow.Context, request *cwssaws.ExpectedMachine) error {
-	logger := log.With().Str("Workflow", "ExpectedMachine").Str("Action", "Create").Str("ID", request.Id.String()).Str("Expected MAC address", request.BmcMacAddress).Str("Serial", request.ChassisSerialNumber).Logger()
+	logger := log.With().Str("Workflow", "ExpectedMachine").Str("Action", "Create").Str("ID", request.GetId().GetValue()).Str("Expected MAC address", request.BmcMacAddress).Str("Serial", request.ChassisSerialNumber).Logger()
 
 	logger.Info().Msg("starting workflow")
 
@@ -101,7 +101,7 @@ func CreateExpectedMachine(ctx workflow.Context, request *cwssaws.ExpectedMachin
 
 // UpdateExpectedMachine is a workflow to update Expected Machines using the UpdateExpectedMachineOnSite activity
 func UpdateExpectedMachine(ctx workflow.Context, request *cwssaws.ExpectedMachine) error {
-	logger := log.With().Str("Workflow", "ExpectedMachine").Str("Action", "Update").Str("ID", request.Id.String()).Str("Expected MAC address", request.BmcMacAddress).Str("Serial", request.ChassisSerialNumber).Logger()
+	logger := log.With().Str("Workflow", "ExpectedMachine").Str("Action", "Update").Str("ID", request.GetId().GetValue()).Str("Expected MAC address", request.BmcMacAddress).Str("Serial", request.ChassisSerialNumber).Logger()
 
 	logger.Info().Msg("starting workflow")
 
@@ -210,7 +210,7 @@ func UpdateExpectedMachines(ctx workflow.Context, request *cwssaws.BatchExpected
 
 // DeleteExpectedMachine is a workflow to Delete Expected Machines using the DeleteExpectedMachineOnSite activity
 func DeleteExpectedMachine(ctx workflow.Context, request *cwssaws.ExpectedMachineRequest) error {
-	logger := log.With().Str("Workflow", "ExpectedMachine").Str("Action", "Delete").Str("ID", request.Id.String()).Str("optional MAC address", request.BmcMacAddress).Logger()
+	logger := log.With().Str("Workflow", "ExpectedMachine").Str("Action", "Delete").Str("ID", request.GetId().GetValue()).Str("optional MAC address", request.BmcMacAddress).Logger()
 
 	logger.Info().Msg("starting workflow")
 

--- a/site-workflow/pkg/workflow/subnet.go
+++ b/site-workflow/pkg/workflow/subnet.go
@@ -71,7 +71,7 @@ func CreateSubnetV2(ctx workflow.Context, request *cwssaws.NetworkSegmentCreatio
 // V1 (DeleteSubnet) is found cloud-workflow and uses a different activity that does not speak
 // to carbide directly.
 func DeleteSubnetV2(ctx workflow.Context, request *cwssaws.NetworkSegmentDeletionRequest) error {
-	logger := log.With().Str("Workflow", "Subnet").Str("Action", "Delete").Str("Subnet ID", request.Id.String()).Logger()
+	logger := log.With().Str("Workflow", "Subnet").Str("Action", "Delete").Str("Subnet ID", request.GetId().GetValue()).Logger()
 
 	logger.Info().Msg("Starting workflow")
 

--- a/site-workflow/pkg/workflow/vpc.go
+++ b/site-workflow/pkg/workflow/vpc.go
@@ -67,7 +67,7 @@ func DiscoverVPCInventory(ctx workflow.Context) error {
 // V1 (CreateVPC) is found in cloud-workflow and uses a different activity that does not speak
 // to carbide directly.
 func CreateVPCV2(ctx workflow.Context, request *cwssaws.VpcCreationRequest) error {
-	logger := log.With().Str("Workflow", "VPC").Str("Action", "Create").Str("VPC ID", request.Id.String()).Str("Name", request.Name).Logger()
+	logger := log.With().Str("Workflow", "VPC").Str("Action", "Create").Str("VPC ID", request.GetId().GetValue()).Str("Name", request.Name).Logger()
 
 	logger.Info().Msg("starting workflow")
 
@@ -102,7 +102,7 @@ func CreateVPCV2(ctx workflow.Context, request *cwssaws.VpcCreationRequest) erro
 
 // UpdateVPC is a workflow to update VPCs using the UpdateVpcOnSite activity
 func UpdateVPC(ctx workflow.Context, request *cwssaws.VpcUpdateRequest) error {
-	logger := log.With().Str("Workflow", "VPC").Str("Action", "Update").Str("VPC ID", request.Id.String()).Logger()
+	logger := log.With().Str("Workflow", "VPC").Str("Action", "Update").Str("VPC ID", request.GetId().GetValue()).Logger()
 
 	logger.Info().Msg("starting workflow")
 
@@ -139,7 +139,7 @@ func UpdateVPC(ctx workflow.Context, request *cwssaws.VpcUpdateRequest) error {
 // V1 (DeleteVPC) is found in cloud-workflow and uses a different activity that does not speak
 // to carbide directly.
 func DeleteVPCV2(ctx workflow.Context, request *cwssaws.VpcDeletionRequest) error {
-	logger := log.With().Str("Workflow", "VPC").Str("Action", "Delete").Str("VPC ID", request.Id.String()).Logger()
+	logger := log.With().Str("Workflow", "VPC").Str("Action", "Delete").Str("VPC ID", request.GetId().GetValue()).Logger()
 
 	logger.Info().Msg("starting workflow")
 
@@ -174,7 +174,7 @@ func DeleteVPCV2(ctx workflow.Context, request *cwssaws.VpcDeletionRequest) erro
 
 // UpdateVPCVirtualization is a workflow to update VPC virtualization type
 func UpdateVPCVirtualization(ctx workflow.Context, request *cwssaws.VpcUpdateVirtualizationRequest) error {
-	logger := log.With().Str("Workflow", "VPC").Str("Action", "Update Virtualization").Str("VPC ID", request.Id.String()).Logger()
+	logger := log.With().Str("Workflow", "VPC").Str("Action", "Update Virtualization").Str("VPC ID", request.GetId().GetValue()).Logger()
 
 	logger.Info().Msg("starting workflow")
 


### PR DESCRIPTION
## Description

In working on https://github.com/NVIDIA/bare-metal-manager-rest/pull/220, it was noticed I was working with `request.Id` and not `request.GetId()`. I fixed it, and figured I should fix any other examples of this as well, so we can avoid `nil` panics in more places! Here they are!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [x] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in Github workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [ ] **API** - API models or endpoints updated
- [x] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
