### PR TITLE
fix: Unwrap full Temporal error chain in UnwrapWorkflowError

### DIFF
--- a/api/pkg/api/handler/instance.go
+++ b/api/pkg/api/handler/instance.go
@@ -1703,8 +1703,10 @@ func (uih UpdateInstanceHandler) handleReboot(c echo.Context, logger *zerolog.Lo
 
 			return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("Failed to reboot Instance, timeout occurred executing workflow on Site: %s", err), nil)
 		}
+		code, err := common.UnwrapWorkflowError(err)
 		logger.Error().Err(err).Msg("failed to execute Temporal workflow to reboot Instance")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("Failed to execute sync workflow to reboot Instance on Site: %s", err), nil)
+
+		return cutil.NewAPIErrorResponse(c, code, fmt.Sprintf("Failed to execute sync workflow to reboot Instance on Site: %s", err), nil)
 	}
 
 	logger.Info().Str("Workflow ID", wid).Msg("completed synchronous reboot Instance workflow")

--- a/api/pkg/api/handler/rack.go
+++ b/api/pkg/api/handler/rack.go
@@ -200,8 +200,10 @@ func (grh GetRackHandler) Handle(c echo.Context) error {
 		if errors.As(err, &timeoutErr) || err == context.DeadlineExceeded || ctx.Err() != nil {
 			return common.TerminateWorkflowOnTimeOut(c, logger, stc, fmt.Sprintf("rack-get-%s", rackStrID), err, "Rack", "GetRack")
 		}
+		code, err := common.UnwrapWorkflowError(err)
 		logger.Error().Err(err).Msg("failed to get result from GetRack workflow")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to get Rack details", nil)
+
+		return cutil.NewAPIErrorResponse(c, code, fmt.Sprintf("Failed to get Rack details: %s", err), nil)
 	}
 
 	// Convert to API model
@@ -404,8 +406,10 @@ func (garh GetAllRackHandler) Handle(c echo.Context) error {
 		if errors.As(err, &timeoutErr) || err == context.DeadlineExceeded || ctx.Err() != nil {
 			return common.TerminateWorkflowOnTimeOut(c, logger, stc, workflowID, err, "Rack", "GetRacks")
 		}
+		code, err := common.UnwrapWorkflowError(err)
 		logger.Error().Err(err).Msg("failed to get result from GetRacks workflow")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to get Racks", nil)
+
+		return cutil.NewAPIErrorResponse(c, code, fmt.Sprintf("Failed to get Racks: %s", err), nil)
 	}
 
 	// Convert to API model
@@ -588,8 +592,10 @@ func (vrh ValidateRackHandler) Handle(c echo.Context) error {
 		if errors.As(err, &timeoutErr) || err == context.DeadlineExceeded || ctx.Err() != nil {
 			return common.TerminateWorkflowOnTimeOut(c, logger, stc, fmt.Sprintf("rack-validate-%s", rackStrID), err, "Rack", "ValidateRackComponents")
 		}
+		code, err := common.UnwrapWorkflowError(err)
 		logger.Error().Err(err).Msg("failed to get result from ValidateComponents workflow")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to validate Rack", nil)
+
+		return cutil.NewAPIErrorResponse(c, code, fmt.Sprintf("Failed to validate Rack: %s", err), nil)
 	}
 
 	// Convert to API model
@@ -751,8 +757,10 @@ func (vrsh ValidateRacksHandler) Handle(c echo.Context) error {
 		if errors.As(err, &timeoutErr) || err == context.DeadlineExceeded || ctx.Err() != nil {
 			return common.TerminateWorkflowOnTimeOut(c, logger, stc, workflowID, err, "Rack", "ValidateRackComponents")
 		}
+		code, err := common.UnwrapWorkflowError(err)
 		logger.Error().Err(err).Msg("failed to get result from ValidateComponents workflow")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to validate Racks", nil)
+
+		return cutil.NewAPIErrorResponse(c, code, fmt.Sprintf("Failed to validate Racks: %s", err), nil)
 	}
 
 	// Convert to API model

--- a/api/pkg/api/handler/tray.go
+++ b/api/pkg/api/handler/tray.go
@@ -193,8 +193,10 @@ func (gth GetTrayHandler) Handle(c echo.Context) error {
 		if errors.As(err, &timeoutErr) || err == context.DeadlineExceeded || ctx.Err() != nil {
 			return common.TerminateWorkflowOnTimeOut(c, logger, stc, fmt.Sprintf("tray-get-%s", trayStrID), err, "Tray", "GetTray")
 		}
+		code, err := common.UnwrapWorkflowError(err)
 		logger.Error().Err(err).Msg("failed to get result from GetTray workflow")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to get Tray details", nil)
+
+		return cutil.NewAPIErrorResponse(c, code, fmt.Sprintf("Failed to get Tray details: %s", err), nil)
 	}
 
 	// Convert to API model
@@ -396,8 +398,10 @@ func (gath GetAllTrayHandler) Handle(c echo.Context) error {
 		if errors.As(err, &timeoutErr) || err == context.DeadlineExceeded || ctx.Err() != nil {
 			return common.TerminateWorkflowOnTimeOut(c, logger, stc, workflowID, err, "Tray", "GetTrays")
 		}
+		code, err := common.UnwrapWorkflowError(err)
 		logger.Error().Err(err).Msg("failed to get result from GetTrays workflow")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to get Trays", nil)
+
+		return cutil.NewAPIErrorResponse(c, code, fmt.Sprintf("Failed to get Trays: %s", err), nil)
 	}
 
 	apiTrays := make([]*model.APITray, 0, len(rlaResponse.GetComponents()))
@@ -582,8 +586,10 @@ func (vth ValidateTrayHandler) Handle(c echo.Context) error {
 		if errors.As(err, &timeoutErr) || err == context.DeadlineExceeded || ctx.Err() != nil {
 			return common.TerminateWorkflowOnTimeOut(c, logger, stc, fmt.Sprintf("tray-validate-%s", trayStrID), err, "Tray", "ValidateRackComponents")
 		}
+		code, err := common.UnwrapWorkflowError(err)
 		logger.Error().Err(err).Msg("failed to get result from ValidateComponents workflow")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to validate Tray", nil)
+
+		return cutil.NewAPIErrorResponse(c, code, fmt.Sprintf("Failed to validate Tray: %s", err), nil)
 	}
 
 	// Convert to API model
@@ -748,8 +754,10 @@ func (vtsh ValidateTraysHandler) Handle(c echo.Context) error {
 		if errors.As(err, &timeoutErr) || err == context.DeadlineExceeded || ctx.Err() != nil {
 			return common.TerminateWorkflowOnTimeOut(c, logger, stc, workflowID, err, "Tray", "ValidateRackComponents")
 		}
+		code, err := common.UnwrapWorkflowError(err)
 		logger.Error().Err(err).Msg("failed to get result from ValidateComponents workflow")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to validate Trays", nil)
+
+		return cutil.NewAPIErrorResponse(c, code, fmt.Sprintf("Failed to validate Trays: %s", err), nil)
 	}
 
 	// Convert to API model

--- a/api/pkg/api/handler/util/common/common.go
+++ b/api/pkg/api/handler/util/common/common.go
@@ -1076,9 +1076,31 @@ func TerminateWorkflowOnTimeOut(echoCtx echo.Context, logger zerolog.Logger, tem
 func UnwrapWorkflowError(err error) (code int, unwrappedError error) {
 	code, unwrappedError = http.StatusInternalServerError, err
 
+	// Attempt to unwrap our way through Temporal's WorkflowExecutionError
+	// and ActivityError layers to reach the underlying cause. These types
+	// contain Temporal-internal details (workflow IDs, run IDs, scheduled
+	// event IDs, etc) that generally shouldn't be getting exposed to users.
+	innerErr := err
+
+	var wfErr *tp.WorkflowExecutionError
+	if errors.As(innerErr, &wfErr) {
+		if cause := errors.Unwrap(wfErr); cause != nil {
+			innerErr = cause
+		}
+	}
+
+	var actErr *tp.ActivityError
+	if errors.As(innerErr, &actErr) {
+		if cause := errors.Unwrap(actErr); cause != nil {
+			innerErr = cause
+		}
+	}
+
+	unwrappedError = innerErr
+
 	// if the error chain contains a gRPC error code use it to tune our HTTP response code
 	// NOTE: this is duplicating some feature of grpc-gateway and not exhaustive
-	s, ok := status.FromError(err)
+	s, ok := status.FromError(innerErr)
 	if ok {
 		// NOTE: this matches WrapErr in site-workflow/pkg/error/error.go
 		switch s.Code() {
@@ -1099,9 +1121,9 @@ func UnwrapWorkflowError(err error) (code int, unwrappedError error) {
 		}
 	}
 
-	// if the error is NOT a Temporal error return as-is
+	// if the error is NOT a Temporal ApplicationError return what we have
 	tpError := &tp.ApplicationError{}
-	if !errors.As(err, &tpError) {
+	if !errors.As(innerErr, &tpError) {
 		return
 	}
 
@@ -1126,7 +1148,7 @@ func UnwrapWorkflowError(err error) (code int, unwrappedError error) {
 	}
 
 	// if the error is an internal Temporal error it is mostly useless so we unwrap it but we keep
-	// the original error if there is no unwrapped error
+	// the current error if there is no unwrapped error
 	if potentialError := errors.Unwrap(tpError); potentialError != nil {
 		unwrappedError = potentialError
 	}

--- a/api/pkg/api/handler/util/common/common_test.go
+++ b/api/pkg/api/handler/util/common/common_test.go
@@ -392,6 +392,12 @@ func TestUnwrapWorkflowError(t *testing.T) {
 			wantCode: http.StatusBadRequest,
 			wantErr:  causeErr,
 		},
+		{
+			name:     "unwraps ApplicationError wrapped in generic error chain",
+			err:      fmt.Errorf("workflow execution error: %w", fmt.Errorf("activity error: %w", temporal.NewApplicationErrorWithCause("wrapped", swe.ErrTypeCarbideObjectNotFound, causeErr))),
+			wantCode: http.StatusNotFound,
+			wantErr:  causeErr,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

This should hopefully take care of https://github.com/NVIDIA/bare-metal-manager-rest/issues/212.

`UnwrapWorkflowError` previously only looked for `ApplicationError` in the error chain, but Temporal wraps activity errors in `WorkflowExecutionError` -> `ActivityError` -> `ApplicationError`. When the innermost error wasn't an `ApplicationError` (e.g. panics), the full temporal error framing with all of the various IDs was being returned to users. This fixes that.

Additionally, the `rack` and `tray` handlers were returning raw errors with a hardcoded 500 status code, instead of unwrapping them with `common.UnwrapWorkflowError()` to extract the underlying cause + HTTP status code, so this fixes that too.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [x] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in Github workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
