### PR TITLE
chore: Add back standard SDK module after repo rename

### DIFF
--- a/docker/local/Dockerfile.carbide-nsm
+++ b/docker/local/Dockerfile.carbide-nsm
@@ -31,8 +31,12 @@ RUN go env
 ARG skipcache=0
 
 WORKDIR /workspace
+
 # Copy go module files and VERSION first for better caching
 COPY go.mod go.sum VERSION ./
+# Copy SDK go module files, required for maintaining separate go.mod for SDK
+COPY sdk/standard/go.mod ./sdk/standard/
+# Download dependencies
 RUN go mod download
 
 COPY nvswitch-manager/ ./nvswitch-manager/

--- a/docker/local/Dockerfile.carbide-psm
+++ b/docker/local/Dockerfile.carbide-psm
@@ -16,8 +16,12 @@ RUN go env
 ARG skipcache=0
 
 WORKDIR /workspace
+
 # Copy go module files and VERSION first for better caching
 COPY go.mod go.sum VERSION ./
+# Copy SDK go module files, required for maintaining separate go.mod for SDK
+COPY sdk/standard/go.mod ./sdk/standard/
+# Download dependencies
 RUN go mod download
 
 COPY common/ ./common/

--- a/docker/local/Dockerfile.carbide-rest-api
+++ b/docker/local/Dockerfile.carbide-rest-api
@@ -37,6 +37,9 @@ WORKDIR /workspace
 
 # Copy go module files and VERSION first for better caching
 COPY go.mod go.sum VERSION ./
+# Copy SDK go module files, required for maintaining separate go.mod for SDK
+COPY sdk/standard/go.mod ./sdk/standard/
+# Download dependencies
 RUN go mod download
 
 # Copy necessary source files

--- a/docker/local/Dockerfile.carbide-rest-cert-manager
+++ b/docker/local/Dockerfile.carbide-rest-cert-manager
@@ -35,8 +35,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /workspace
 
-# Copy go module files and VERSION
+# Copy go module files and VERSION first for better caching
 COPY go.mod go.sum VERSION ./
+# Copy SDK go module files, required for maintaining separate go.mod for SDK
+COPY sdk/standard/go.mod ./sdk/standard/
+# Download dependencies
 RUN go mod download
 
 # Copy source files

--- a/docker/local/Dockerfile.carbide-rest-db
+++ b/docker/local/Dockerfile.carbide-rest-db
@@ -35,8 +35,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /workspace
 
-# Copy go module files and VERSION
+# Copy go module files and VERSION first for better caching
 COPY go.mod go.sum VERSION ./
+# Copy SDK go module files, required for maintaining separate go.mod for SDK
+COPY sdk/standard/go.mod ./sdk/standard/
+# Download dependencies
 RUN go mod download
 
 # Copy source files

--- a/docker/local/Dockerfile.carbide-rest-mock-core
+++ b/docker/local/Dockerfile.carbide-rest-mock-core
@@ -35,8 +35,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /workspace
 
-# Copy go module files and VERSION
+# Copy go module files and VERSION first for better caching
 COPY go.mod go.sum VERSION ./
+# Copy SDK go module files, required for maintaining separate go.mod for SDK
+COPY sdk/standard/go.mod ./sdk/standard/
+# Download dependencies
 RUN go mod download
 
 # Copy source files

--- a/docker/local/Dockerfile.carbide-rest-site-agent
+++ b/docker/local/Dockerfile.carbide-rest-site-agent
@@ -35,8 +35,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /workspace
 
-# Copy go module files and VERSION
+# Copy go module files and VERSION first for better caching
 COPY go.mod go.sum VERSION ./
+# Copy SDK go module files, required for maintaining separate go.mod for SDK
+COPY sdk/standard/go.mod ./sdk/standard/
+# Download dependencies
 RUN go mod download
 
 # Copy source files

--- a/docker/local/Dockerfile.carbide-rest-site-manager
+++ b/docker/local/Dockerfile.carbide-rest-site-manager
@@ -35,8 +35,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /workspace
 
-# Copy go module files and VERSION
+# Copy go module files and VERSION first for better caching
 COPY go.mod go.sum VERSION ./
+# Copy SDK go module files, required for maintaining separate go.mod for SDK
+COPY sdk/standard/go.mod ./sdk/standard/
+# Download dependencies
 RUN go mod download
 
 # Copy source files

--- a/docker/local/Dockerfile.carbide-rest-workflow
+++ b/docker/local/Dockerfile.carbide-rest-workflow
@@ -35,8 +35,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /workspace
 
-# Copy go module files and VERSION
+# Copy go module files and VERSION first for better caching
 COPY go.mod go.sum VERSION ./
+# Copy SDK go module files, required for maintaining separate go.mod for SDK
+COPY sdk/standard/go.mod ./sdk/standard/
+# Download dependencies
 RUN go mod download
 
 # Copy source files

--- a/docker/local/Dockerfile.carbide-rla
+++ b/docker/local/Dockerfile.carbide-rla
@@ -16,8 +16,12 @@ RUN go env
 ARG skipcache=0
 
 WORKDIR /workspace
+
 # Copy go module files and VERSION first for better caching
 COPY go.mod go.sum VERSION ./
+# Copy SDK go module files, required for maintaining separate go.mod for SDK
+COPY sdk/standard/go.mod ./sdk/standard/
+# Download dependencies
 RUN go mod download
 
 COPY common/ ./common/

--- a/docker/production/Dockerfile.carbide-nsm
+++ b/docker/production/Dockerfile.carbide-nsm
@@ -31,8 +31,12 @@ RUN go env
 ARG skipcache=0
 
 WORKDIR /workspace
+
 # Copy go module files and VERSION first for better caching
 COPY go.mod go.sum VERSION ./
+# Copy SDK go module files, required for maintaining separate go.mod for SDK
+COPY sdk/standard/go.mod ./sdk/standard/
+# Download dependencies
 RUN go mod download
 
 COPY nvswitch-manager/ ./nvswitch-manager/

--- a/docker/production/Dockerfile.carbide-psm
+++ b/docker/production/Dockerfile.carbide-psm
@@ -16,8 +16,12 @@ RUN go env
 ARG skipcache=0
 
 WORKDIR /workspace
+
 # Copy go module files and VERSION first for better caching
 COPY go.mod go.sum VERSION ./
+# Copy SDK go module files, required for maintaining separate go.mod for SDK
+COPY sdk/standard/go.mod ./sdk/standard/
+# Download dependencies
 RUN go mod download
 
 COPY common/ ./common/

--- a/docker/production/Dockerfile.carbide-rest-api
+++ b/docker/production/Dockerfile.carbide-rest-api
@@ -35,6 +35,9 @@ WORKDIR /workspace
 
 # Copy go module files and VERSION first for better caching
 COPY go.mod go.sum VERSION ./
+# Copy SDK go module files, required for maintaining separate go.mod for SDK
+COPY sdk/standard/go.mod ./sdk/standard/
+# Download dependencies
 RUN go mod download
 
 # Copy necessary source files

--- a/docker/production/Dockerfile.carbide-rest-cert-manager
+++ b/docker/production/Dockerfile.carbide-rest-cert-manager
@@ -33,8 +33,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /workspace
 
-# Copy go module files and VERSION
+# Copy go module files and VERSION first for better caching
 COPY go.mod go.sum VERSION ./
+# Copy SDK go module files, required for maintaining separate go.mod for SDK
+COPY sdk/standard/go.mod ./sdk/standard/
+# Download dependencies
 RUN go mod download
 
 # Copy source files

--- a/docker/production/Dockerfile.carbide-rest-db
+++ b/docker/production/Dockerfile.carbide-rest-db
@@ -33,8 +33,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /workspace
 
-# Copy go module files and VERSION
+# Copy go module files and VERSION first for better caching
 COPY go.mod go.sum VERSION ./
+# Copy SDK go module files, required for maintaining separate go.mod for SDK
+COPY sdk/standard/go.mod ./sdk/standard/
+# Download dependencies
 RUN go mod download
 
 # Copy source files

--- a/docker/production/Dockerfile.carbide-rest-site-agent
+++ b/docker/production/Dockerfile.carbide-rest-site-agent
@@ -33,8 +33,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /workspace
 
-# Copy go module files and VERSION
+# Copy go module files and VERSION first for better caching
 COPY go.mod go.sum VERSION ./
+# Copy SDK go module files, required for maintaining separate go.mod for SDK
+COPY sdk/standard/go.mod ./sdk/standard/
+# Download dependencies
 RUN go mod download
 
 # Copy source files

--- a/docker/production/Dockerfile.carbide-rest-site-manager
+++ b/docker/production/Dockerfile.carbide-rest-site-manager
@@ -33,8 +33,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /workspace
 
-# Copy go module files and VERSION
+# Copy go module files and VERSION first for better caching
 COPY go.mod go.sum VERSION ./
+# Copy SDK go module files, required for maintaining separate go.mod for SDK
+COPY sdk/standard/go.mod ./sdk/standard/
+# Download dependencies
 RUN go mod download
 
 # Copy source files

--- a/docker/production/Dockerfile.carbide-rest-workflow
+++ b/docker/production/Dockerfile.carbide-rest-workflow
@@ -33,8 +33,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /workspace
 
-# Copy go module files and VERSION
+# Copy go module files and VERSION first for better caching
 COPY go.mod go.sum VERSION ./
+# Copy SDK go module files, required for maintaining separate go.mod for SDK
+COPY sdk/standard/go.mod ./sdk/standard/
+# Download dependencies
 RUN go mod download
 
 # Copy source files

--- a/docker/production/Dockerfile.carbide-rla
+++ b/docker/production/Dockerfile.carbide-rla
@@ -16,8 +16,12 @@ RUN go env
 ARG skipcache=0
 
 WORKDIR /workspace
+
 # Copy go module files and VERSION first for better caching
 COPY go.mod go.sum VERSION ./
+# Copy SDK go module files, required for maintaining separate go.mod for SDK
+COPY sdk/standard/go.mod ./sdk/standard/
+# Download dependencies
 RUN go mod download
 
 COPY common/ ./common/

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	connectrpc.com/grpcreflect v1.3.0
 	connectrpc.com/otelconnect v0.9.0
 	github.com/DATA-DOG/go-sqlmock v1.5.2
+	github.com/NVIDIA/ncx-infra-controller-rest/sdk/standard v0.0.0-00010101000000-000000000000
 	github.com/Nerzal/gocloak/v13 v13.9.0
 	github.com/PagerDuty/go-pagerduty v1.8.0
 	github.com/avast/retry-go/v4 v4.7.0
@@ -108,6 +109,8 @@ require (
 	logur.dev/adapter/zerolog v0.6.0
 	logur.dev/logur v0.17.0
 )
+
+replace github.com/NVIDIA/ncx-infra-controller-rest/sdk/standard => ./sdk/standard
 
 require (
 	dario.cat/mergo v1.0.2 // indirect

--- a/sdk/standard/go.mod
+++ b/sdk/standard/go.mod
@@ -1,3 +1,11 @@
 module github.com/NVIDIA/ncx-infra-controller-rest/sdk/standard
 
 go 1.25.4
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/sdk/standard/go.mod
+++ b/sdk/standard/go.mod
@@ -1,0 +1,3 @@
+module github.com/NVIDIA/ncx-infra-controller-rest/sdk/standard
+
+go 1.25.4

--- a/sdk/standard/go.sum
+++ b/sdk/standard/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Description
Due to Go pulling module version from previous Git repo name, the SDK Go module had to be removed and re-added.

## Type of Change
- [x] **Chore** - Modification or removal of existing functionality (chore:)

## Services Affected
None

## Related Issues (Optional)
None

## Breaking Changes
- [x] This PR contains breaking changes

SDK imports will need to be updated to `github.com/NVIDIA/ncx-infra-controller-rest/sdk/standard` in newer versions.

## Testing
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
None
