### PR TITLE
refactor: Rename ExpectedPowerShelf and ExpectedSwitch IDs

### DIFF
--- a/api/pkg/api/handler/expectedpowershelf.go
+++ b/api/pkg/api/handler/expectedpowershelf.go
@@ -192,9 +192,9 @@ func (cepsh CreateExpectedPowerShelfHandler) Handle(c echo.Context) error {
 	// Build the create request for workflow
 	// BMC credentials come from API request since they're not stored in DB
 	createExpectedPowerShelfRequest := &cwssaws.ExpectedPowerShelf{
-		Id:                &cwssaws.UUID{Value: expectedPowerShelf.ID.String()},
-		BmcMacAddress:     expectedPowerShelf.BmcMacAddress,
-		ShelfSerialNumber: expectedPowerShelf.ShelfSerialNumber,
+		ExpectedPowerShelfId: &cwssaws.UUID{Value: expectedPowerShelf.ID.String()},
+		BmcMacAddress:        expectedPowerShelf.BmcMacAddress,
+		ShelfSerialNumber:    expectedPowerShelf.ShelfSerialNumber,
 	}
 
 	if expectedPowerShelf.IpAddress != nil {
@@ -665,9 +665,9 @@ func (uepsh UpdateExpectedPowerShelfHandler) Handle(c echo.Context) error {
 	// Build the update request for workflow
 	// BMC credentials come from API request since they're not stored in DB
 	updateExpectedPowerShelfRequest := &cwssaws.ExpectedPowerShelf{
-		Id:                &cwssaws.UUID{Value: expectedPowerShelf.ID.String()},
-		BmcMacAddress:     updatedExpectedPowerShelf.BmcMacAddress,
-		ShelfSerialNumber: updatedExpectedPowerShelf.ShelfSerialNumber,
+		ExpectedPowerShelfId: &cwssaws.UUID{Value: expectedPowerShelf.ID.String()},
+		BmcMacAddress:        updatedExpectedPowerShelf.BmcMacAddress,
+		ShelfSerialNumber:    updatedExpectedPowerShelf.ShelfSerialNumber,
 	}
 
 	if updatedExpectedPowerShelf.IpAddress != nil {
@@ -834,8 +834,8 @@ func (depsh DeleteExpectedPowerShelfHandler) Handle(c echo.Context) error {
 
 	// Build the delete request for workflow
 	deleteExpectedPowerShelfRequest := &cwssaws.ExpectedPowerShelfRequest{
-		Id:            &cwssaws.UUID{Value: expectedPowerShelf.ID.String()},
-		BmcMacAddress: expectedPowerShelf.BmcMacAddress,
+		ExpectedPowerShelfId: &cwssaws.UUID{Value: expectedPowerShelf.ID.String()},
+		BmcMacAddress:        expectedPowerShelf.BmcMacAddress,
 	}
 
 	logger.Info().Msg("triggering ExpectedPowerShelf delete workflow")

--- a/api/pkg/api/handler/expectedpowershelf_test.go
+++ b/api/pkg/api/handler/expectedpowershelf_test.go
@@ -1,0 +1,923 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/nvidia/bare-metal-manager-rest/api/internal/config"
+	"github.com/nvidia/bare-metal-manager-rest/api/pkg/api/handler/util/common"
+	"github.com/nvidia/bare-metal-manager-rest/api/pkg/api/model"
+	sc "github.com/nvidia/bare-metal-manager-rest/api/pkg/client/site"
+	cdb "github.com/nvidia/bare-metal-manager-rest/db/pkg/db"
+	cdbm "github.com/nvidia/bare-metal-manager-rest/db/pkg/db/model"
+	cdbu "github.com/nvidia/bare-metal-manager-rest/db/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/uptrace/bun/extra/bundebug"
+	tmocks "go.temporal.io/sdk/mocks"
+)
+
+// testExpectedPowerShelfInitDB initializes a test database session
+func testExpectedPowerShelfInitDB(t *testing.T) *cdb.Session {
+	dbSession := cdbu.GetTestDBSession(t, false)
+	dbSession.DB.AddQueryHook(bundebug.NewQueryHook(
+		bundebug.WithEnabled(false),
+		bundebug.FromEnv("BUNDEBUG"),
+	))
+
+	ctx := context.Background()
+
+	err := dbSession.DB.ResetModel(ctx, (*cdbm.User)(nil))
+	assert.Nil(t, err)
+	err = dbSession.DB.ResetModel(ctx, (*cdbm.InfrastructureProvider)(nil))
+	assert.Nil(t, err)
+	err = dbSession.DB.ResetModel(ctx, (*cdbm.Tenant)(nil))
+	assert.Nil(t, err)
+	err = dbSession.DB.ResetModel(ctx, (*cdbm.Site)(nil))
+	assert.Nil(t, err)
+	err = dbSession.DB.ResetModel(ctx, (*cdbm.TenantAccount)(nil))
+	assert.Nil(t, err)
+	err = dbSession.DB.ResetModel(ctx, (*cdbm.ExpectedPowerShelf)(nil))
+	assert.Nil(t, err)
+
+	return dbSession
+}
+
+// testExpectedPowerShelfSetupTestData creates test infrastructure provider and site
+func testExpectedPowerShelfSetupTestData(t *testing.T, dbSession *cdb.Session, org string) (*cdbm.InfrastructureProvider, *cdbm.Site) {
+	ctx := context.Background()
+
+	ip := &cdbm.InfrastructureProvider{
+		ID:   uuid.New(),
+		Name: "test-provider",
+		Org:  org,
+	}
+	_, err := dbSession.DB.NewInsert().Model(ip).Exec(ctx)
+	assert.Nil(t, err)
+
+	site := &cdbm.Site{
+		ID:                       uuid.New(),
+		Name:                     "test-site",
+		Org:                      org,
+		InfrastructureProviderID: ip.ID,
+		Status:                   cdbm.SiteStatusRegistered,
+	}
+	_, err = dbSession.DB.NewInsert().Model(site).Exec(ctx)
+	assert.Nil(t, err)
+
+	return ip, site
+}
+
+func TestCreateExpectedPowerShelfHandler_Handle(t *testing.T) {
+	e := echo.New()
+
+	dbSession := testExpectedPowerShelfInitDB(t)
+	defer dbSession.Close()
+
+	cfg := common.GetTestConfig()
+
+	tcfg, _ := cfg.GetTemporalConfig()
+	scp := sc.NewClientPool(tcfg)
+
+	org := "test-org"
+	infraProv, site := testExpectedPowerShelfSetupTestData(t, dbSession, org)
+
+	ctx := context.Background()
+	unmanagedIP := &cdbm.InfrastructureProvider{
+		ID:   uuid.New(),
+		Name: "unmanaged-provider",
+		Org:  "other-org",
+	}
+	_, err := dbSession.DB.NewInsert().Model(unmanagedIP).Exec(ctx)
+	assert.Nil(t, err)
+
+	unmanagedSite := &cdbm.Site{
+		ID:                       uuid.New(),
+		Name:                     "unmanaged-site",
+		Org:                      "other-org",
+		InfrastructureProviderID: unmanagedIP.ID,
+		Status:                   cdbm.SiteStatusRegistered,
+	}
+	_, err = dbSession.DB.NewInsert().Model(unmanagedSite).Exec(ctx)
+	assert.Nil(t, err)
+
+	// Create an existing Expected Power Shelf with a specific MAC address for duplicate test
+	epsDAO := cdbm.NewExpectedPowerShelfDAO(dbSession)
+	existingMAC := "AA:BB:CC:DD:EE:11"
+	_, err = epsDAO.Create(ctx, nil, cdbm.ExpectedPowerShelfCreateInput{
+		ExpectedPowerShelfID: uuid.New(),
+		SiteID:               site.ID,
+		BmcMacAddress:        existingMAC,
+		ShelfSerialNumber:    "EXISTING-SHELF-001",
+		Labels:               map[string]string{"env": "existing"},
+	})
+	assert.Nil(t, err)
+
+	// Add mock temporal client for the site
+	mockTemporalClient := &tmocks.Client{}
+	mockWorkflowRun := &tmocks.WorkflowRun{}
+	mockWorkflowRun.On("GetID").Return("test-workflow-id")
+	mockWorkflowRun.Mock.On("Get", mock.Anything, mock.Anything).Return(nil)
+	mockTemporalClient.Mock.On("ExecuteWorkflow", mock.Anything, mock.Anything, "CreateExpectedPowerShelf", mock.Anything).Return(mockWorkflowRun, nil)
+	scp.IDClientMap[site.ID.String()] = mockTemporalClient
+
+	handler := NewCreateExpectedPowerShelfHandler(dbSession, nil, scp, cfg)
+
+	createMockUser := func(org string) *cdbm.User {
+		return &cdbm.User{
+			StarfleetID: cdb.GetStrPtr("test-user"),
+			OrgData: cdbm.OrgData{
+				org: cdbm.Org{
+					ID:          123,
+					Name:        org,
+					DisplayName: org,
+					OrgType:     "ENTERPRISE",
+					Roles:       []string{"FORGE_PROVIDER_ADMIN"},
+				},
+			},
+		}
+	}
+
+	validIpAddress := "192.168.1.100"
+
+	tests := []struct {
+		name           string
+		requestBody    model.APIExpectedPowerShelfCreateRequest
+		setupContext   func(c echo.Context)
+		expectedStatus int
+	}{
+		{
+			name: "successful creation",
+			requestBody: model.APIExpectedPowerShelfCreateRequest{
+				SiteID:             site.ID.String(),
+				BmcMacAddress:      "00:11:22:33:44:55",
+				DefaultBmcUsername: cdb.GetStrPtr("admin"),
+				DefaultBmcPassword: cdb.GetStrPtr("password"),
+				ShelfSerialNumber:  "SHELF123",
+				IpAddress:          &validIpAddress,
+				Labels:             map[string]string{"env": "test"},
+			},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName")
+				c.SetParamValues(org)
+			},
+			expectedStatus: http.StatusCreated,
+		},
+		{
+			name: "missing user context",
+			requestBody: model.APIExpectedPowerShelfCreateRequest{
+				SiteID:             site.ID.String(),
+				BmcMacAddress:      "00:11:22:33:44:77",
+				DefaultBmcUsername: cdb.GetStrPtr("admin"),
+				DefaultBmcPassword: cdb.GetStrPtr("password"),
+				ShelfSerialNumber:  "SHELF125",
+			},
+			setupContext: func(c echo.Context) {
+				c.SetParamNames("orgName")
+				c.SetParamValues(org)
+			},
+			expectedStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "invalid mac address length",
+			requestBody: model.APIExpectedPowerShelfCreateRequest{
+				SiteID:             site.ID.String(),
+				BmcMacAddress:      "00:11:22:33:44",
+				DefaultBmcUsername: cdb.GetStrPtr("admin"),
+				DefaultBmcPassword: cdb.GetStrPtr("password"),
+				ShelfSerialNumber:  "SHELF126",
+			},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName")
+				c.SetParamValues(org)
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "site not found",
+			requestBody: model.APIExpectedPowerShelfCreateRequest{
+				SiteID:             "12345678-1234-1234-1234-123456789099",
+				BmcMacAddress:      "00:11:22:33:44:88",
+				DefaultBmcUsername: cdb.GetStrPtr("admin"),
+				DefaultBmcPassword: cdb.GetStrPtr("password"),
+				ShelfSerialNumber:  "SHELF127",
+			},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName")
+				c.SetParamValues(org)
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "cannot create on unmanaged site",
+			requestBody: model.APIExpectedPowerShelfCreateRequest{
+				SiteID:             unmanagedSite.ID.String(),
+				BmcMacAddress:      "00:11:22:33:44:99",
+				DefaultBmcUsername: cdb.GetStrPtr("admin"),
+				DefaultBmcPassword: cdb.GetStrPtr("password"),
+				ShelfSerialNumber:  "SHELF128",
+			},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName")
+				c.SetParamValues(org)
+			},
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name: "duplicate MAC address should return 409",
+			requestBody: model.APIExpectedPowerShelfCreateRequest{
+				SiteID:             site.ID.String(),
+				BmcMacAddress:      existingMAC,
+				DefaultBmcUsername: cdb.GetStrPtr("admin"),
+				DefaultBmcPassword: cdb.GetStrPtr("password"),
+				ShelfSerialNumber:  "DUPLICATE-SHELF-999",
+				Labels:             map[string]string{"env": "duplicate-test"},
+			},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName")
+				c.SetParamValues(org)
+			},
+			expectedStatus: http.StatusConflict,
+		},
+	}
+
+	_ = infraProv
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reqBody, _ := json.Marshal(tt.requestBody)
+			req := httptest.NewRequest(http.MethodPost, "/v2/org/test-org/carbide/expected-power-shelf", bytes.NewReader(reqBody))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			req = req.WithContext(context.Background())
+
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			tt.setupContext(c)
+
+			err := handler.Handle(c)
+
+			assert.Nil(t, err)
+			assert.Equal(t, tt.expectedStatus, rec.Code)
+			if tt.expectedStatus != rec.Code {
+				t.Errorf("Response: %v", rec.Body.String())
+			}
+
+			if tt.expectedStatus == http.StatusCreated && tt.requestBody.Labels != nil {
+				var response model.APIExpectedPowerShelf
+				err := json.Unmarshal(rec.Body.Bytes(), &response)
+				assert.Nil(t, err)
+				assert.NotNil(t, response.Labels, "Labels should not be nil in response")
+				assert.Equal(t, tt.requestBody.Labels, response.Labels, "Labels in response should match request")
+			}
+		})
+	}
+}
+
+func TestGetAllExpectedPowerShelfHandler_Handle(t *testing.T) {
+	e := echo.New()
+	dbSession := testExpectedPowerShelfInitDB(t)
+	defer dbSession.Close()
+
+	ctx := context.Background()
+	cfg := &config.Config{}
+	handler := NewGetAllExpectedPowerShelfHandler(dbSession, nil, cfg)
+
+	org := "test-org"
+	infraProv, site := testExpectedPowerShelfSetupTestData(t, dbSession, org)
+
+	unmanagedIP := &cdbm.InfrastructureProvider{
+		ID:   uuid.New(),
+		Name: "unmanaged-provider",
+		Org:  "other-org",
+	}
+	_, err := dbSession.DB.NewInsert().Model(unmanagedIP).Exec(ctx)
+	assert.Nil(t, err)
+
+	unmanagedSite := &cdbm.Site{
+		ID:                       uuid.New(),
+		Name:                     "unmanaged-site",
+		Org:                      "other-org",
+		InfrastructureProviderID: unmanagedIP.ID,
+		Status:                   cdbm.SiteStatusRegistered,
+	}
+	_, err = dbSession.DB.NewInsert().Model(unmanagedSite).Exec(ctx)
+	assert.Nil(t, err)
+
+	// Create expected power shelves - one on managed site, one on unmanaged site
+	epsDAO := cdbm.NewExpectedPowerShelfDAO(dbSession)
+	managedEPS, err := epsDAO.Create(ctx, nil, cdbm.ExpectedPowerShelfCreateInput{
+		ExpectedPowerShelfID: uuid.New(),
+		SiteID:               site.ID,
+		BmcMacAddress:        "00:11:22:33:44:AA",
+		ShelfSerialNumber:    "MANAGED-SHELF",
+		Labels:               map[string]string{"env": "test"},
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, managedEPS)
+
+	unmanagedEPS, err := epsDAO.Create(ctx, nil, cdbm.ExpectedPowerShelfCreateInput{
+		ExpectedPowerShelfID: uuid.New(),
+		SiteID:               unmanagedSite.ID,
+		BmcMacAddress:        "00:11:22:33:44:BB",
+		ShelfSerialNumber:    "UNMANAGED-SHELF",
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, unmanagedEPS)
+
+	createMockUser := func(org string) *cdbm.User {
+		return &cdbm.User{
+			StarfleetID: cdb.GetStrPtr("test-user"),
+			OrgData: cdbm.OrgData{
+				org: cdbm.Org{
+					ID:          123,
+					Name:        org,
+					DisplayName: org,
+					OrgType:     "ENTERPRISE",
+					Roles:       []string{"FORGE_PROVIDER_VIEWER"},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name                 string
+		siteId               string
+		includeRelations     []string
+		setupContext         func(c echo.Context)
+		expectedStatus       int
+		checkResponseContent func(t *testing.T, body []byte)
+	}{
+		{
+			name:   "successful GetAll without siteId (lists only managed sites)",
+			siteId: "",
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName")
+				c.SetParamValues(org)
+			},
+			expectedStatus: http.StatusOK,
+			checkResponseContent: func(t *testing.T, body []byte) {
+				var response []model.APIExpectedPowerShelf
+				err := json.Unmarshal(body, &response)
+				assert.Nil(t, err)
+				for _, eps := range response {
+					assert.NotEqual(t, unmanagedEPS.ID, eps.ID, "Unmanaged power shelf should not be in response")
+				}
+			},
+		},
+		{
+			name:   "successful GetAll with valid siteId",
+			siteId: site.ID.String(),
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName")
+				c.SetParamValues(org)
+			},
+			expectedStatus: http.StatusOK,
+			checkResponseContent: func(t *testing.T, body []byte) {
+				var response []model.APIExpectedPowerShelf
+				err := json.Unmarshal(body, &response)
+				assert.Nil(t, err)
+				for _, eps := range response {
+					assert.Equal(t, site.ID, eps.SiteID, "All results should be from the specified site")
+				}
+			},
+		},
+		{
+			name:             "successful GetAll with includeRelation=Site",
+			siteId:           "",
+			includeRelations: []string{"Site"},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName")
+				c.SetParamValues(org)
+			},
+			expectedStatus: http.StatusOK,
+			checkResponseContent: func(t *testing.T, body []byte) {
+				var response []model.APIExpectedPowerShelf
+				err := json.Unmarshal(body, &response)
+				assert.Nil(t, err)
+				assert.Greater(t, len(response), 0, "Should return at least one expected power shelf")
+				for _, eps := range response {
+					assert.NotNil(t, eps.Site, "Site relation should be loaded")
+					assert.Equal(t, eps.SiteID.String(), eps.Site.ID, "Site ID should match")
+				}
+			},
+		},
+		{
+			name:   "cannot retrieve from unmanaged site",
+			siteId: unmanagedSite.ID.String(),
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName")
+				c.SetParamValues(org)
+			},
+			expectedStatus: http.StatusForbidden,
+		},
+	}
+
+	_ = infraProv
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url := "/v2/org/" + org + "/carbide/expected-power-shelf"
+			params := []string{}
+			if tt.siteId != "" {
+				params = append(params, "siteId="+tt.siteId)
+			}
+			for _, relation := range tt.includeRelations {
+				params = append(params, "includeRelation="+relation)
+			}
+			if len(params) > 0 {
+				url += "?" + params[0]
+				for i := 1; i < len(params); i++ {
+					url += "&" + params[i]
+				}
+			}
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			req = req.WithContext(context.Background())
+
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			tt.setupContext(c)
+
+			err := handler.Handle(c)
+
+			assert.Nil(t, err)
+			assert.Equal(t, tt.expectedStatus, rec.Code)
+			if tt.expectedStatus != rec.Code {
+				t.Errorf("Response: %v", rec.Body.String())
+			}
+
+			if tt.checkResponseContent != nil && rec.Code == http.StatusOK {
+				tt.checkResponseContent(t, rec.Body.Bytes())
+			}
+		})
+	}
+}
+
+func TestGetExpectedPowerShelfHandler_Handle(t *testing.T) {
+	e := echo.New()
+	dbSession := testExpectedPowerShelfInitDB(t)
+	defer dbSession.Close()
+
+	ctx := context.Background()
+
+	cfg := &config.Config{}
+	handler := NewGetExpectedPowerShelfHandler(dbSession, nil, cfg)
+
+	org := "test-org"
+	infraProv, site := testExpectedPowerShelfSetupTestData(t, dbSession, org)
+
+	unmanagedIP := &cdbm.InfrastructureProvider{
+		ID:   uuid.New(),
+		Name: "unmanaged-provider",
+		Org:  "other-org",
+	}
+	_, err := dbSession.DB.NewInsert().Model(unmanagedIP).Exec(ctx)
+	assert.Nil(t, err)
+
+	unmanagedSite := &cdbm.Site{
+		ID:                       uuid.New(),
+		Name:                     "unmanaged-site",
+		Org:                      "other-org",
+		InfrastructureProviderID: unmanagedIP.ID,
+		Status:                   cdbm.SiteStatusRegistered,
+	}
+	_, err = dbSession.DB.NewInsert().Model(unmanagedSite).Exec(ctx)
+	assert.Nil(t, err)
+
+	// Create a test ExpectedPowerShelf on managed site
+	epsDAO := cdbm.NewExpectedPowerShelfDAO(dbSession)
+	testEPS, err := epsDAO.Create(ctx, nil, cdbm.ExpectedPowerShelfCreateInput{
+		ExpectedPowerShelfID: uuid.New(),
+		SiteID:               site.ID,
+		BmcMacAddress:        "00:11:22:33:44:55",
+		ShelfSerialNumber:    "TEST-SHELF-123",
+		Labels:               map[string]string{"env": "test"},
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, testEPS)
+
+	// Create a test ExpectedPowerShelf on unmanaged site
+	unmanagedEPS, err := epsDAO.Create(ctx, nil, cdbm.ExpectedPowerShelfCreateInput{
+		ExpectedPowerShelfID: uuid.New(),
+		SiteID:               unmanagedSite.ID,
+		BmcMacAddress:        "00:11:22:33:44:CC",
+		ShelfSerialNumber:    "UNMANAGED-SHELF-456",
+		Labels:               map[string]string{"env": "unmanaged"},
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, unmanagedEPS)
+
+	createMockUser := func(org string) *cdbm.User {
+		return &cdbm.User{
+			StarfleetID: cdb.GetStrPtr("test-user"),
+			OrgData: cdbm.OrgData{
+				org: cdbm.Org{
+					ID:          123,
+					Name:        org,
+					DisplayName: org,
+					OrgType:     "ENTERPRISE",
+					Roles:       []string{"FORGE_PROVIDER_ADMIN"},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name           string
+		id             string
+		setupContext   func(c echo.Context)
+		expectedStatus int
+	}{
+		{
+			name: "invalid ID",
+			id:   "invalid-id",
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName", "id")
+				c.SetParamValues(org, "invalid-id")
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "successful retrieval",
+			id:   testEPS.ID.String(),
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName", "id")
+				c.SetParamValues(org, testEPS.ID.String())
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "power shelf not found",
+			id:   "12345678-1234-1234-1234-123456789099",
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName", "id")
+				c.SetParamValues(org, "12345678-1234-1234-1234-123456789099")
+			},
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			name: "cannot retrieve from unmanaged site",
+			id:   unmanagedEPS.ID.String(),
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName", "id")
+				c.SetParamValues(org, unmanagedEPS.ID.String())
+			},
+			expectedStatus: http.StatusForbidden,
+		},
+	}
+
+	_ = infraProv
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url := "/v2/org/" + org + "/carbide/expected-power-shelf/" + tt.id
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			req = req.WithContext(context.Background())
+
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			tt.setupContext(c)
+
+			err := handler.Handle(c)
+
+			assert.Nil(t, err)
+			assert.Equal(t, tt.expectedStatus, rec.Code)
+			if tt.expectedStatus != rec.Code {
+				t.Errorf("Response: %v", rec.Body.String())
+			}
+
+			if tt.expectedStatus == http.StatusOK && tt.name == "successful retrieval" {
+				var response model.APIExpectedPowerShelf
+				err := json.Unmarshal(rec.Body.Bytes(), &response)
+				assert.Nil(t, err)
+				assert.NotNil(t, response.Labels, "Labels should not be nil in response")
+				assert.Equal(t, "test", response.Labels["env"], "Labels in response should contain the 'env' label with value 'test'")
+			}
+		})
+	}
+}
+
+func TestUpdateExpectedPowerShelfHandler_Handle(t *testing.T) {
+	e := echo.New()
+	dbSession := testExpectedPowerShelfInitDB(t)
+	defer dbSession.Close()
+
+	ctx := context.Background()
+	cfg := common.GetTestConfig()
+
+	tcfg, _ := cfg.GetTemporalConfig()
+	scp := sc.NewClientPool(tcfg)
+
+	org := "test-org"
+	infraProv, site := testExpectedPowerShelfSetupTestData(t, dbSession, org)
+
+	unmanagedIP := &cdbm.InfrastructureProvider{
+		ID:   uuid.New(),
+		Name: "unmanaged-provider",
+		Org:  "other-org",
+	}
+	_, err := dbSession.DB.NewInsert().Model(unmanagedIP).Exec(ctx)
+	assert.Nil(t, err)
+
+	unmanagedSite := &cdbm.Site{
+		ID:                       uuid.New(),
+		Name:                     "unmanaged-site",
+		Org:                      "other-org",
+		InfrastructureProviderID: unmanagedIP.ID,
+		Status:                   cdbm.SiteStatusRegistered,
+	}
+	_, err = dbSession.DB.NewInsert().Model(unmanagedSite).Exec(ctx)
+	assert.Nil(t, err)
+
+	// Create a test ExpectedPowerShelf on managed site
+	epsDAO := cdbm.NewExpectedPowerShelfDAO(dbSession)
+	testEPS, err := epsDAO.Create(ctx, nil, cdbm.ExpectedPowerShelfCreateInput{
+		ExpectedPowerShelfID: uuid.New(),
+		SiteID:               site.ID,
+		BmcMacAddress:        "00:11:22:33:44:DD",
+		ShelfSerialNumber:    "UPDATE-SHELF-123",
+		Labels:               map[string]string{"env": "test"},
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, testEPS)
+
+	// Create a test ExpectedPowerShelf on unmanaged site
+	unmanagedEPS, err := epsDAO.Create(ctx, nil, cdbm.ExpectedPowerShelfCreateInput{
+		ExpectedPowerShelfID: uuid.New(),
+		SiteID:               unmanagedSite.ID,
+		BmcMacAddress:        "00:11:22:33:44:EE",
+		ShelfSerialNumber:    "UNMANAGED-UPDATE-456",
+		Labels:               map[string]string{"env": "unmanaged"},
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, unmanagedEPS)
+
+	// Add mock temporal client for the site
+	mockTemporalClient := &tmocks.Client{}
+	mockWorkflowRun := &tmocks.WorkflowRun{}
+	mockWorkflowRun.On("GetID").Return("test-workflow-id")
+	mockWorkflowRun.Mock.On("Get", mock.Anything, mock.Anything).Return(nil)
+	mockTemporalClient.Mock.On("ExecuteWorkflow", mock.Anything, mock.Anything, "UpdateExpectedPowerShelf", mock.Anything).Return(mockWorkflowRun, nil)
+	scp.IDClientMap[site.ID.String()] = mockTemporalClient
+
+	handler := NewUpdateExpectedPowerShelfHandler(dbSession, nil, scp, cfg)
+
+	createMockUser := func(org string) *cdbm.User {
+		return &cdbm.User{
+			StarfleetID: cdb.GetStrPtr("test-user"),
+			OrgData: cdbm.OrgData{
+				org: cdbm.Org{
+					ID:          123,
+					Name:        org,
+					DisplayName: org,
+					OrgType:     "ENTERPRISE",
+					Roles:       []string{"FORGE_PROVIDER_ADMIN"},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name           string
+		id             string
+		requestBody    model.APIExpectedPowerShelfUpdateRequest
+		setupContext   func(c echo.Context)
+		expectedStatus int
+	}{
+		{
+			name: "successful update",
+			id:   testEPS.ID.String(),
+			requestBody: model.APIExpectedPowerShelfUpdateRequest{
+				ShelfSerialNumber: cdb.GetStrPtr("UPDATED-SHELF-123"),
+				Labels:            map[string]string{"env": "updated"},
+			},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName", "id")
+				c.SetParamValues(org, testEPS.ID.String())
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "body ID mismatch with URL should return 400",
+			id:   testEPS.ID.String(),
+			requestBody: model.APIExpectedPowerShelfUpdateRequest{
+				ID:                cdb.GetStrPtr(uuid.New().String()),
+				ShelfSerialNumber: cdb.GetStrPtr("SHOULD-NOT-UPDATE"),
+			},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName", "id")
+				c.SetParamValues(org, testEPS.ID.String())
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "cannot update on unmanaged site",
+			id:   unmanagedEPS.ID.String(),
+			requestBody: model.APIExpectedPowerShelfUpdateRequest{
+				ShelfSerialNumber: cdb.GetStrPtr("SHOULD-NOT-UPDATE"),
+				Labels:            map[string]string{"env": "fail"},
+			},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName", "id")
+				c.SetParamValues(org, unmanagedEPS.ID.String())
+			},
+			expectedStatus: http.StatusForbidden,
+		},
+	}
+
+	_ = infraProv
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reqBody, _ := json.Marshal(tt.requestBody)
+			url := "/v2/org/" + org + "/carbide/expected-power-shelf/" + tt.id
+			req := httptest.NewRequest(http.MethodPatch, url, bytes.NewReader(reqBody))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			req = req.WithContext(context.Background())
+
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			tt.setupContext(c)
+
+			err := handler.Handle(c)
+
+			assert.Nil(t, err)
+			assert.Equal(t, tt.expectedStatus, rec.Code)
+			if tt.expectedStatus != rec.Code {
+				t.Errorf("Response: %v", rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestDeleteExpectedPowerShelfHandler_Handle(t *testing.T) {
+	e := echo.New()
+	dbSession := testExpectedPowerShelfInitDB(t)
+	defer dbSession.Close()
+
+	ctx := context.Background()
+	cfg := common.GetTestConfig()
+
+	tcfg, _ := cfg.GetTemporalConfig()
+	scp := sc.NewClientPool(tcfg)
+
+	org := "test-org"
+	infraProv, site := testExpectedPowerShelfSetupTestData(t, dbSession, org)
+
+	unmanagedIP := &cdbm.InfrastructureProvider{
+		ID:   uuid.New(),
+		Name: "unmanaged-provider",
+		Org:  "other-org",
+	}
+	_, err := dbSession.DB.NewInsert().Model(unmanagedIP).Exec(ctx)
+	assert.Nil(t, err)
+
+	unmanagedSite := &cdbm.Site{
+		ID:                       uuid.New(),
+		Name:                     "unmanaged-site",
+		Org:                      "other-org",
+		InfrastructureProviderID: unmanagedIP.ID,
+		Status:                   cdbm.SiteStatusRegistered,
+	}
+	_, err = dbSession.DB.NewInsert().Model(unmanagedSite).Exec(ctx)
+	assert.Nil(t, err)
+
+	// Create a test ExpectedPowerShelf on managed site (to be deleted)
+	epsDAO := cdbm.NewExpectedPowerShelfDAO(dbSession)
+	testEPS, err := epsDAO.Create(ctx, nil, cdbm.ExpectedPowerShelfCreateInput{
+		ExpectedPowerShelfID: uuid.New(),
+		SiteID:               site.ID,
+		BmcMacAddress:        "00:11:22:33:44:FF",
+		ShelfSerialNumber:    "DELETE-SHELF-123",
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, testEPS)
+
+	// Create a test ExpectedPowerShelf on unmanaged site (should not be deletable)
+	unmanagedEPS, err := epsDAO.Create(ctx, nil, cdbm.ExpectedPowerShelfCreateInput{
+		ExpectedPowerShelfID: uuid.New(),
+		SiteID:               unmanagedSite.ID,
+		BmcMacAddress:        "00:11:22:33:55:00",
+		ShelfSerialNumber:    "UNMANAGED-DELETE-456",
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, unmanagedEPS)
+
+	// Add mock temporal client for the site
+	mockTemporalClient := &tmocks.Client{}
+	mockWorkflowRun := &tmocks.WorkflowRun{}
+	mockWorkflowRun.On("GetID").Return("test-workflow-id")
+	mockWorkflowRun.Mock.On("Get", mock.Anything, mock.Anything).Return(nil)
+	mockTemporalClient.Mock.On("ExecuteWorkflow", mock.Anything, mock.Anything, "DeleteExpectedPowerShelf", mock.Anything).Return(mockWorkflowRun, nil)
+	scp.IDClientMap[site.ID.String()] = mockTemporalClient
+
+	handler := NewDeleteExpectedPowerShelfHandler(dbSession, nil, scp, cfg)
+
+	createMockUser := func(org string) *cdbm.User {
+		return &cdbm.User{
+			StarfleetID: cdb.GetStrPtr("test-user"),
+			OrgData: cdbm.OrgData{
+				org: cdbm.Org{
+					ID:          123,
+					Name:        org,
+					DisplayName: org,
+					OrgType:     "ENTERPRISE",
+					Roles:       []string{"FORGE_PROVIDER_ADMIN"},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name           string
+		id             string
+		setupContext   func(c echo.Context)
+		expectedStatus int
+	}{
+		{
+			name: "successful delete",
+			id:   testEPS.ID.String(),
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName", "id")
+				c.SetParamValues(org, testEPS.ID.String())
+			},
+			expectedStatus: http.StatusNoContent,
+		},
+		{
+			name: "cannot delete on unmanaged site",
+			id:   unmanagedEPS.ID.String(),
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName", "id")
+				c.SetParamValues(org, unmanagedEPS.ID.String())
+			},
+			expectedStatus: http.StatusForbidden,
+		},
+	}
+
+	_ = infraProv
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url := "/v2/org/" + org + "/carbide/expected-power-shelf/" + tt.id
+			req := httptest.NewRequest(http.MethodDelete, url, nil)
+			req = req.WithContext(context.Background())
+
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			tt.setupContext(c)
+
+			err := handler.Handle(c)
+
+			assert.Nil(t, err)
+			assert.Equal(t, tt.expectedStatus, rec.Code)
+			if tt.expectedStatus != rec.Code {
+				t.Errorf("Response: %v", rec.Body.String())
+			}
+		})
+	}
+}

--- a/api/pkg/api/handler/expectedswitch.go
+++ b/api/pkg/api/handler/expectedswitch.go
@@ -191,7 +191,7 @@ func (cesh CreateExpectedSwitchHandler) Handle(c echo.Context) error {
 	// Build the create request for workflow
 	// NVOS credentials come from API request since they're not stored in DB
 	createExpectedSwitchRequest := &cwssaws.ExpectedSwitch{
-		Id:                 &cwssaws.UUID{Value: expectedSwitch.ID.String()},
+		ExpectedSwitchId:   &cwssaws.UUID{Value: expectedSwitch.ID.String()},
 		BmcMacAddress:      expectedSwitch.BmcMacAddress,
 		SwitchSerialNumber: expectedSwitch.SwitchSerialNumber,
 	}
@@ -667,7 +667,7 @@ func (uesh UpdateExpectedSwitchHandler) Handle(c echo.Context) error {
 	// Build the update request for workflow
 	// NVOS credentials come from API request since they're not stored in DB
 	updateExpectedSwitchRequest := &cwssaws.ExpectedSwitch{
-		Id:                 &cwssaws.UUID{Value: expectedSwitch.ID.String()},
+		ExpectedSwitchId:   &cwssaws.UUID{Value: expectedSwitch.ID.String()},
 		BmcMacAddress:      updatedExpectedSwitch.BmcMacAddress,
 		SwitchSerialNumber: updatedExpectedSwitch.SwitchSerialNumber,
 	}
@@ -840,8 +840,8 @@ func (desh DeleteExpectedSwitchHandler) Handle(c echo.Context) error {
 
 	// Build the delete request for workflow
 	deleteExpectedSwitchRequest := &cwssaws.ExpectedSwitchRequest{
-		Id:            &cwssaws.UUID{Value: expectedSwitch.ID.String()},
-		BmcMacAddress: expectedSwitch.BmcMacAddress,
+		ExpectedSwitchId: &cwssaws.UUID{Value: expectedSwitch.ID.String()},
+		BmcMacAddress:    expectedSwitch.BmcMacAddress,
 	}
 
 	logger.Info().Msg("triggering ExpectedSwitch delete workflow")

--- a/api/pkg/api/handler/expectedswitch_test.go
+++ b/api/pkg/api/handler/expectedswitch_test.go
@@ -1,0 +1,922 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/nvidia/bare-metal-manager-rest/api/internal/config"
+	"github.com/nvidia/bare-metal-manager-rest/api/pkg/api/handler/util/common"
+	"github.com/nvidia/bare-metal-manager-rest/api/pkg/api/model"
+	sc "github.com/nvidia/bare-metal-manager-rest/api/pkg/client/site"
+	cdb "github.com/nvidia/bare-metal-manager-rest/db/pkg/db"
+	cdbm "github.com/nvidia/bare-metal-manager-rest/db/pkg/db/model"
+	cdbu "github.com/nvidia/bare-metal-manager-rest/db/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/uptrace/bun/extra/bundebug"
+	tmocks "go.temporal.io/sdk/mocks"
+)
+
+// testExpectedSwitchInitDB initializes a test database session
+func testExpectedSwitchInitDB(t *testing.T) *cdb.Session {
+	dbSession := cdbu.GetTestDBSession(t, false)
+	dbSession.DB.AddQueryHook(bundebug.NewQueryHook(
+		bundebug.WithEnabled(false),
+		bundebug.FromEnv("BUNDEBUG"),
+	))
+
+	ctx := context.Background()
+
+	err := dbSession.DB.ResetModel(ctx, (*cdbm.User)(nil))
+	assert.Nil(t, err)
+	err = dbSession.DB.ResetModel(ctx, (*cdbm.InfrastructureProvider)(nil))
+	assert.Nil(t, err)
+	err = dbSession.DB.ResetModel(ctx, (*cdbm.Tenant)(nil))
+	assert.Nil(t, err)
+	err = dbSession.DB.ResetModel(ctx, (*cdbm.Site)(nil))
+	assert.Nil(t, err)
+	err = dbSession.DB.ResetModel(ctx, (*cdbm.TenantAccount)(nil))
+	assert.Nil(t, err)
+	err = dbSession.DB.ResetModel(ctx, (*cdbm.ExpectedSwitch)(nil))
+	assert.Nil(t, err)
+
+	return dbSession
+}
+
+// testExpectedSwitchSetupTestData creates test infrastructure provider and site
+func testExpectedSwitchSetupTestData(t *testing.T, dbSession *cdb.Session, org string) (*cdbm.InfrastructureProvider, *cdbm.Site) {
+	ctx := context.Background()
+
+	ip := &cdbm.InfrastructureProvider{
+		ID:   uuid.New(),
+		Name: "test-provider",
+		Org:  org,
+	}
+	_, err := dbSession.DB.NewInsert().Model(ip).Exec(ctx)
+	assert.Nil(t, err)
+
+	site := &cdbm.Site{
+		ID:                       uuid.New(),
+		Name:                     "test-site",
+		Org:                      org,
+		InfrastructureProviderID: ip.ID,
+		Status:                   cdbm.SiteStatusRegistered,
+	}
+	_, err = dbSession.DB.NewInsert().Model(site).Exec(ctx)
+	assert.Nil(t, err)
+
+	return ip, site
+}
+
+func TestCreateExpectedSwitchHandler_Handle(t *testing.T) {
+	e := echo.New()
+
+	dbSession := testExpectedSwitchInitDB(t)
+	defer dbSession.Close()
+
+	cfg := common.GetTestConfig()
+
+	tcfg, _ := cfg.GetTemporalConfig()
+	scp := sc.NewClientPool(tcfg)
+
+	org := "test-org"
+	infraProv, site := testExpectedSwitchSetupTestData(t, dbSession, org)
+
+	ctx := context.Background()
+	unmanagedIP := &cdbm.InfrastructureProvider{
+		ID:   uuid.New(),
+		Name: "unmanaged-provider",
+		Org:  "other-org",
+	}
+	_, err := dbSession.DB.NewInsert().Model(unmanagedIP).Exec(ctx)
+	assert.Nil(t, err)
+
+	unmanagedSite := &cdbm.Site{
+		ID:                       uuid.New(),
+		Name:                     "unmanaged-site",
+		Org:                      "other-org",
+		InfrastructureProviderID: unmanagedIP.ID,
+		Status:                   cdbm.SiteStatusRegistered,
+	}
+	_, err = dbSession.DB.NewInsert().Model(unmanagedSite).Exec(ctx)
+	assert.Nil(t, err)
+
+	// Create an existing Expected Switch with a specific MAC address for duplicate test
+	esDAO := cdbm.NewExpectedSwitchDAO(dbSession)
+	existingMAC := "AA:BB:CC:DD:EE:11"
+	_, err = esDAO.Create(ctx, nil, cdbm.ExpectedSwitchCreateInput{
+		ExpectedSwitchID:   uuid.New(),
+		SiteID:             site.ID,
+		BmcMacAddress:      existingMAC,
+		SwitchSerialNumber: "EXISTING-SWITCH-001",
+		Labels:             map[string]string{"env": "existing"},
+	})
+	assert.Nil(t, err)
+
+	// Add mock temporal client for the site
+	mockTemporalClient := &tmocks.Client{}
+	mockWorkflowRun := &tmocks.WorkflowRun{}
+	mockWorkflowRun.On("GetID").Return("test-workflow-id")
+	mockWorkflowRun.Mock.On("Get", mock.Anything, mock.Anything).Return(nil)
+	mockTemporalClient.Mock.On("ExecuteWorkflow", mock.Anything, mock.Anything, "CreateExpectedSwitch", mock.Anything).Return(mockWorkflowRun, nil)
+	scp.IDClientMap[site.ID.String()] = mockTemporalClient
+
+	handler := NewCreateExpectedSwitchHandler(dbSession, nil, scp, cfg)
+
+	createMockUser := func(org string) *cdbm.User {
+		return &cdbm.User{
+			StarfleetID: cdb.GetStrPtr("test-user"),
+			OrgData: cdbm.OrgData{
+				org: cdbm.Org{
+					ID:          123,
+					Name:        org,
+					DisplayName: org,
+					OrgType:     "ENTERPRISE",
+					Roles:       []string{"FORGE_PROVIDER_ADMIN"},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name           string
+		requestBody    model.APIExpectedSwitchCreateRequest
+		setupContext   func(c echo.Context)
+		expectedStatus int
+	}{
+		{
+			name: "successful creation",
+			requestBody: model.APIExpectedSwitchCreateRequest{
+				SiteID:             site.ID.String(),
+				BmcMacAddress:      "00:11:22:33:44:55",
+				DefaultBmcUsername: cdb.GetStrPtr("admin"),
+				DefaultBmcPassword: cdb.GetStrPtr("password"),
+				SwitchSerialNumber: "SWITCH123",
+				NvOsUsername:       cdb.GetStrPtr("nvos-admin"),
+				NvOsPassword:       cdb.GetStrPtr("nvos-password"),
+				Labels:             map[string]string{"env": "test"},
+			},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName")
+				c.SetParamValues(org)
+			},
+			expectedStatus: http.StatusCreated,
+		},
+		{
+			name: "missing user context",
+			requestBody: model.APIExpectedSwitchCreateRequest{
+				SiteID:             site.ID.String(),
+				BmcMacAddress:      "00:11:22:33:44:77",
+				DefaultBmcUsername: cdb.GetStrPtr("admin"),
+				DefaultBmcPassword: cdb.GetStrPtr("password"),
+				SwitchSerialNumber: "SWITCH125",
+			},
+			setupContext: func(c echo.Context) {
+				c.SetParamNames("orgName")
+				c.SetParamValues(org)
+			},
+			expectedStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "invalid mac address length",
+			requestBody: model.APIExpectedSwitchCreateRequest{
+				SiteID:             site.ID.String(),
+				BmcMacAddress:      "00:11:22:33:44",
+				DefaultBmcUsername: cdb.GetStrPtr("admin"),
+				DefaultBmcPassword: cdb.GetStrPtr("password"),
+				SwitchSerialNumber: "SWITCH126",
+			},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName")
+				c.SetParamValues(org)
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "site not found",
+			requestBody: model.APIExpectedSwitchCreateRequest{
+				SiteID:             "12345678-1234-1234-1234-123456789099",
+				BmcMacAddress:      "00:11:22:33:44:88",
+				DefaultBmcUsername: cdb.GetStrPtr("admin"),
+				DefaultBmcPassword: cdb.GetStrPtr("password"),
+				SwitchSerialNumber: "SWITCH127",
+			},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName")
+				c.SetParamValues(org)
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "cannot create on unmanaged site",
+			requestBody: model.APIExpectedSwitchCreateRequest{
+				SiteID:             unmanagedSite.ID.String(),
+				BmcMacAddress:      "00:11:22:33:44:99",
+				DefaultBmcUsername: cdb.GetStrPtr("admin"),
+				DefaultBmcPassword: cdb.GetStrPtr("password"),
+				SwitchSerialNumber: "SWITCH128",
+			},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName")
+				c.SetParamValues(org)
+			},
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name: "duplicate MAC address should return 409",
+			requestBody: model.APIExpectedSwitchCreateRequest{
+				SiteID:             site.ID.String(),
+				BmcMacAddress:      existingMAC,
+				DefaultBmcUsername: cdb.GetStrPtr("admin"),
+				DefaultBmcPassword: cdb.GetStrPtr("password"),
+				SwitchSerialNumber: "DUPLICATE-SWITCH-999",
+				Labels:             map[string]string{"env": "duplicate-test"},
+			},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName")
+				c.SetParamValues(org)
+			},
+			expectedStatus: http.StatusConflict,
+		},
+	}
+
+	_ = infraProv
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reqBody, _ := json.Marshal(tt.requestBody)
+			req := httptest.NewRequest(http.MethodPost, "/v2/org/test-org/carbide/expected-switch", bytes.NewReader(reqBody))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			req = req.WithContext(context.Background())
+
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			tt.setupContext(c)
+
+			err := handler.Handle(c)
+
+			assert.Nil(t, err)
+			assert.Equal(t, tt.expectedStatus, rec.Code)
+			if tt.expectedStatus != rec.Code {
+				t.Errorf("Response: %v", rec.Body.String())
+			}
+
+			if tt.expectedStatus == http.StatusCreated && tt.requestBody.Labels != nil {
+				var response model.APIExpectedSwitch
+				err := json.Unmarshal(rec.Body.Bytes(), &response)
+				assert.Nil(t, err)
+				assert.NotNil(t, response.Labels, "Labels should not be nil in response")
+				assert.Equal(t, tt.requestBody.Labels, response.Labels, "Labels in response should match request")
+			}
+		})
+	}
+}
+
+func TestGetAllExpectedSwitchHandler_Handle(t *testing.T) {
+	e := echo.New()
+	dbSession := testExpectedSwitchInitDB(t)
+	defer dbSession.Close()
+
+	ctx := context.Background()
+	cfg := &config.Config{}
+	handler := NewGetAllExpectedSwitchHandler(dbSession, nil, cfg)
+
+	org := "test-org"
+	infraProv, site := testExpectedSwitchSetupTestData(t, dbSession, org)
+
+	unmanagedIP := &cdbm.InfrastructureProvider{
+		ID:   uuid.New(),
+		Name: "unmanaged-provider",
+		Org:  "other-org",
+	}
+	_, err := dbSession.DB.NewInsert().Model(unmanagedIP).Exec(ctx)
+	assert.Nil(t, err)
+
+	unmanagedSite := &cdbm.Site{
+		ID:                       uuid.New(),
+		Name:                     "unmanaged-site",
+		Org:                      "other-org",
+		InfrastructureProviderID: unmanagedIP.ID,
+		Status:                   cdbm.SiteStatusRegistered,
+	}
+	_, err = dbSession.DB.NewInsert().Model(unmanagedSite).Exec(ctx)
+	assert.Nil(t, err)
+
+	// Create expected switches - one on managed site, one on unmanaged site
+	esDAO := cdbm.NewExpectedSwitchDAO(dbSession)
+	managedES, err := esDAO.Create(ctx, nil, cdbm.ExpectedSwitchCreateInput{
+		ExpectedSwitchID:   uuid.New(),
+		SiteID:             site.ID,
+		BmcMacAddress:      "00:11:22:33:44:AA",
+		SwitchSerialNumber: "MANAGED-SWITCH",
+		Labels:             map[string]string{"env": "test"},
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, managedES)
+
+	unmanagedES, err := esDAO.Create(ctx, nil, cdbm.ExpectedSwitchCreateInput{
+		ExpectedSwitchID:   uuid.New(),
+		SiteID:             unmanagedSite.ID,
+		BmcMacAddress:      "00:11:22:33:44:BB",
+		SwitchSerialNumber: "UNMANAGED-SWITCH",
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, unmanagedES)
+
+	createMockUser := func(org string) *cdbm.User {
+		return &cdbm.User{
+			StarfleetID: cdb.GetStrPtr("test-user"),
+			OrgData: cdbm.OrgData{
+				org: cdbm.Org{
+					ID:          123,
+					Name:        org,
+					DisplayName: org,
+					OrgType:     "ENTERPRISE",
+					Roles:       []string{"FORGE_PROVIDER_VIEWER"},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name                 string
+		siteId               string
+		includeRelations     []string
+		setupContext         func(c echo.Context)
+		expectedStatus       int
+		checkResponseContent func(t *testing.T, body []byte)
+	}{
+		{
+			name:   "successful GetAll without siteId (lists only managed sites)",
+			siteId: "",
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName")
+				c.SetParamValues(org)
+			},
+			expectedStatus: http.StatusOK,
+			checkResponseContent: func(t *testing.T, body []byte) {
+				var response []model.APIExpectedSwitch
+				err := json.Unmarshal(body, &response)
+				assert.Nil(t, err)
+				for _, es := range response {
+					assert.NotEqual(t, unmanagedES.ID, es.ID, "Unmanaged switch should not be in response")
+				}
+			},
+		},
+		{
+			name:   "successful GetAll with valid siteId",
+			siteId: site.ID.String(),
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName")
+				c.SetParamValues(org)
+			},
+			expectedStatus: http.StatusOK,
+			checkResponseContent: func(t *testing.T, body []byte) {
+				var response []model.APIExpectedSwitch
+				err := json.Unmarshal(body, &response)
+				assert.Nil(t, err)
+				for _, es := range response {
+					assert.Equal(t, site.ID, es.SiteID, "All results should be from the specified site")
+				}
+			},
+		},
+		{
+			name:             "successful GetAll with includeRelation=Site",
+			siteId:           "",
+			includeRelations: []string{"Site"},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName")
+				c.SetParamValues(org)
+			},
+			expectedStatus: http.StatusOK,
+			checkResponseContent: func(t *testing.T, body []byte) {
+				var response []model.APIExpectedSwitch
+				err := json.Unmarshal(body, &response)
+				assert.Nil(t, err)
+				assert.Greater(t, len(response), 0, "Should return at least one expected switch")
+				for _, es := range response {
+					assert.NotNil(t, es.Site, "Site relation should be loaded")
+					assert.Equal(t, es.SiteID.String(), es.Site.ID, "Site ID should match")
+				}
+			},
+		},
+		{
+			name:   "cannot retrieve from unmanaged site",
+			siteId: unmanagedSite.ID.String(),
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName")
+				c.SetParamValues(org)
+			},
+			expectedStatus: http.StatusForbidden,
+		},
+	}
+
+	_ = infraProv
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url := "/v2/org/" + org + "/carbide/expected-switch"
+			params := []string{}
+			if tt.siteId != "" {
+				params = append(params, "siteId="+tt.siteId)
+			}
+			for _, relation := range tt.includeRelations {
+				params = append(params, "includeRelation="+relation)
+			}
+			if len(params) > 0 {
+				url += "?" + params[0]
+				for i := 1; i < len(params); i++ {
+					url += "&" + params[i]
+				}
+			}
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			req = req.WithContext(context.Background())
+
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			tt.setupContext(c)
+
+			err := handler.Handle(c)
+
+			assert.Nil(t, err)
+			assert.Equal(t, tt.expectedStatus, rec.Code)
+			if tt.expectedStatus != rec.Code {
+				t.Errorf("Response: %v", rec.Body.String())
+			}
+
+			if tt.checkResponseContent != nil && rec.Code == http.StatusOK {
+				tt.checkResponseContent(t, rec.Body.Bytes())
+			}
+		})
+	}
+}
+
+func TestGetExpectedSwitchHandler_Handle(t *testing.T) {
+	e := echo.New()
+	dbSession := testExpectedSwitchInitDB(t)
+	defer dbSession.Close()
+
+	ctx := context.Background()
+
+	cfg := &config.Config{}
+	handler := NewGetExpectedSwitchHandler(dbSession, nil, cfg)
+
+	org := "test-org"
+	infraProv, site := testExpectedSwitchSetupTestData(t, dbSession, org)
+
+	unmanagedIP := &cdbm.InfrastructureProvider{
+		ID:   uuid.New(),
+		Name: "unmanaged-provider",
+		Org:  "other-org",
+	}
+	_, err := dbSession.DB.NewInsert().Model(unmanagedIP).Exec(ctx)
+	assert.Nil(t, err)
+
+	unmanagedSite := &cdbm.Site{
+		ID:                       uuid.New(),
+		Name:                     "unmanaged-site",
+		Org:                      "other-org",
+		InfrastructureProviderID: unmanagedIP.ID,
+		Status:                   cdbm.SiteStatusRegistered,
+	}
+	_, err = dbSession.DB.NewInsert().Model(unmanagedSite).Exec(ctx)
+	assert.Nil(t, err)
+
+	// Create a test ExpectedSwitch on managed site
+	esDAO := cdbm.NewExpectedSwitchDAO(dbSession)
+	testES, err := esDAO.Create(ctx, nil, cdbm.ExpectedSwitchCreateInput{
+		ExpectedSwitchID:   uuid.New(),
+		SiteID:             site.ID,
+		BmcMacAddress:      "00:11:22:33:44:55",
+		SwitchSerialNumber: "TEST-SWITCH-123",
+		Labels:             map[string]string{"env": "test"},
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, testES)
+
+	// Create a test ExpectedSwitch on unmanaged site
+	unmanagedES, err := esDAO.Create(ctx, nil, cdbm.ExpectedSwitchCreateInput{
+		ExpectedSwitchID:   uuid.New(),
+		SiteID:             unmanagedSite.ID,
+		BmcMacAddress:      "00:11:22:33:44:CC",
+		SwitchSerialNumber: "UNMANAGED-SWITCH-456",
+		Labels:             map[string]string{"env": "unmanaged"},
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, unmanagedES)
+
+	createMockUser := func(org string) *cdbm.User {
+		return &cdbm.User{
+			StarfleetID: cdb.GetStrPtr("test-user"),
+			OrgData: cdbm.OrgData{
+				org: cdbm.Org{
+					ID:          123,
+					Name:        org,
+					DisplayName: org,
+					OrgType:     "ENTERPRISE",
+					Roles:       []string{"FORGE_PROVIDER_ADMIN"},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name           string
+		id             string
+		setupContext   func(c echo.Context)
+		expectedStatus int
+	}{
+		{
+			name: "invalid ID",
+			id:   "invalid-id",
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName", "id")
+				c.SetParamValues(org, "invalid-id")
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "successful retrieval",
+			id:   testES.ID.String(),
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName", "id")
+				c.SetParamValues(org, testES.ID.String())
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "switch not found",
+			id:   "12345678-1234-1234-1234-123456789099",
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName", "id")
+				c.SetParamValues(org, "12345678-1234-1234-1234-123456789099")
+			},
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			name: "cannot retrieve from unmanaged site",
+			id:   unmanagedES.ID.String(),
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName", "id")
+				c.SetParamValues(org, unmanagedES.ID.String())
+			},
+			expectedStatus: http.StatusForbidden,
+		},
+	}
+
+	_ = infraProv
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url := "/v2/org/" + org + "/carbide/expected-switch/" + tt.id
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			req = req.WithContext(context.Background())
+
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			tt.setupContext(c)
+
+			err := handler.Handle(c)
+
+			assert.Nil(t, err)
+			assert.Equal(t, tt.expectedStatus, rec.Code)
+			if tt.expectedStatus != rec.Code {
+				t.Errorf("Response: %v", rec.Body.String())
+			}
+
+			if tt.expectedStatus == http.StatusOK && tt.name == "successful retrieval" {
+				var response model.APIExpectedSwitch
+				err := json.Unmarshal(rec.Body.Bytes(), &response)
+				assert.Nil(t, err)
+				assert.NotNil(t, response.Labels, "Labels should not be nil in response")
+				assert.Equal(t, "test", response.Labels["env"], "Labels in response should contain the 'env' label with value 'test'")
+			}
+		})
+	}
+}
+
+func TestUpdateExpectedSwitchHandler_Handle(t *testing.T) {
+	e := echo.New()
+	dbSession := testExpectedSwitchInitDB(t)
+	defer dbSession.Close()
+
+	ctx := context.Background()
+	cfg := common.GetTestConfig()
+
+	tcfg, _ := cfg.GetTemporalConfig()
+	scp := sc.NewClientPool(tcfg)
+
+	org := "test-org"
+	infraProv, site := testExpectedSwitchSetupTestData(t, dbSession, org)
+
+	unmanagedIP := &cdbm.InfrastructureProvider{
+		ID:   uuid.New(),
+		Name: "unmanaged-provider",
+		Org:  "other-org",
+	}
+	_, err := dbSession.DB.NewInsert().Model(unmanagedIP).Exec(ctx)
+	assert.Nil(t, err)
+
+	unmanagedSite := &cdbm.Site{
+		ID:                       uuid.New(),
+		Name:                     "unmanaged-site",
+		Org:                      "other-org",
+		InfrastructureProviderID: unmanagedIP.ID,
+		Status:                   cdbm.SiteStatusRegistered,
+	}
+	_, err = dbSession.DB.NewInsert().Model(unmanagedSite).Exec(ctx)
+	assert.Nil(t, err)
+
+	// Create a test ExpectedSwitch on managed site
+	esDAO := cdbm.NewExpectedSwitchDAO(dbSession)
+	testES, err := esDAO.Create(ctx, nil, cdbm.ExpectedSwitchCreateInput{
+		ExpectedSwitchID:   uuid.New(),
+		SiteID:             site.ID,
+		BmcMacAddress:      "00:11:22:33:44:DD",
+		SwitchSerialNumber: "UPDATE-SWITCH-123",
+		Labels:             map[string]string{"env": "test"},
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, testES)
+
+	// Create a test ExpectedSwitch on unmanaged site
+	unmanagedES, err := esDAO.Create(ctx, nil, cdbm.ExpectedSwitchCreateInput{
+		ExpectedSwitchID:   uuid.New(),
+		SiteID:             unmanagedSite.ID,
+		BmcMacAddress:      "00:11:22:33:44:EE",
+		SwitchSerialNumber: "UNMANAGED-UPDATE-456",
+		Labels:             map[string]string{"env": "unmanaged"},
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, unmanagedES)
+
+	// Add mock temporal client for the site
+	mockTemporalClient := &tmocks.Client{}
+	mockWorkflowRun := &tmocks.WorkflowRun{}
+	mockWorkflowRun.On("GetID").Return("test-workflow-id")
+	mockWorkflowRun.Mock.On("Get", mock.Anything, mock.Anything).Return(nil)
+	mockTemporalClient.Mock.On("ExecuteWorkflow", mock.Anything, mock.Anything, "UpdateExpectedSwitch", mock.Anything).Return(mockWorkflowRun, nil)
+	scp.IDClientMap[site.ID.String()] = mockTemporalClient
+
+	handler := NewUpdateExpectedSwitchHandler(dbSession, nil, scp, cfg)
+
+	createMockUser := func(org string) *cdbm.User {
+		return &cdbm.User{
+			StarfleetID: cdb.GetStrPtr("test-user"),
+			OrgData: cdbm.OrgData{
+				org: cdbm.Org{
+					ID:          123,
+					Name:        org,
+					DisplayName: org,
+					OrgType:     "ENTERPRISE",
+					Roles:       []string{"FORGE_PROVIDER_ADMIN"},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name           string
+		id             string
+		requestBody    model.APIExpectedSwitchUpdateRequest
+		setupContext   func(c echo.Context)
+		expectedStatus int
+	}{
+		{
+			name: "successful update",
+			id:   testES.ID.String(),
+			requestBody: model.APIExpectedSwitchUpdateRequest{
+				SwitchSerialNumber: cdb.GetStrPtr("UPDATED-SWITCH-123"),
+				Labels:             map[string]string{"env": "updated"},
+			},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName", "id")
+				c.SetParamValues(org, testES.ID.String())
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "body ID mismatch with URL should return 400",
+			id:   testES.ID.String(),
+			requestBody: model.APIExpectedSwitchUpdateRequest{
+				ID:                 cdb.GetStrPtr(uuid.New().String()),
+				SwitchSerialNumber: cdb.GetStrPtr("SHOULD-NOT-UPDATE"),
+			},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName", "id")
+				c.SetParamValues(org, testES.ID.String())
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "cannot update on unmanaged site",
+			id:   unmanagedES.ID.String(),
+			requestBody: model.APIExpectedSwitchUpdateRequest{
+				SwitchSerialNumber: cdb.GetStrPtr("SHOULD-NOT-UPDATE"),
+				Labels:             map[string]string{"env": "fail"},
+			},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName", "id")
+				c.SetParamValues(org, unmanagedES.ID.String())
+			},
+			expectedStatus: http.StatusForbidden,
+		},
+	}
+
+	_ = infraProv
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reqBody, _ := json.Marshal(tt.requestBody)
+			url := "/v2/org/" + org + "/carbide/expected-switch/" + tt.id
+			req := httptest.NewRequest(http.MethodPatch, url, bytes.NewReader(reqBody))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			req = req.WithContext(context.Background())
+
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			tt.setupContext(c)
+
+			err := handler.Handle(c)
+
+			assert.Nil(t, err)
+			assert.Equal(t, tt.expectedStatus, rec.Code)
+			if tt.expectedStatus != rec.Code {
+				t.Errorf("Response: %v", rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestDeleteExpectedSwitchHandler_Handle(t *testing.T) {
+	e := echo.New()
+	dbSession := testExpectedSwitchInitDB(t)
+	defer dbSession.Close()
+
+	ctx := context.Background()
+	cfg := common.GetTestConfig()
+
+	tcfg, _ := cfg.GetTemporalConfig()
+	scp := sc.NewClientPool(tcfg)
+
+	org := "test-org"
+	infraProv, site := testExpectedSwitchSetupTestData(t, dbSession, org)
+
+	unmanagedIP := &cdbm.InfrastructureProvider{
+		ID:   uuid.New(),
+		Name: "unmanaged-provider",
+		Org:  "other-org",
+	}
+	_, err := dbSession.DB.NewInsert().Model(unmanagedIP).Exec(ctx)
+	assert.Nil(t, err)
+
+	unmanagedSite := &cdbm.Site{
+		ID:                       uuid.New(),
+		Name:                     "unmanaged-site",
+		Org:                      "other-org",
+		InfrastructureProviderID: unmanagedIP.ID,
+		Status:                   cdbm.SiteStatusRegistered,
+	}
+	_, err = dbSession.DB.NewInsert().Model(unmanagedSite).Exec(ctx)
+	assert.Nil(t, err)
+
+	// Create a test ExpectedSwitch on managed site (to be deleted)
+	esDAO := cdbm.NewExpectedSwitchDAO(dbSession)
+	testES, err := esDAO.Create(ctx, nil, cdbm.ExpectedSwitchCreateInput{
+		ExpectedSwitchID:   uuid.New(),
+		SiteID:             site.ID,
+		BmcMacAddress:      "00:11:22:33:44:FF",
+		SwitchSerialNumber: "DELETE-SWITCH-123",
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, testES)
+
+	// Create a test ExpectedSwitch on unmanaged site (should not be deletable)
+	unmanagedES, err := esDAO.Create(ctx, nil, cdbm.ExpectedSwitchCreateInput{
+		ExpectedSwitchID:   uuid.New(),
+		SiteID:             unmanagedSite.ID,
+		BmcMacAddress:      "00:11:22:33:55:00",
+		SwitchSerialNumber: "UNMANAGED-DELETE-456",
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, unmanagedES)
+
+	// Add mock temporal client for the site
+	mockTemporalClient := &tmocks.Client{}
+	mockWorkflowRun := &tmocks.WorkflowRun{}
+	mockWorkflowRun.On("GetID").Return("test-workflow-id")
+	mockWorkflowRun.Mock.On("Get", mock.Anything, mock.Anything).Return(nil)
+	mockTemporalClient.Mock.On("ExecuteWorkflow", mock.Anything, mock.Anything, "DeleteExpectedSwitch", mock.Anything).Return(mockWorkflowRun, nil)
+	scp.IDClientMap[site.ID.String()] = mockTemporalClient
+
+	handler := NewDeleteExpectedSwitchHandler(dbSession, nil, scp, cfg)
+
+	createMockUser := func(org string) *cdbm.User {
+		return &cdbm.User{
+			StarfleetID: cdb.GetStrPtr("test-user"),
+			OrgData: cdbm.OrgData{
+				org: cdbm.Org{
+					ID:          123,
+					Name:        org,
+					DisplayName: org,
+					OrgType:     "ENTERPRISE",
+					Roles:       []string{"FORGE_PROVIDER_ADMIN"},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name           string
+		id             string
+		setupContext   func(c echo.Context)
+		expectedStatus int
+	}{
+		{
+			name: "successful delete",
+			id:   testES.ID.String(),
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName", "id")
+				c.SetParamValues(org, testES.ID.String())
+			},
+			expectedStatus: http.StatusNoContent,
+		},
+		{
+			name: "cannot delete on unmanaged site",
+			id:   unmanagedES.ID.String(),
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName", "id")
+				c.SetParamValues(org, unmanagedES.ID.String())
+			},
+			expectedStatus: http.StatusForbidden,
+		},
+	}
+
+	_ = infraProv
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url := "/v2/org/" + org + "/carbide/expected-switch/" + tt.id
+			req := httptest.NewRequest(http.MethodDelete, url, nil)
+			req = req.WithContext(context.Background())
+
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			tt.setupContext(c)
+
+			err := handler.Handle(c)
+
+			assert.Nil(t, err)
+			assert.Equal(t, tt.expectedStatus, rec.Code)
+			if tt.expectedStatus != rec.Code {
+				t.Errorf("Response: %v", rec.Body.String())
+			}
+		})
+	}
+}

--- a/site-workflow/pkg/activity/expectedmachine.go
+++ b/site-workflow/pkg/activity/expectedmachine.go
@@ -276,7 +276,7 @@ func (mem *ManageExpectedMachine) CreateExpectedMachineOnSite(ctx context.Contex
 	// Validate request
 	if request == nil {
 		err = errors.New("received empty create Expected Machine request")
-	} else if id := request.GetId(); id == nil || (*id).String() == "" {
+	} else if request.GetId().GetValue() == "" {
 		err = errors.New("received create Expected Machine request without required id field")
 	} else if request.GetBmcMacAddress() == "" || request.GetChassisSerialNumber() == "" {
 		err = errors.New("received create Expected Machine request with missing MAC or serial")
@@ -316,7 +316,7 @@ func (mem *ManageExpectedMachine) UpdateExpectedMachineOnSite(ctx context.Contex
 	// Validate request
 	if request == nil {
 		err = errors.New("received empty update Expected Machine request")
-	} else if id := request.GetId(); id == nil || (*id).String() == "" {
+	} else if request.GetId().GetValue() == "" {
 		err = errors.New("received update Expected Machine request without required id field")
 	} else if request.GetBmcMacAddress() == "" || request.GetChassisSerialNumber() == "" {
 		err = errors.New("received update Expected Machine request with missing MAC or serial")
@@ -355,7 +355,7 @@ func (mem *ManageExpectedMachine) DeleteExpectedMachineOnSite(ctx context.Contex
 	// Validate request
 	if request == nil {
 		err = errors.New("received empty delete Expected Machine request")
-	} else if id := request.GetId(); id == nil || (*id).String() == "" {
+	} else if request.GetId().GetValue() == "" {
 		err = errors.New("received delete Expected Machine request without required id field")
 	}
 

--- a/site-workflow/pkg/activity/expectedpowershelf.go
+++ b/site-workflow/pkg/activity/expectedpowershelf.go
@@ -120,11 +120,11 @@ func (mepsi *ManageExpectedPowerShelfInventory) DiscoverExpectedPowerShelfInvent
 	allExpectedPowerShelfIDs := []string{}
 	for _, eps := range epsList.ExpectedPowerShelves {
 		// Discard records without ID
-		if eps.Id == nil || eps.Id.Value == "" {
+		if eps.ExpectedPowerShelfId == nil || eps.ExpectedPowerShelfId.Value == "" {
 			logger.Warn().Str("MAC", eps.BmcMacAddress).Str("Serial", eps.ShelfSerialNumber).Msg("Discarding ExpectedPowerShelf without ID")
 			continue
 		}
-		allExpectedPowerShelfIDs = append(allExpectedPowerShelfIDs, eps.Id.Value)
+		allExpectedPowerShelfIDs = append(allExpectedPowerShelfIDs, eps.ExpectedPowerShelfId.Value)
 		// Find matching LinkedPowerShelf record by MAC address if it exists
 		linked := linkedPowerShelvesByKey[eps.BmcMacAddress]
 		linkedExpectedPowerShelvesInfo = append(linkedExpectedPowerShelvesInfo, linkedExpectedPowerShelfInfo{
@@ -273,7 +273,7 @@ func (meps *ManageExpectedPowerShelf) CreateExpectedPowerShelfOnSite(ctx context
 	// Validate request
 	if request == nil {
 		err = errors.New("received empty create Expected Power Shelf request")
-	} else if id := request.GetId(); id == nil || (*id).String() == "" {
+	} else if request.GetExpectedPowerShelfId().GetValue() == "" {
 		err = errors.New("received create Expected Power Shelf request without required id field")
 	} else if request.GetBmcMacAddress() == "" || request.GetShelfSerialNumber() == "" {
 		err = errors.New("received create Expected Power Shelf request with missing MAC or serial")
@@ -310,7 +310,7 @@ func (meps *ManageExpectedPowerShelf) UpdateExpectedPowerShelfOnSite(ctx context
 	// Validate request
 	if request == nil {
 		err = errors.New("received empty update Expected Power Shelf request")
-	} else if id := request.GetId(); id == nil || (*id).String() == "" {
+	} else if request.GetExpectedPowerShelfId().GetValue() == "" {
 		err = errors.New("received update Expected Power Shelf request without required id field")
 	} else if request.GetBmcMacAddress() == "" || request.GetShelfSerialNumber() == "" {
 		err = errors.New("received update Expected Power Shelf request with missing MAC or serial")
@@ -346,7 +346,7 @@ func (meps *ManageExpectedPowerShelf) DeleteExpectedPowerShelfOnSite(ctx context
 	// Validate request
 	if request == nil {
 		err = errors.New("received empty delete Expected Power Shelf request")
-	} else if id := request.GetId(); id == nil || (*id).String() == "" {
+	} else if request.GetExpectedPowerShelfId().GetValue() == "" {
 		err = errors.New("received delete Expected Power Shelf request without required id field")
 	}
 

--- a/site-workflow/pkg/activity/expectedpowershelf_test.go
+++ b/site-workflow/pkg/activity/expectedpowershelf_test.go
@@ -160,9 +160,9 @@ func TestManageExpectedPowerShelf_CreateExpectedPowerShelfOnSite(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				request: &cwssaws.ExpectedPowerShelf{
-					Id:                &cwssaws.UUID{Value: "test-powershelf-001"},
-					BmcMacAddress:     "00:11:22:33:44:55",
-					ShelfSerialNumber: "SHELF-123456789",
+					ExpectedPowerShelfId: &cwssaws.UUID{Value: "test-powershelf-001"},
+					BmcMacAddress:        "00:11:22:33:44:55",
+					ShelfSerialNumber:    "SHELF-123456789",
 				},
 			},
 			wantErr: false,
@@ -175,9 +175,9 @@ func TestManageExpectedPowerShelf_CreateExpectedPowerShelfOnSite(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				request: &cwssaws.ExpectedPowerShelf{
-					Id:                &cwssaws.UUID{Value: "test-powershelf-002"},
-					BmcMacAddress:     "",
-					ShelfSerialNumber: "SHELF-123456789",
+					ExpectedPowerShelfId: &cwssaws.UUID{Value: "test-powershelf-002"},
+					BmcMacAddress:        "",
+					ShelfSerialNumber:    "SHELF-123456789",
 				},
 			},
 			wantErr: true,
@@ -190,9 +190,9 @@ func TestManageExpectedPowerShelf_CreateExpectedPowerShelfOnSite(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				request: &cwssaws.ExpectedPowerShelf{
-					Id:                &cwssaws.UUID{Value: "test-powershelf-003"},
-					BmcMacAddress:     "00:11:22:33:44:55",
-					ShelfSerialNumber: "",
+					ExpectedPowerShelfId: &cwssaws.UUID{Value: "test-powershelf-003"},
+					BmcMacAddress:        "00:11:22:33:44:55",
+					ShelfSerialNumber:    "",
 				},
 			},
 			wantErr: true,
@@ -205,9 +205,9 @@ func TestManageExpectedPowerShelf_CreateExpectedPowerShelfOnSite(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				request: &cwssaws.ExpectedPowerShelf{
-					Id:                nil,
-					BmcMacAddress:     "00:11:22:33:44:55",
-					ShelfSerialNumber: "SHELF-123456789",
+					ExpectedPowerShelfId: nil,
+					BmcMacAddress:        "00:11:22:33:44:55",
+					ShelfSerialNumber:    "SHELF-123456789",
 				},
 			},
 			wantErr: true,
@@ -220,9 +220,9 @@ func TestManageExpectedPowerShelf_CreateExpectedPowerShelfOnSite(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				request: &cwssaws.ExpectedPowerShelf{
-					Id:                &cwssaws.UUID{Value: "test-powershelf-004"},
-					BmcMacAddress:     "",
-					ShelfSerialNumber: "",
+					ExpectedPowerShelfId: &cwssaws.UUID{Value: "test-powershelf-004"},
+					BmcMacAddress:        "",
+					ShelfSerialNumber:    "",
 				},
 			},
 			wantErr: true,
@@ -279,9 +279,9 @@ func TestManageExpectedPowerShelf_UpdateExpectedPowerShelfOnSite(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				request: &cwssaws.ExpectedPowerShelf{
-					Id:                &cwssaws.UUID{Value: "test-update-001"},
-					BmcMacAddress:     "00:11:22:33:44:55",
-					ShelfSerialNumber: "SHELF-123456789",
+					ExpectedPowerShelfId: &cwssaws.UUID{Value: "test-update-001"},
+					BmcMacAddress:        "00:11:22:33:44:55",
+					ShelfSerialNumber:    "SHELF-123456789",
 				},
 			},
 			wantErr: false,
@@ -294,9 +294,9 @@ func TestManageExpectedPowerShelf_UpdateExpectedPowerShelfOnSite(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				request: &cwssaws.ExpectedPowerShelf{
-					Id:                nil,
-					BmcMacAddress:     "00:11:22:33:44:55",
-					ShelfSerialNumber: "SHELF-123456789",
+					ExpectedPowerShelfId: nil,
+					BmcMacAddress:        "00:11:22:33:44:55",
+					ShelfSerialNumber:    "SHELF-123456789",
 				},
 			},
 			wantErr: true,
@@ -309,9 +309,9 @@ func TestManageExpectedPowerShelf_UpdateExpectedPowerShelfOnSite(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				request: &cwssaws.ExpectedPowerShelf{
-					Id:                &cwssaws.UUID{Value: "test-update-002"},
-					BmcMacAddress:     "",
-					ShelfSerialNumber: "SHELF-123456789",
+					ExpectedPowerShelfId: &cwssaws.UUID{Value: "test-update-002"},
+					BmcMacAddress:        "",
+					ShelfSerialNumber:    "SHELF-123456789",
 				},
 			},
 			wantErr: true,
@@ -324,9 +324,9 @@ func TestManageExpectedPowerShelf_UpdateExpectedPowerShelfOnSite(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				request: &cwssaws.ExpectedPowerShelf{
-					Id:                &cwssaws.UUID{Value: "test-update-003"},
-					BmcMacAddress:     "00:11:22:33:44:55",
-					ShelfSerialNumber: "",
+					ExpectedPowerShelfId: &cwssaws.UUID{Value: "test-update-003"},
+					BmcMacAddress:        "00:11:22:33:44:55",
+					ShelfSerialNumber:    "",
 				},
 			},
 			wantErr: true,
@@ -339,9 +339,9 @@ func TestManageExpectedPowerShelf_UpdateExpectedPowerShelfOnSite(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				request: &cwssaws.ExpectedPowerShelf{
-					Id:                &cwssaws.UUID{Value: "test-update-004"},
-					BmcMacAddress:     "",
-					ShelfSerialNumber: "",
+					ExpectedPowerShelfId: &cwssaws.UUID{Value: "test-update-004"},
+					BmcMacAddress:        "",
+					ShelfSerialNumber:    "",
 				},
 			},
 			wantErr: true,
@@ -398,8 +398,8 @@ func TestManageExpectedPowerShelf_DeleteExpectedPowerShelfOnSite(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				request: &cwssaws.ExpectedPowerShelfRequest{
-					Id:            &cwssaws.UUID{Value: "test-delete-001"},
-					BmcMacAddress: "00:11:22:33:44:55",
+					ExpectedPowerShelfId: &cwssaws.UUID{Value: "test-delete-001"},
+					BmcMacAddress:        "00:11:22:33:44:55",
 				},
 			},
 			wantErr: false,
@@ -412,8 +412,8 @@ func TestManageExpectedPowerShelf_DeleteExpectedPowerShelfOnSite(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				request: &cwssaws.ExpectedPowerShelfRequest{
-					Id:            nil,
-					BmcMacAddress: "00:11:22:33:44:55",
+					ExpectedPowerShelfId: nil,
+					BmcMacAddress:        "00:11:22:33:44:55",
 				},
 			},
 			wantErr: true,
@@ -426,8 +426,8 @@ func TestManageExpectedPowerShelf_DeleteExpectedPowerShelfOnSite(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				request: &cwssaws.ExpectedPowerShelfRequest{
-					Id:            &cwssaws.UUID{Value: "test-delete-002"},
-					BmcMacAddress: "",
+					ExpectedPowerShelfId: &cwssaws.UUID{Value: "test-delete-002"},
+					BmcMacAddress:        "",
 				},
 			},
 			wantErr: false,

--- a/site-workflow/pkg/activity/expectedswitch.go
+++ b/site-workflow/pkg/activity/expectedswitch.go
@@ -120,11 +120,11 @@ func (mesi *ManageExpectedSwitchInventory) DiscoverExpectedSwitchInventory(ctx c
 	allExpectedSwitchIDs := []string{}
 	for _, es := range esList.ExpectedSwitches {
 		// Discard records without ID
-		if es.Id == nil || es.Id.Value == "" {
+		if es.ExpectedSwitchId == nil || es.ExpectedSwitchId.Value == "" {
 			logger.Warn().Str("MAC", es.BmcMacAddress).Str("Serial", es.SwitchSerialNumber).Msg("Discarding ExpectedSwitch without ID")
 			continue
 		}
-		allExpectedSwitchIDs = append(allExpectedSwitchIDs, es.Id.Value)
+		allExpectedSwitchIDs = append(allExpectedSwitchIDs, es.ExpectedSwitchId.Value)
 		// Find matching LinkedSwitch record by MAC address if it exists
 		linked := linkedSwitchesByKey[es.BmcMacAddress]
 		linkedExpectedSwitchesInfo = append(linkedExpectedSwitchesInfo, linkedExpectedSwitchInfo{
@@ -273,7 +273,7 @@ func (mes *ManageExpectedSwitch) CreateExpectedSwitchOnSite(ctx context.Context,
 	// Validate request
 	if request == nil {
 		err = errors.New("received empty create Expected Switch request")
-	} else if id := request.GetId(); id == nil || (*id).String() == "" {
+	} else if request.GetExpectedSwitchId().GetValue() == "" {
 		err = errors.New("received create Expected Switch request without required id field")
 	} else if request.GetBmcMacAddress() == "" || request.GetSwitchSerialNumber() == "" {
 		err = errors.New("received create Expected Switch request with missing MAC or serial")
@@ -310,7 +310,7 @@ func (mes *ManageExpectedSwitch) UpdateExpectedSwitchOnSite(ctx context.Context,
 	// Validate request
 	if request == nil {
 		err = errors.New("received empty update Expected Switch request")
-	} else if id := request.GetId(); id == nil || (*id).String() == "" {
+	} else if request.GetExpectedSwitchId().GetValue() == "" {
 		err = errors.New("received update Expected Switch request without required id field")
 	} else if request.GetBmcMacAddress() == "" || request.GetSwitchSerialNumber() == "" {
 		err = errors.New("received update Expected Switch request with missing MAC or serial")
@@ -346,7 +346,7 @@ func (mes *ManageExpectedSwitch) DeleteExpectedSwitchOnSite(ctx context.Context,
 	// Validate request
 	if request == nil {
 		err = errors.New("received empty delete Expected Switch request")
-	} else if id := request.GetId(); id == nil || (*id).String() == "" {
+	} else if request.GetExpectedSwitchId().GetValue() == "" {
 		err = errors.New("received delete Expected Switch request without required id field")
 	}
 

--- a/site-workflow/pkg/activity/expectedswitch_test.go
+++ b/site-workflow/pkg/activity/expectedswitch_test.go
@@ -160,7 +160,7 @@ func TestManageExpectedSwitch_CreateExpectedSwitchOnSite(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				request: &cwssaws.ExpectedSwitch{
-					Id:                 &cwssaws.UUID{Value: "test-switch-001"},
+					ExpectedSwitchId:   &cwssaws.UUID{Value: "test-switch-001"},
 					BmcMacAddress:      "00:11:22:33:44:55",
 					SwitchSerialNumber: "SWITCH-123456789",
 				},
@@ -175,7 +175,7 @@ func TestManageExpectedSwitch_CreateExpectedSwitchOnSite(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				request: &cwssaws.ExpectedSwitch{
-					Id:                 &cwssaws.UUID{Value: "test-switch-002"},
+					ExpectedSwitchId:   &cwssaws.UUID{Value: "test-switch-002"},
 					BmcMacAddress:      "",
 					SwitchSerialNumber: "SWITCH-123456789",
 				},
@@ -190,7 +190,7 @@ func TestManageExpectedSwitch_CreateExpectedSwitchOnSite(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				request: &cwssaws.ExpectedSwitch{
-					Id:                 &cwssaws.UUID{Value: "test-switch-003"},
+					ExpectedSwitchId:   &cwssaws.UUID{Value: "test-switch-003"},
 					BmcMacAddress:      "00:11:22:33:44:55",
 					SwitchSerialNumber: "",
 				},
@@ -205,7 +205,7 @@ func TestManageExpectedSwitch_CreateExpectedSwitchOnSite(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				request: &cwssaws.ExpectedSwitch{
-					Id:                 nil,
+					ExpectedSwitchId:   nil,
 					BmcMacAddress:      "00:11:22:33:44:55",
 					SwitchSerialNumber: "SWITCH-123456789",
 				},
@@ -220,7 +220,7 @@ func TestManageExpectedSwitch_CreateExpectedSwitchOnSite(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				request: &cwssaws.ExpectedSwitch{
-					Id:                 &cwssaws.UUID{Value: "test-switch-004"},
+					ExpectedSwitchId:   &cwssaws.UUID{Value: "test-switch-004"},
 					BmcMacAddress:      "",
 					SwitchSerialNumber: "",
 				},
@@ -279,7 +279,7 @@ func TestManageExpectedSwitch_UpdateExpectedSwitchOnSite(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				request: &cwssaws.ExpectedSwitch{
-					Id:                 &cwssaws.UUID{Value: "test-update-001"},
+					ExpectedSwitchId:   &cwssaws.UUID{Value: "test-update-001"},
 					BmcMacAddress:      "00:11:22:33:44:55",
 					SwitchSerialNumber: "SWITCH-123456789",
 				},
@@ -294,7 +294,7 @@ func TestManageExpectedSwitch_UpdateExpectedSwitchOnSite(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				request: &cwssaws.ExpectedSwitch{
-					Id:                 nil,
+					ExpectedSwitchId:   nil,
 					BmcMacAddress:      "00:11:22:33:44:55",
 					SwitchSerialNumber: "SWITCH-123456789",
 				},
@@ -309,7 +309,7 @@ func TestManageExpectedSwitch_UpdateExpectedSwitchOnSite(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				request: &cwssaws.ExpectedSwitch{
-					Id:                 &cwssaws.UUID{Value: "test-update-002"},
+					ExpectedSwitchId:   &cwssaws.UUID{Value: "test-update-002"},
 					BmcMacAddress:      "",
 					SwitchSerialNumber: "SWITCH-123456789",
 				},
@@ -324,7 +324,7 @@ func TestManageExpectedSwitch_UpdateExpectedSwitchOnSite(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				request: &cwssaws.ExpectedSwitch{
-					Id:                 &cwssaws.UUID{Value: "test-update-003"},
+					ExpectedSwitchId:   &cwssaws.UUID{Value: "test-update-003"},
 					BmcMacAddress:      "00:11:22:33:44:55",
 					SwitchSerialNumber: "",
 				},
@@ -339,7 +339,7 @@ func TestManageExpectedSwitch_UpdateExpectedSwitchOnSite(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				request: &cwssaws.ExpectedSwitch{
-					Id:                 &cwssaws.UUID{Value: "test-update-004"},
+					ExpectedSwitchId:   &cwssaws.UUID{Value: "test-update-004"},
 					BmcMacAddress:      "",
 					SwitchSerialNumber: "",
 				},
@@ -398,8 +398,8 @@ func TestManageExpectedSwitch_DeleteExpectedSwitchOnSite(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				request: &cwssaws.ExpectedSwitchRequest{
-					Id:            &cwssaws.UUID{Value: "test-delete-001"},
-					BmcMacAddress: "00:11:22:33:44:55",
+					ExpectedSwitchId: &cwssaws.UUID{Value: "test-delete-001"},
+					BmcMacAddress:    "00:11:22:33:44:55",
 				},
 			},
 			wantErr: false,
@@ -412,8 +412,8 @@ func TestManageExpectedSwitch_DeleteExpectedSwitchOnSite(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				request: &cwssaws.ExpectedSwitchRequest{
-					Id:            nil,
-					BmcMacAddress: "00:11:22:33:44:55",
+					ExpectedSwitchId: nil,
+					BmcMacAddress:    "00:11:22:33:44:55",
 				},
 			},
 			wantErr: true,
@@ -426,8 +426,8 @@ func TestManageExpectedSwitch_DeleteExpectedSwitchOnSite(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				request: &cwssaws.ExpectedSwitchRequest{
-					Id:            &cwssaws.UUID{Value: "test-delete-002"},
-					BmcMacAddress: "",
+					ExpectedSwitchId: &cwssaws.UUID{Value: "test-delete-002"},
+					BmcMacAddress:    "",
 				},
 			},
 			wantErr: false,

--- a/site-workflow/pkg/grpc/client/testing.go
+++ b/site-workflow/pkg/grpc/client/testing.go
@@ -1054,7 +1054,7 @@ func (c *MockForgeClient) GetAllExpectedMachinesLinked(ctx context.Context, in *
 
 /* Expected Power Shelf mock methods */
 func (c *MockForgeClient) AddExpectedPowerShelf(ctx context.Context, in *wflows.ExpectedPowerShelf, opts ...grpc.CallOption) (*emptypb.Empty, error) {
-	if in.Id == nil || in.Id.Value == "" {
+	if in.ExpectedPowerShelfId == nil || in.ExpectedPowerShelfId.Value == "" {
 		return nil, status.Error(codes.Internal, "ID not provided for AddExpectedPowerShelf")
 	}
 	if in.BmcMacAddress == "" {
@@ -1068,7 +1068,7 @@ func (c *MockForgeClient) AddExpectedPowerShelf(ctx context.Context, in *wflows.
 }
 
 func (c *MockForgeClient) DeleteExpectedPowerShelf(ctx context.Context, in *wflows.ExpectedPowerShelfRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
-	if in.Id == nil || in.Id.Value == "" {
+	if in.ExpectedPowerShelfId == nil || in.ExpectedPowerShelfId.Value == "" {
 		return nil, status.Error(codes.Internal, "ID not provided for DeleteExpectedPowerShelf")
 	}
 	out := new(emptypb.Empty)
@@ -1076,7 +1076,7 @@ func (c *MockForgeClient) DeleteExpectedPowerShelf(ctx context.Context, in *wflo
 }
 
 func (c *MockForgeClient) UpdateExpectedPowerShelf(ctx context.Context, in *wflows.ExpectedPowerShelf, opts ...grpc.CallOption) (*emptypb.Empty, error) {
-	if in.Id == nil || in.Id.Value == "" {
+	if in.ExpectedPowerShelfId == nil || in.ExpectedPowerShelfId.Value == "" {
 		return nil, status.Error(codes.Internal, "ID not provided for UpdateExpectedPowerShelf")
 	}
 	if in.BmcMacAddress == "" {
@@ -1107,9 +1107,9 @@ func (c *MockForgeClient) GetAllExpectedPowerShelves(ctx context.Context, in *em
 			copy(uuidBytes[:6], mac)
 			epsID, _ := uuid.FromBytes(uuidBytes[:])
 			out.ExpectedPowerShelves = append(out.ExpectedPowerShelves, &wflows.ExpectedPowerShelf{
-				Id:                &wflows.UUID{Value: epsID.String()},
-				BmcMacAddress:     mac.String(),
-				ShelfSerialNumber: "shelf-serial-" + mac.String()})
+				ExpectedPowerShelfId: &wflows.UUID{Value: epsID.String()},
+				BmcMacAddress:        mac.String(),
+				ShelfSerialNumber:    "shelf-serial-" + mac.String()})
 			incrementMAC(mac)
 		}
 	}
@@ -1149,7 +1149,7 @@ func (c *MockForgeClient) GetAllExpectedPowerShelvesLinked(ctx context.Context, 
 
 /* Expected Switch mock methods */
 func (c *MockForgeClient) AddExpectedSwitch(ctx context.Context, in *wflows.ExpectedSwitch, opts ...grpc.CallOption) (*emptypb.Empty, error) {
-	if in.Id == nil || in.Id.Value == "" {
+	if in.ExpectedSwitchId == nil || in.ExpectedSwitchId.Value == "" {
 		return nil, status.Error(codes.Internal, "ID not provided for AddExpectedSwitch")
 	}
 	if in.BmcMacAddress == "" {
@@ -1163,7 +1163,7 @@ func (c *MockForgeClient) AddExpectedSwitch(ctx context.Context, in *wflows.Expe
 }
 
 func (c *MockForgeClient) DeleteExpectedSwitch(ctx context.Context, in *wflows.ExpectedSwitchRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
-	if in.Id == nil || in.Id.Value == "" {
+	if in.ExpectedSwitchId == nil || in.ExpectedSwitchId.Value == "" {
 		return nil, status.Error(codes.Internal, "ID not provided for DeleteExpectedSwitch")
 	}
 	out := new(emptypb.Empty)
@@ -1171,7 +1171,7 @@ func (c *MockForgeClient) DeleteExpectedSwitch(ctx context.Context, in *wflows.E
 }
 
 func (c *MockForgeClient) UpdateExpectedSwitch(ctx context.Context, in *wflows.ExpectedSwitch, opts ...grpc.CallOption) (*emptypb.Empty, error) {
-	if in.Id == nil || in.Id.Value == "" {
+	if in.ExpectedSwitchId == nil || in.ExpectedSwitchId.Value == "" {
 		return nil, status.Error(codes.Internal, "ID not provided for UpdateExpectedSwitch")
 	}
 	if in.BmcMacAddress == "" {
@@ -1202,7 +1202,7 @@ func (c *MockForgeClient) GetAllExpectedSwitches(ctx context.Context, in *emptyp
 			copy(uuidBytes[:6], mac)
 			esID, _ := uuid.FromBytes(uuidBytes[:])
 			out.ExpectedSwitches = append(out.ExpectedSwitches, &wflows.ExpectedSwitch{
-				Id:                 &wflows.UUID{Value: esID.String()},
+				ExpectedSwitchId:   &wflows.UUID{Value: esID.String()},
 				BmcMacAddress:      mac.String(),
 				SwitchSerialNumber: "switch-serial-" + mac.String()})
 			incrementMAC(mac)

--- a/site-workflow/pkg/grpc/server/forge_test_server.go
+++ b/site-workflow/pkg/grpc/server/forge_test_server.go
@@ -1135,7 +1135,7 @@ func (f *ForgeServerImpl) UpdateExpectedMachines(ctx context.Context, req *cwssa
 
 // AddExpectedPowerShelf implements interface ForgeServer
 func (f *ForgeServerImpl) AddExpectedPowerShelf(ctx context.Context, req *cwssaws.ExpectedPowerShelf) (*emptypb.Empty, error) {
-	if req == nil || req.Id == nil || req.Id.Value == "" {
+	if req == nil || req.ExpectedPowerShelfId == nil || req.ExpectedPowerShelfId.Value == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "ID not provided for AddExpectedPowerShelf")
 	}
 	if req.BmcMacAddress == "" {
@@ -1144,13 +1144,13 @@ func (f *ForgeServerImpl) AddExpectedPowerShelf(ctx context.Context, req *cwssaw
 	if req.ShelfSerialNumber == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "Shelf Serial Number not provided for AddExpectedPowerShelf")
 	}
-	f.eps[req.Id.Value] = req
+	f.eps[req.ExpectedPowerShelfId.Value] = req
 	return &emptypb.Empty{}, nil
 }
 
 // UpdateExpectedPowerShelf implements interface ForgeServer
 func (f *ForgeServerImpl) UpdateExpectedPowerShelf(ctx context.Context, req *cwssaws.ExpectedPowerShelf) (*emptypb.Empty, error) {
-	if req == nil || req.Id == nil || req.Id.Value == "" {
+	if req == nil || req.ExpectedPowerShelfId == nil || req.ExpectedPowerShelfId.Value == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "ID not provided for UpdateExpectedPowerShelf")
 	}
 	if req.BmcMacAddress == "" {
@@ -1159,33 +1159,33 @@ func (f *ForgeServerImpl) UpdateExpectedPowerShelf(ctx context.Context, req *cws
 	if req.ShelfSerialNumber == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "Shelf Serial Number not provided for UpdateExpectedPowerShelf")
 	}
-	if _, ok := f.eps[req.Id.Value]; !ok {
-		return nil, status.Errorf(codes.NotFound, "ExpectedPowerShelf with ID %q not found", req.Id.Value)
+	if _, ok := f.eps[req.ExpectedPowerShelfId.Value]; !ok {
+		return nil, status.Errorf(codes.NotFound, "ExpectedPowerShelf with ID %q not found", req.ExpectedPowerShelfId.Value)
 	}
-	f.eps[req.Id.Value] = req
+	f.eps[req.ExpectedPowerShelfId.Value] = req
 	return &emptypb.Empty{}, nil
 }
 
 // DeleteExpectedPowerShelf implements interface ForgeServer
 func (f *ForgeServerImpl) DeleteExpectedPowerShelf(ctx context.Context, req *cwssaws.ExpectedPowerShelfRequest) (*emptypb.Empty, error) {
-	if req == nil || req.Id == nil || req.Id.Value == "" {
+	if req == nil || req.ExpectedPowerShelfId == nil || req.ExpectedPowerShelfId.Value == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "ID not provided for DeleteExpectedPowerShelf")
 	}
-	if _, ok := f.eps[req.Id.Value]; !ok {
-		return nil, status.Errorf(codes.NotFound, "ExpectedPowerShelf with ID %q not found", req.Id.Value)
+	if _, ok := f.eps[req.ExpectedPowerShelfId.Value]; !ok {
+		return nil, status.Errorf(codes.NotFound, "ExpectedPowerShelf with ID %q not found", req.ExpectedPowerShelfId.Value)
 	}
-	delete(f.eps, req.Id.Value)
+	delete(f.eps, req.ExpectedPowerShelfId.Value)
 	return &emptypb.Empty{}, nil
 }
 
 // GetExpectedPowerShelf implements interface ForgeServer
 func (f *ForgeServerImpl) GetExpectedPowerShelf(ctx context.Context, req *cwssaws.ExpectedPowerShelfRequest) (*cwssaws.ExpectedPowerShelf, error) {
-	if req == nil || req.Id == nil || req.Id.Value == "" {
+	if req == nil || req.ExpectedPowerShelfId == nil || req.ExpectedPowerShelfId.Value == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "ID not provided for GetExpectedPowerShelf")
 	}
-	eps, ok := f.eps[req.Id.Value]
+	eps, ok := f.eps[req.ExpectedPowerShelfId.Value]
 	if !ok {
-		return nil, status.Errorf(codes.NotFound, "ExpectedPowerShelf with ID %q not found", req.Id.Value)
+		return nil, status.Errorf(codes.NotFound, "ExpectedPowerShelf with ID %q not found", req.ExpectedPowerShelfId.Value)
 	}
 	return eps, nil
 }
@@ -1201,7 +1201,7 @@ func (f *ForgeServerImpl) GetAllExpectedPowerShelves(ctx context.Context, req *e
 
 // AddExpectedSwitch implements interface ForgeServer
 func (f *ForgeServerImpl) AddExpectedSwitch(ctx context.Context, req *cwssaws.ExpectedSwitch) (*emptypb.Empty, error) {
-	if req == nil || req.Id == nil || req.Id.Value == "" {
+	if req == nil || req.ExpectedSwitchId == nil || req.ExpectedSwitchId.Value == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "ID not provided for AddExpectedSwitch")
 	}
 	if req.BmcMacAddress == "" {
@@ -1210,13 +1210,13 @@ func (f *ForgeServerImpl) AddExpectedSwitch(ctx context.Context, req *cwssaws.Ex
 	if req.SwitchSerialNumber == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "Switch Serial Number not provided for AddExpectedSwitch")
 	}
-	f.es[req.Id.Value] = req
+	f.es[req.ExpectedSwitchId.Value] = req
 	return &emptypb.Empty{}, nil
 }
 
 // UpdateExpectedSwitch implements interface ForgeServer
 func (f *ForgeServerImpl) UpdateExpectedSwitch(ctx context.Context, req *cwssaws.ExpectedSwitch) (*emptypb.Empty, error) {
-	if req == nil || req.Id == nil || req.Id.Value == "" {
+	if req == nil || req.ExpectedSwitchId == nil || req.ExpectedSwitchId.Value == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "ID not provided for UpdateExpectedSwitch")
 	}
 	if req.BmcMacAddress == "" {
@@ -1225,33 +1225,33 @@ func (f *ForgeServerImpl) UpdateExpectedSwitch(ctx context.Context, req *cwssaws
 	if req.SwitchSerialNumber == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "Switch Serial Number not provided for UpdateExpectedSwitch")
 	}
-	if _, ok := f.es[req.Id.Value]; !ok {
-		return nil, status.Errorf(codes.NotFound, "ExpectedSwitch with ID %q not found", req.Id.Value)
+	if _, ok := f.es[req.ExpectedSwitchId.Value]; !ok {
+		return nil, status.Errorf(codes.NotFound, "ExpectedSwitch with ID %q not found", req.ExpectedSwitchId.Value)
 	}
-	f.es[req.Id.Value] = req
+	f.es[req.ExpectedSwitchId.Value] = req
 	return &emptypb.Empty{}, nil
 }
 
 // DeleteExpectedSwitch implements interface ForgeServer
 func (f *ForgeServerImpl) DeleteExpectedSwitch(ctx context.Context, req *cwssaws.ExpectedSwitchRequest) (*emptypb.Empty, error) {
-	if req == nil || req.Id == nil || req.Id.Value == "" {
+	if req == nil || req.ExpectedSwitchId == nil || req.ExpectedSwitchId.Value == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "ID not provided for DeleteExpectedSwitch")
 	}
-	if _, ok := f.es[req.Id.Value]; !ok {
-		return nil, status.Errorf(codes.NotFound, "ExpectedSwitch with ID %q not found", req.Id.Value)
+	if _, ok := f.es[req.ExpectedSwitchId.Value]; !ok {
+		return nil, status.Errorf(codes.NotFound, "ExpectedSwitch with ID %q not found", req.ExpectedSwitchId.Value)
 	}
-	delete(f.es, req.Id.Value)
+	delete(f.es, req.ExpectedSwitchId.Value)
 	return &emptypb.Empty{}, nil
 }
 
 // GetExpectedSwitch implements interface ForgeServer
 func (f *ForgeServerImpl) GetExpectedSwitch(ctx context.Context, req *cwssaws.ExpectedSwitchRequest) (*cwssaws.ExpectedSwitch, error) {
-	if req == nil || req.Id == nil || req.Id.Value == "" {
+	if req == nil || req.ExpectedSwitchId == nil || req.ExpectedSwitchId.Value == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "ID not provided for GetExpectedSwitch")
 	}
-	es, ok := f.es[req.Id.Value]
+	es, ok := f.es[req.ExpectedSwitchId.Value]
 	if !ok {
-		return nil, status.Errorf(codes.NotFound, "ExpectedSwitch with ID %q not found", req.Id.Value)
+		return nil, status.Errorf(codes.NotFound, "ExpectedSwitch with ID %q not found", req.ExpectedSwitchId.Value)
 	}
 	return es, nil
 }

--- a/site-workflow/pkg/workflow/expectedpowershelf.go
+++ b/site-workflow/pkg/workflow/expectedpowershelf.go
@@ -66,7 +66,7 @@ func DiscoverExpectedPowerShelfInventory(ctx workflow.Context) error {
 
 // CreateExpectedPowerShelf is a workflow to create a new Expected Power Shelf using the CreateExpectedPowerShelfOnSite activity
 func CreateExpectedPowerShelf(ctx workflow.Context, request *cwssaws.ExpectedPowerShelf) error {
-	logger := log.With().Str("Workflow", "ExpectedPowerShelf").Str("Action", "Create").Str("ID", request.GetId().GetValue()).Str("Expected MAC address", request.BmcMacAddress).Str("Serial", request.ShelfSerialNumber).Logger()
+	logger := log.With().Str("Workflow", "ExpectedPowerShelf").Str("Action", "Create").Str("ID", request.GetExpectedPowerShelfId().GetValue()).Str("Expected MAC address", request.BmcMacAddress).Str("Serial", request.ShelfSerialNumber).Logger()
 
 	logger.Info().Msg("starting workflow")
 
@@ -101,7 +101,7 @@ func CreateExpectedPowerShelf(ctx workflow.Context, request *cwssaws.ExpectedPow
 
 // UpdateExpectedPowerShelf is a workflow to update an Expected Power Shelf using the UpdateExpectedPowerShelfOnSite activity
 func UpdateExpectedPowerShelf(ctx workflow.Context, request *cwssaws.ExpectedPowerShelf) error {
-	logger := log.With().Str("Workflow", "ExpectedPowerShelf").Str("Action", "Update").Str("ID", request.GetId().GetValue()).Str("Expected MAC address", request.BmcMacAddress).Str("Serial", request.ShelfSerialNumber).Logger()
+	logger := log.With().Str("Workflow", "ExpectedPowerShelf").Str("Action", "Update").Str("ID", request.GetExpectedPowerShelfId().GetValue()).Str("Expected MAC address", request.BmcMacAddress).Str("Serial", request.ShelfSerialNumber).Logger()
 
 	logger.Info().Msg("starting workflow")
 
@@ -136,7 +136,7 @@ func UpdateExpectedPowerShelf(ctx workflow.Context, request *cwssaws.ExpectedPow
 
 // DeleteExpectedPowerShelf is a workflow to Delete an Expected Power Shelf using the DeleteExpectedPowerShelfOnSite activity
 func DeleteExpectedPowerShelf(ctx workflow.Context, request *cwssaws.ExpectedPowerShelfRequest) error {
-	logger := log.With().Str("Workflow", "ExpectedPowerShelf").Str("Action", "Delete").Str("ID", request.GetId().GetValue()).Str("optional MAC address", request.BmcMacAddress).Logger()
+	logger := log.With().Str("Workflow", "ExpectedPowerShelf").Str("Action", "Delete").Str("ID", request.GetExpectedPowerShelfId().GetValue()).Str("optional MAC address", request.BmcMacAddress).Logger()
 
 	logger.Info().Msg("starting workflow")
 

--- a/site-workflow/pkg/workflow/expectedpowershelf_test.go
+++ b/site-workflow/pkg/workflow/expectedpowershelf_test.go
@@ -98,9 +98,9 @@ func (cepsts *CreateExpectedPowerShelfTestSuite) Test_CreateExpectedPowerShelf_S
 	var expectedPowerShelfManager iActivity.ManageExpectedPowerShelf
 
 	request := &cwssaws.ExpectedPowerShelf{
-		Id:                &cwssaws.UUID{Value: "test-create-workflow-001"},
-		BmcMacAddress:     "00:11:22:33:44:55",
-		ShelfSerialNumber: "SHELF-001",
+		ExpectedPowerShelfId: &cwssaws.UUID{Value: "test-create-workflow-001"},
+		BmcMacAddress:        "00:11:22:33:44:55",
+		ShelfSerialNumber:    "SHELF-001",
 	}
 
 	// Mock CreateExpectedPowerShelfOnSite activity
@@ -117,9 +117,9 @@ func (cepsts *CreateExpectedPowerShelfTestSuite) Test_CreateExpectedPowerShelf_F
 	var expectedPowerShelfManager iActivity.ManageExpectedPowerShelf
 
 	request := &cwssaws.ExpectedPowerShelf{
-		Id:                &cwssaws.UUID{Value: "test-create-workflow-001"},
-		BmcMacAddress:     "00:11:22:33:44:55",
-		ShelfSerialNumber: "SHELF-001",
+		ExpectedPowerShelfId: &cwssaws.UUID{Value: "test-create-workflow-001"},
+		BmcMacAddress:        "00:11:22:33:44:55",
+		ShelfSerialNumber:    "SHELF-001",
 	}
 
 	errMsg := "Site Controller communication error"
@@ -157,9 +157,9 @@ func (uepsts *UpdateExpectedPowerShelfTestSuite) Test_UpdateExpectedPowerShelf_S
 	var expectedPowerShelfManager iActivity.ManageExpectedPowerShelf
 
 	request := &cwssaws.ExpectedPowerShelf{
-		Id:                &cwssaws.UUID{Value: "test-update-workflow-001"},
-		BmcMacAddress:     "00:11:22:33:44:55",
-		ShelfSerialNumber: "SHELF-001",
+		ExpectedPowerShelfId: &cwssaws.UUID{Value: "test-update-workflow-001"},
+		BmcMacAddress:        "00:11:22:33:44:55",
+		ShelfSerialNumber:    "SHELF-001",
 	}
 
 	// Mock UpdateExpectedPowerShelfOnSite activity
@@ -176,9 +176,9 @@ func (uepsts *UpdateExpectedPowerShelfTestSuite) Test_UpdateExpectedPowerShelf_F
 	var expectedPowerShelfManager iActivity.ManageExpectedPowerShelf
 
 	request := &cwssaws.ExpectedPowerShelf{
-		Id:                &cwssaws.UUID{Value: "test-update-workflow-001"},
-		BmcMacAddress:     "00:11:22:33:44:55",
-		ShelfSerialNumber: "SHELF-001",
+		ExpectedPowerShelfId: &cwssaws.UUID{Value: "test-update-workflow-001"},
+		BmcMacAddress:        "00:11:22:33:44:55",
+		ShelfSerialNumber:    "SHELF-001",
 	}
 
 	errMsg := "Site Controller communication error"
@@ -216,8 +216,8 @@ func (depsts *DeleteExpectedPowerShelfTestSuite) Test_DeleteExpectedPowerShelf_S
 	var expectedPowerShelfManager iActivity.ManageExpectedPowerShelf
 
 	request := &cwssaws.ExpectedPowerShelfRequest{
-		Id:            &cwssaws.UUID{Value: "test-delete-workflow-001"},
-		BmcMacAddress: "00:11:22:33:44:55",
+		ExpectedPowerShelfId: &cwssaws.UUID{Value: "test-delete-workflow-001"},
+		BmcMacAddress:        "00:11:22:33:44:55",
 	}
 
 	// Mock DeleteExpectedPowerShelfOnSite activity
@@ -234,8 +234,8 @@ func (depsts *DeleteExpectedPowerShelfTestSuite) Test_DeleteExpectedPowerShelf_F
 	var expectedPowerShelfManager iActivity.ManageExpectedPowerShelf
 
 	request := &cwssaws.ExpectedPowerShelfRequest{
-		Id:            &cwssaws.UUID{Value: "test-delete-workflow-001"},
-		BmcMacAddress: "00:11:22:33:44:55",
+		ExpectedPowerShelfId: &cwssaws.UUID{Value: "test-delete-workflow-001"},
+		BmcMacAddress:        "00:11:22:33:44:55",
 	}
 
 	errMsg := "Site Controller communication error"

--- a/site-workflow/pkg/workflow/expectedswitch.go
+++ b/site-workflow/pkg/workflow/expectedswitch.go
@@ -66,7 +66,7 @@ func DiscoverExpectedSwitchInventory(ctx workflow.Context) error {
 
 // CreateExpectedSwitch is a workflow to create a new Expected Switch using the CreateExpectedSwitchOnSite activity
 func CreateExpectedSwitch(ctx workflow.Context, request *cwssaws.ExpectedSwitch) error {
-	logger := log.With().Str("Workflow", "ExpectedSwitch").Str("Action", "Create").Str("ID", request.GetId().GetValue()).Str("Expected MAC address", request.BmcMacAddress).Str("Serial", request.SwitchSerialNumber).Logger()
+	logger := log.With().Str("Workflow", "ExpectedSwitch").Str("Action", "Create").Str("ID", request.GetExpectedSwitchId().GetValue()).Str("Expected MAC address", request.BmcMacAddress).Str("Serial", request.SwitchSerialNumber).Logger()
 
 	logger.Info().Msg("starting workflow")
 
@@ -101,7 +101,7 @@ func CreateExpectedSwitch(ctx workflow.Context, request *cwssaws.ExpectedSwitch)
 
 // UpdateExpectedSwitch is a workflow to update an Expected Switch using the UpdateExpectedSwitchOnSite activity
 func UpdateExpectedSwitch(ctx workflow.Context, request *cwssaws.ExpectedSwitch) error {
-	logger := log.With().Str("Workflow", "ExpectedSwitch").Str("Action", "Update").Str("ID", request.GetId().GetValue()).Str("Expected MAC address", request.BmcMacAddress).Str("Serial", request.SwitchSerialNumber).Logger()
+	logger := log.With().Str("Workflow", "ExpectedSwitch").Str("Action", "Update").Str("ID", request.GetExpectedSwitchId().GetValue()).Str("Expected MAC address", request.BmcMacAddress).Str("Serial", request.SwitchSerialNumber).Logger()
 
 	logger.Info().Msg("starting workflow")
 
@@ -136,7 +136,7 @@ func UpdateExpectedSwitch(ctx workflow.Context, request *cwssaws.ExpectedSwitch)
 
 // DeleteExpectedSwitch is a workflow to Delete an Expected Switch using the DeleteExpectedSwitchOnSite activity
 func DeleteExpectedSwitch(ctx workflow.Context, request *cwssaws.ExpectedSwitchRequest) error {
-	logger := log.With().Str("Workflow", "ExpectedSwitch").Str("Action", "Delete").Str("ID", request.GetId().GetValue()).Str("optional MAC address", request.BmcMacAddress).Logger()
+	logger := log.With().Str("Workflow", "ExpectedSwitch").Str("Action", "Delete").Str("ID", request.GetExpectedSwitchId().GetValue()).Str("optional MAC address", request.BmcMacAddress).Logger()
 
 	logger.Info().Msg("starting workflow")
 

--- a/site-workflow/pkg/workflow/expectedswitch_test.go
+++ b/site-workflow/pkg/workflow/expectedswitch_test.go
@@ -98,7 +98,7 @@ func (cests *CreateExpectedSwitchTestSuite) Test_CreateExpectedSwitch_Success() 
 	var expectedSwitchManager iActivity.ManageExpectedSwitch
 
 	request := &cwssaws.ExpectedSwitch{
-		Id:                 &cwssaws.UUID{Value: "test-create-workflow-001"},
+		ExpectedSwitchId:   &cwssaws.UUID{Value: "test-create-workflow-001"},
 		BmcMacAddress:      "00:11:22:33:44:55",
 		SwitchSerialNumber: "SWITCH-001",
 	}
@@ -117,7 +117,7 @@ func (cests *CreateExpectedSwitchTestSuite) Test_CreateExpectedSwitch_Failure() 
 	var expectedSwitchManager iActivity.ManageExpectedSwitch
 
 	request := &cwssaws.ExpectedSwitch{
-		Id:                 &cwssaws.UUID{Value: "test-create-workflow-001"},
+		ExpectedSwitchId:   &cwssaws.UUID{Value: "test-create-workflow-001"},
 		BmcMacAddress:      "00:11:22:33:44:55",
 		SwitchSerialNumber: "SWITCH-001",
 	}
@@ -157,7 +157,7 @@ func (uests *UpdateExpectedSwitchTestSuite) Test_UpdateExpectedSwitch_Success() 
 	var expectedSwitchManager iActivity.ManageExpectedSwitch
 
 	request := &cwssaws.ExpectedSwitch{
-		Id:                 &cwssaws.UUID{Value: "test-update-workflow-001"},
+		ExpectedSwitchId:   &cwssaws.UUID{Value: "test-update-workflow-001"},
 		BmcMacAddress:      "00:11:22:33:44:55",
 		SwitchSerialNumber: "SWITCH-001",
 	}
@@ -176,7 +176,7 @@ func (uests *UpdateExpectedSwitchTestSuite) Test_UpdateExpectedSwitch_Failure() 
 	var expectedSwitchManager iActivity.ManageExpectedSwitch
 
 	request := &cwssaws.ExpectedSwitch{
-		Id:                 &cwssaws.UUID{Value: "test-update-workflow-001"},
+		ExpectedSwitchId:   &cwssaws.UUID{Value: "test-update-workflow-001"},
 		BmcMacAddress:      "00:11:22:33:44:55",
 		SwitchSerialNumber: "SWITCH-001",
 	}
@@ -216,8 +216,8 @@ func (dests *DeleteExpectedSwitchTestSuite) Test_DeleteExpectedSwitch_Success() 
 	var expectedSwitchManager iActivity.ManageExpectedSwitch
 
 	request := &cwssaws.ExpectedSwitchRequest{
-		Id:            &cwssaws.UUID{Value: "test-delete-workflow-001"},
-		BmcMacAddress: "00:11:22:33:44:55",
+		ExpectedSwitchId: &cwssaws.UUID{Value: "test-delete-workflow-001"},
+		BmcMacAddress:    "00:11:22:33:44:55",
 	}
 
 	// Mock DeleteExpectedSwitchOnSite activity
@@ -234,8 +234,8 @@ func (dests *DeleteExpectedSwitchTestSuite) Test_DeleteExpectedSwitch_Failure() 
 	var expectedSwitchManager iActivity.ManageExpectedSwitch
 
 	request := &cwssaws.ExpectedSwitchRequest{
-		Id:            &cwssaws.UUID{Value: "test-delete-workflow-001"},
-		BmcMacAddress: "00:11:22:33:44:55",
+		ExpectedSwitchId: &cwssaws.UUID{Value: "test-delete-workflow-001"},
+		BmcMacAddress:    "00:11:22:33:44:55",
 	}
 
 	errMsg := "Site Controller communication error"

--- a/workflow-schema/schema/site-agent/workflows/v1/forge_carbide.pb.go
+++ b/workflow-schema/schema/site-agent/workflows/v1/forge_carbide.pb.go
@@ -24214,9 +24214,9 @@ type ExpectedPowerShelf struct {
 	Metadata *Metadata `protobuf:"bytes,6,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	RackId   *string   `protobuf:"bytes,7,opt,name=rack_id,json=rackId,proto3,oneof" json:"rack_id,omitempty"`
 	// Unique identifier for the expected power shelf. When omitted, server generates one.
-	Id            *UUID `protobuf:"bytes,8,opt,name=id,proto3,oneof" json:"id,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	ExpectedPowerShelfId *UUID `protobuf:"bytes,8,opt,name=expected_power_shelf_id,json=expectedPowerShelfId,proto3,oneof" json:"expected_power_shelf_id,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *ExpectedPowerShelf) Reset() {
@@ -24298,9 +24298,9 @@ func (x *ExpectedPowerShelf) GetRackId() string {
 	return ""
 }
 
-func (x *ExpectedPowerShelf) GetId() *UUID {
+func (x *ExpectedPowerShelf) GetExpectedPowerShelfId() *UUID {
 	if x != nil {
-		return x.Id
+		return x.ExpectedPowerShelfId
 	}
 	return nil
 }
@@ -24309,9 +24309,9 @@ type ExpectedPowerShelfRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	BmcMacAddress string                 `protobuf:"bytes,1,opt,name=bmc_mac_address,json=bmcMacAddress,proto3" json:"bmc_mac_address,omitempty"`
 	// Optional unique identifier for selecting an expected power shelf.
-	Id            *UUID `protobuf:"bytes,2,opt,name=id,proto3,oneof" json:"id,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	ExpectedPowerShelfId *UUID `protobuf:"bytes,2,opt,name=expected_power_shelf_id,json=expectedPowerShelfId,proto3,oneof" json:"expected_power_shelf_id,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *ExpectedPowerShelfRequest) Reset() {
@@ -24351,9 +24351,9 @@ func (x *ExpectedPowerShelfRequest) GetBmcMacAddress() string {
 	return ""
 }
 
-func (x *ExpectedPowerShelfRequest) GetId() *UUID {
+func (x *ExpectedPowerShelfRequest) GetExpectedPowerShelfId() *UUID {
 	if x != nil {
-		return x.Id
+		return x.ExpectedPowerShelfId
 	}
 	return nil
 }
@@ -24527,9 +24527,9 @@ type ExpectedSwitch struct {
 	NvosUsername *string   `protobuf:"bytes,7,opt,name=nvos_username,json=nvosUsername,proto3,oneof" json:"nvos_username,omitempty"`
 	NvosPassword *string   `protobuf:"bytes,8,opt,name=nvos_password,json=nvosPassword,proto3,oneof" json:"nvos_password,omitempty"`
 	// Unique identifier for the expected switch. When omitted, server generates one.
-	Id            *UUID `protobuf:"bytes,9,opt,name=id,proto3,oneof" json:"id,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	ExpectedSwitchId *UUID `protobuf:"bytes,9,opt,name=expected_switch_id,json=expectedSwitchId,proto3,oneof" json:"expected_switch_id,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *ExpectedSwitch) Reset() {
@@ -24618,9 +24618,9 @@ func (x *ExpectedSwitch) GetNvosPassword() string {
 	return ""
 }
 
-func (x *ExpectedSwitch) GetId() *UUID {
+func (x *ExpectedSwitch) GetExpectedSwitchId() *UUID {
 	if x != nil {
-		return x.Id
+		return x.ExpectedSwitchId
 	}
 	return nil
 }
@@ -24629,9 +24629,9 @@ type ExpectedSwitchRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	BmcMacAddress string                 `protobuf:"bytes,1,opt,name=bmc_mac_address,json=bmcMacAddress,proto3" json:"bmc_mac_address,omitempty"`
 	// Optional unique identifier for selecting an expected switch.
-	Id            *UUID `protobuf:"bytes,2,opt,name=id,proto3,oneof" json:"id,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	ExpectedSwitchId *UUID `protobuf:"bytes,2,opt,name=expected_switch_id,json=expectedSwitchId,proto3,oneof" json:"expected_switch_id,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *ExpectedSwitchRequest) Reset() {
@@ -24671,9 +24671,9 @@ func (x *ExpectedSwitchRequest) GetBmcMacAddress() string {
 	return ""
 }
 
-func (x *ExpectedSwitchRequest) GetId() *UUID {
+func (x *ExpectedSwitchRequest) GetExpectedSwitchId() *UUID {
 	if x != nil {
-		return x.Id
+		return x.ExpectedSwitchId
 	}
 	return nil
 }
@@ -39631,7 +39631,7 @@ const file_forge_carbide_proto_rawDesc = "" +
 	"\x0e_error_messageB\x13\n" +
 	"\x11_expected_machine\"h\n" +
 	"%BatchExpectedMachineOperationResponse\x12?\n" +
-	"\aresults\x18\x01 \x03(\v2%.forge.ExpectedMachineOperationResultR\aresults\"\xd2\x02\n" +
+	"\aresults\x18\x01 \x03(\v2%.forge.ExpectedMachineOperationResultR\aresults\"\x8e\x03\n" +
 	"\x12ExpectedPowerShelf\x12&\n" +
 	"\x0fbmc_mac_address\x18\x01 \x01(\tR\rbmcMacAddress\x12!\n" +
 	"\fbmc_username\x18\x02 \x01(\tR\vbmcUsername\x12!\n" +
@@ -39640,15 +39640,15 @@ const file_forge_carbide_proto_rawDesc = "" +
 	"\n" +
 	"ip_address\x18\x05 \x01(\tR\tipAddress\x12+\n" +
 	"\bmetadata\x18\x06 \x01(\v2\x0f.forge.MetadataR\bmetadata\x12\x1c\n" +
-	"\arack_id\x18\a \x01(\tH\x00R\x06rackId\x88\x01\x01\x12!\n" +
-	"\x02id\x18\b \x01(\v2\f.common.UUIDH\x01R\x02id\x88\x01\x01B\n" +
+	"\arack_id\x18\a \x01(\tH\x00R\x06rackId\x88\x01\x01\x12H\n" +
+	"\x17expected_power_shelf_id\x18\b \x01(\v2\f.common.UUIDH\x01R\x14expectedPowerShelfId\x88\x01\x01B\n" +
 	"\n" +
-	"\b_rack_idB\x05\n" +
-	"\x03_id\"m\n" +
+	"\b_rack_idB\x1a\n" +
+	"\x18_expected_power_shelf_id\"\xa9\x01\n" +
 	"\x19ExpectedPowerShelfRequest\x12&\n" +
-	"\x0fbmc_mac_address\x18\x01 \x01(\tR\rbmcMacAddress\x12!\n" +
-	"\x02id\x18\x02 \x01(\v2\f.common.UUIDH\x00R\x02id\x88\x01\x01B\x05\n" +
-	"\x03_id\"i\n" +
+	"\x0fbmc_mac_address\x18\x01 \x01(\tR\rbmcMacAddress\x12H\n" +
+	"\x17expected_power_shelf_id\x18\x02 \x01(\v2\f.common.UUIDH\x00R\x14expectedPowerShelfId\x88\x01\x01B\x1a\n" +
+	"\x18_expected_power_shelf_id\"i\n" +
 	"\x16ExpectedPowerShelfList\x12O\n" +
 	"\x16expected_power_shelves\x18\x01 \x03(\v2\x19.forge.ExpectedPowerShelfR\x14expectedPowerShelves\"u\n" +
 	"\x1cLinkedExpectedPowerShelfList\x12U\n" +
@@ -39659,7 +39659,7 @@ const file_forge_carbide_proto_rawDesc = "" +
 	"\x0epower_shelf_id\x18\x03 \x01(\v2\x14.common.PowerShelfIdH\x00R\fpowerShelfId\x88\x01\x01\x12H\n" +
 	"\x17expected_power_shelf_id\x18\x04 \x01(\v2\f.common.UUIDH\x01R\x14expectedPowerShelfId\x88\x01\x01B\x11\n" +
 	"\x0f_power_shelf_idB\x1a\n" +
-	"\x18_expected_power_shelf_id\"\xa9\x03\n" +
+	"\x18_expected_power_shelf_id\"\xd7\x03\n" +
 	"\x0eExpectedSwitch\x12&\n" +
 	"\x0fbmc_mac_address\x18\x01 \x01(\tR\rbmcMacAddress\x12!\n" +
 	"\fbmc_username\x18\x02 \x01(\tR\vbmcUsername\x12!\n" +
@@ -39668,17 +39668,17 @@ const file_forge_carbide_proto_rawDesc = "" +
 	"\bmetadata\x18\x05 \x01(\v2\x0f.forge.MetadataR\bmetadata\x12\x1c\n" +
 	"\arack_id\x18\x06 \x01(\tH\x00R\x06rackId\x88\x01\x01\x12(\n" +
 	"\rnvos_username\x18\a \x01(\tH\x01R\fnvosUsername\x88\x01\x01\x12(\n" +
-	"\rnvos_password\x18\b \x01(\tH\x02R\fnvosPassword\x88\x01\x01\x12!\n" +
-	"\x02id\x18\t \x01(\v2\f.common.UUIDH\x03R\x02id\x88\x01\x01B\n" +
+	"\rnvos_password\x18\b \x01(\tH\x02R\fnvosPassword\x88\x01\x01\x12?\n" +
+	"\x12expected_switch_id\x18\t \x01(\v2\f.common.UUIDH\x03R\x10expectedSwitchId\x88\x01\x01B\n" +
 	"\n" +
 	"\b_rack_idB\x10\n" +
 	"\x0e_nvos_usernameB\x10\n" +
-	"\x0e_nvos_passwordB\x05\n" +
-	"\x03_id\"i\n" +
+	"\x0e_nvos_passwordB\x15\n" +
+	"\x13_expected_switch_id\"\x97\x01\n" +
 	"\x15ExpectedSwitchRequest\x12&\n" +
-	"\x0fbmc_mac_address\x18\x01 \x01(\tR\rbmcMacAddress\x12!\n" +
-	"\x02id\x18\x02 \x01(\v2\f.common.UUIDH\x00R\x02id\x88\x01\x01B\x05\n" +
-	"\x03_id\"X\n" +
+	"\x0fbmc_mac_address\x18\x01 \x01(\tR\rbmcMacAddress\x12?\n" +
+	"\x12expected_switch_id\x18\x02 \x01(\v2\f.common.UUIDH\x00R\x10expectedSwitchId\x88\x01\x01B\x15\n" +
+	"\x13_expected_switch_id\"X\n" +
 	"\x12ExpectedSwitchList\x12B\n" +
 	"\x11expected_switches\x18\x01 \x03(\v2\x15.forge.ExpectedSwitchR\x10expectedSwitches\"d\n" +
 	"\x18LinkedExpectedSwitchList\x12H\n" +
@@ -42564,15 +42564,15 @@ var file_forge_carbide_proto_depIdxs = []int32{
 	395, // 433: forge.ExpectedMachineOperationResult.expected_machine:type_name -> forge.ExpectedMachine
 	401, // 434: forge.BatchExpectedMachineOperationResponse.results:type_name -> forge.ExpectedMachineOperationResult
 	149, // 435: forge.ExpectedPowerShelf.metadata:type_name -> forge.Metadata
-	649, // 436: forge.ExpectedPowerShelf.id:type_name -> common.UUID
-	649, // 437: forge.ExpectedPowerShelfRequest.id:type_name -> common.UUID
+	649, // 436: forge.ExpectedPowerShelf.expected_power_shelf_id:type_name -> common.UUID
+	649, // 437: forge.ExpectedPowerShelfRequest.expected_power_shelf_id:type_name -> common.UUID
 	403, // 438: forge.ExpectedPowerShelfList.expected_power_shelves:type_name -> forge.ExpectedPowerShelf
 	407, // 439: forge.LinkedExpectedPowerShelfList.expected_power_shelves:type_name -> forge.LinkedExpectedPowerShelf
 	658, // 440: forge.LinkedExpectedPowerShelf.power_shelf_id:type_name -> common.PowerShelfId
 	649, // 441: forge.LinkedExpectedPowerShelf.expected_power_shelf_id:type_name -> common.UUID
 	149, // 442: forge.ExpectedSwitch.metadata:type_name -> forge.Metadata
-	649, // 443: forge.ExpectedSwitch.id:type_name -> common.UUID
-	649, // 444: forge.ExpectedSwitchRequest.id:type_name -> common.UUID
+	649, // 443: forge.ExpectedSwitch.expected_switch_id:type_name -> common.UUID
+	649, // 444: forge.ExpectedSwitchRequest.expected_switch_id:type_name -> common.UUID
 	408, // 445: forge.ExpectedSwitchList.expected_switches:type_name -> forge.ExpectedSwitch
 	412, // 446: forge.LinkedExpectedSwitchList.expected_switches:type_name -> forge.LinkedExpectedSwitch
 	659, // 447: forge.LinkedExpectedSwitch.switch_id:type_name -> common.SwitchId

--- a/workflow-schema/site-agent/workflows/v1/forge_carbide.proto
+++ b/workflow-schema/site-agent/workflows/v1/forge_carbide.proto
@@ -4148,13 +4148,13 @@ message ExpectedPowerShelf {
   Metadata metadata = 6;
   optional string rack_id = 7;
   // Unique identifier for the expected power shelf. When omitted, server generates one.
-  optional common.UUID id = 8;
+  optional common.UUID expected_power_shelf_id = 8;
 }
 
 message ExpectedPowerShelfRequest {
   string bmc_mac_address = 1;
   // Optional unique identifier for selecting an expected power shelf.
-  optional common.UUID id = 2;
+  optional common.UUID expected_power_shelf_id = 2;
 }
 
 message ExpectedPowerShelfList {
@@ -4184,13 +4184,13 @@ message ExpectedSwitch {
   optional string nvos_username = 7;
   optional string nvos_password = 8;
   // Unique identifier for the expected switch. When omitted, server generates one.
-  optional common.UUID id = 9;
+  optional common.UUID expected_switch_id = 9;
 }
 
 message ExpectedSwitchRequest {
   string bmc_mac_address = 1;
   // Optional unique identifier for selecting an expected switch.
-  optional common.UUID id = 2;
+  optional common.UUID expected_switch_id = 2;
 }
 
 message ExpectedSwitchList {

--- a/workflow/pkg/activity/expectedpowershelf/expectedpowershelf.go
+++ b/workflow/pkg/activity/expectedpowershelf/expectedpowershelf.go
@@ -137,7 +137,7 @@ func (mei ManageExpectedPowerShelf) UpdateExpectedPowerShelvesInDB(ctx context.C
 		if reps == nil {
 			logger.Error().Msg("received nil Expected Power Shelf entry, skipping processing")
 			continue
-		} else if reps.Id == nil {
+		} else if reps.ExpectedPowerShelfId == nil {
 			mac := "unknown"
 			if reps.BmcMacAddress != "" {
 				mac = reps.BmcMacAddress
@@ -145,9 +145,9 @@ func (mei ManageExpectedPowerShelf) UpdateExpectedPowerShelvesInDB(ctx context.C
 			logger.Error().Str("MAC", mac).Msg("received Expected Power Shelf entry from Site without UUID set, skipping processing")
 			continue
 		}
-		epsID, perr := uuid.Parse(reps.Id.Value)
+		epsID, perr := uuid.Parse(reps.ExpectedPowerShelfId.Value)
 		if perr != nil || epsID == uuid.Nil {
-			logger.Error().Str("ID", reps.Id.Value).Msg("received Expected Power Shelf entry from Site with invalid UUID, skipping processing")
+			logger.Error().Str("ID", reps.ExpectedPowerShelfId.Value).Msg("received Expected Power Shelf entry from Site with invalid UUID, skipping processing")
 			continue
 		}
 		reportedIDs[epsID] = true

--- a/workflow/pkg/activity/expectedpowershelf/expectedpowershelf_test.go
+++ b/workflow/pkg/activity/expectedpowershelf/expectedpowershelf_test.go
@@ -160,10 +160,10 @@ func TestManageExpectedPowerShelf_UpdateExpectedPowerShelvesInDB(t *testing.T) {
 		}
 
 		ctrlExpectedPowerShelf := &cwssaws.ExpectedPowerShelf{
-			Id:                &cwssaws.UUID{Value: pagedExpectedPowerShelves[i].ID.String()},
-			BmcMacAddress:     pagedExpectedPowerShelves[i].BmcMacAddress,
-			ShelfSerialNumber: pagedExpectedPowerShelves[i].ShelfSerialNumber,
-			IpAddress:         protoIpAddress,
+			ExpectedPowerShelfId: &cwssaws.UUID{Value: pagedExpectedPowerShelves[i].ID.String()},
+			BmcMacAddress:        pagedExpectedPowerShelves[i].BmcMacAddress,
+			ShelfSerialNumber:    pagedExpectedPowerShelves[i].ShelfSerialNumber,
+			IpAddress:            protoIpAddress,
 		}
 
 		// Add labels to controller expected power shelves
@@ -389,10 +389,10 @@ func TestManageExpectedPowerShelf_UpdateExpectedPowerShelvesInDB(t *testing.T) {
 				expectedPowerShelfInventory: &cwssaws.ExpectedPowerShelfInventory{
 					ExpectedPowerShelves: []*cwssaws.ExpectedPowerShelf{
 						{
-							Id:                &cwssaws.UUID{Value: uuid.New().String()},
-							BmcMacAddress:     "00:11:22:33:44:FF",
-							ShelfSerialNumber: "SHELF-SN-NEW-1",
-							IpAddress:         "10.0.0.100",
+							ExpectedPowerShelfId: &cwssaws.UUID{Value: uuid.New().String()},
+							BmcMacAddress:        "00:11:22:33:44:FF",
+							ShelfSerialNumber:    "SHELF-SN-NEW-1",
+							IpAddress:            "10.0.0.100",
 							Metadata: &cwssaws.Metadata{
 								Labels: []*cwssaws.Label{
 									{Key: "environment", Value: cdb.GetStrPtr("test")},
@@ -442,7 +442,7 @@ func TestManageExpectedPowerShelf_UpdateExpectedPowerShelvesInDB(t *testing.T) {
 				// Find the corresponding controller power shelf
 				var ctrlEPS *cwssaws.ExpectedPowerShelf
 				for _, ceps := range tt.args.expectedPowerShelfInventory.ExpectedPowerShelves {
-					if ceps.Id.Value == eps.ID.String() {
+					if ceps.ExpectedPowerShelfId.Value == eps.ID.String() {
 						ctrlEPS = ceps
 						break
 					}
@@ -471,7 +471,7 @@ func TestManageExpectedPowerShelf_UpdateExpectedPowerShelvesInDB(t *testing.T) {
 
 			// Verify newly created power shelves have correct labels
 			for _, ceps := range tt.args.expectedPowerShelfInventory.ExpectedPowerShelves {
-				epsID, perr := uuid.Parse(ceps.Id.Value)
+				epsID, perr := uuid.Parse(ceps.ExpectedPowerShelfId.Value)
 				assert.NoError(t, perr)
 				created := powerShelvesByID[epsID]
 				if created != nil {

--- a/workflow/pkg/activity/expectedswitch/expectedswitch.go
+++ b/workflow/pkg/activity/expectedswitch/expectedswitch.go
@@ -137,7 +137,7 @@ func (mei ManageExpectedSwitch) UpdateExpectedSwitchesInDB(ctx context.Context, 
 		if res == nil {
 			logger.Error().Msg("received nil Expected Switch entry, skipping processing")
 			continue
-		} else if res.Id == nil {
+		} else if res.ExpectedSwitchId == nil {
 			mac := "unknown"
 			if res.BmcMacAddress != "" {
 				mac = res.BmcMacAddress
@@ -145,9 +145,9 @@ func (mei ManageExpectedSwitch) UpdateExpectedSwitchesInDB(ctx context.Context, 
 			logger.Error().Str("MAC", mac).Msg("received Expected Switch entry from Site without UUID set, skipping processing")
 			continue
 		}
-		esID, perr := uuid.Parse(res.Id.Value)
+		esID, perr := uuid.Parse(res.ExpectedSwitchId.Value)
 		if perr != nil || esID == uuid.Nil {
-			logger.Error().Str("ID", res.Id.Value).Msg("received Expected Switch entry from Site with invalid UUID, skipping processing")
+			logger.Error().Str("ID", res.ExpectedSwitchId.Value).Msg("received Expected Switch entry from Site with invalid UUID, skipping processing")
 			continue
 		}
 		reportedIDs[esID] = true

--- a/workflow/pkg/activity/expectedswitch/expectedswitch_test.go
+++ b/workflow/pkg/activity/expectedswitch/expectedswitch_test.go
@@ -147,7 +147,7 @@ func TestManageExpectedSwitch_UpdateExpectedSwitchesInDB(t *testing.T) {
 
 	for i := 0; i < 34; i++ {
 		ctrlExpectedSwitch := &cwssaws.ExpectedSwitch{
-			Id:                 &cwssaws.UUID{Value: pagedExpectedSwitches[i].ID.String()},
+			ExpectedSwitchId:   &cwssaws.UUID{Value: pagedExpectedSwitches[i].ID.String()},
 			BmcMacAddress:      pagedExpectedSwitches[i].BmcMacAddress,
 			SwitchSerialNumber: pagedExpectedSwitches[i].SwitchSerialNumber,
 		}
@@ -369,7 +369,7 @@ func TestManageExpectedSwitch_UpdateExpectedSwitchesInDB(t *testing.T) {
 				expectedSwitchInventory: &cwssaws.ExpectedSwitchInventory{
 					ExpectedSwitches: []*cwssaws.ExpectedSwitch{
 						{
-							Id:                 &cwssaws.UUID{Value: uuid.New().String()},
+							ExpectedSwitchId:   &cwssaws.UUID{Value: uuid.New().String()},
 							BmcMacAddress:      "00:11:22:33:44:FF",
 							SwitchSerialNumber: "SW-SN-NEW-1",
 							Metadata: &cwssaws.Metadata{
@@ -421,7 +421,7 @@ func TestManageExpectedSwitch_UpdateExpectedSwitchesInDB(t *testing.T) {
 				// Find the corresponding controller switch
 				var ctrlES *cwssaws.ExpectedSwitch
 				for _, ces := range tt.args.expectedSwitchInventory.ExpectedSwitches {
-					if ces.Id.Value == es.ID.String() {
+					if ces.ExpectedSwitchId.Value == es.ID.String() {
 						ctrlES = ces
 						break
 					}
@@ -450,7 +450,7 @@ func TestManageExpectedSwitch_UpdateExpectedSwitchesInDB(t *testing.T) {
 
 			// Verify newly created switches have correct labels
 			for _, ces := range tt.args.expectedSwitchInventory.ExpectedSwitches {
-				esID, perr := uuid.Parse(ces.Id.Value)
+				esID, perr := uuid.Parse(ces.ExpectedSwitchId.Value)
 				assert.NoError(t, perr)
 				created := switchesByID[esID]
 				if created != nil {


### PR DESCRIPTION
## Description

When putting together https://github.com/NVIDIA/bare-metal-manager-rest/pull/220, I misunderstood the purpose of `ExpectedMachine.id`, and the comment made it look like it was something specific to Carbide REST, and not carried over from Carbide Core (even though I knew we kept parity between the two).

@thossain-nv noticed that I added `ExpectedPowerShelf.id` and `ExpectedSwitch.id` in the above PR, but that they don't exist in Carbide Core.

After understanding the purpose of why it exists for `ExpectedMachine`, I realized it makes sense for it to exist for `ExpectedPowerShelf` and `ExpectedSwitch` to, so I'm adding them into Carbide Core with all of the plumbing needed in https://github.com/NVIDIA/bare-metal-manager-core/pull/563, AND, I *am* changing the names of the fields while I'm at it (so it's not just `id`).

It was also noticed I missed handler tests for them, so I'm adding them here as well.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [x] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in Github workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
