### PR TITLE
ci: Update CodeRabbit config to prevent PR description update, reduce noise

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,3 +3,6 @@ reviews:
   profile: chill # assertive / chill profile
   auto_review:
     enabled: true # Enable auto-review for this repository
+  high_level_summary_in_walkthrough: true # Copilot already does this
+  suggested_reviewers: false
+  in_progress_fortune: false


### PR DESCRIPTION
## Description
CodeRabbit is updating PR description, causing PR Title Checker to stall. Github doesn't have configuration to only check PR title, it emits same event for title and description change.

## Type of Change
- [x] **CI** - Changes in Github workflows. Requires additional scrutiny (ci:)

## Services Affected
None

## Related Issues (Optional)
None

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
None
