### PR TITLE
fix: Empty array must be passed to underlying SDK when caller specifies one

### DIFF
--- a/sdk/simple/expectedmachine_test.go
+++ b/sdk/simple/expectedmachine_test.go
@@ -1,0 +1,115 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package simple
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestToStandardExpectedMachineUpdateRequest verifies that nil slice/map fields are not
+// forwarded to the standard API request, preventing unintended clearing of existing
+// attributes on partial updates.
+func TestToStandardExpectedMachineUpdateRequest(t *testing.T) {
+	t.Run("partial update with only ChassisSerialNumber set leaves FallbackDPUSerialNumbers and Labels nil", func(t *testing.T) {
+		serial := "CHASSIS-001"
+		req := ExpectedMachineUpdateRequest{
+			ChassisSerialNumber: &serial,
+		}
+
+		apiReq := toStandardExpectedMachineUpdateRequest(req)
+
+		assert.True(t, apiReq.ChassisSerialNumber.IsSet())
+
+		// These must stay nil so the server does not clear them
+		assert.Nil(t, apiReq.FallbackDPUSerialNumbers,
+			"FallbackDPUSerialNumbers must be nil when not set, to avoid clearing existing DPU serial numbers on the server")
+		assert.Nil(t, apiReq.Labels,
+			"Labels must be nil when not set, to avoid clearing existing labels on the server")
+
+		body, err := apiReq.ToMap()
+		require.NoError(t, err)
+		assert.Contains(t, body, "chassisSerialNumber")
+		assert.NotContains(t, body, "fallbackDPUSerialNumbers")
+		assert.NotContains(t, body, "labels")
+	})
+
+	t.Run("partial update with only FallbackDPUSerialNumbers set leaves Labels nil", func(t *testing.T) {
+		req := ExpectedMachineUpdateRequest{
+			FallbackDPUSerialNumbers: []string{"DPU-001", "DPU-002"},
+		}
+
+		apiReq := toStandardExpectedMachineUpdateRequest(req)
+
+		assert.Equal(t, []string{"DPU-001", "DPU-002"}, apiReq.FallbackDPUSerialNumbers)
+		assert.Nil(t, apiReq.Labels)
+
+		body, err := apiReq.ToMap()
+		require.NoError(t, err)
+		assert.Contains(t, body, "fallbackDPUSerialNumbers")
+		assert.NotContains(t, body, "labels")
+	})
+
+	t.Run("explicit empty FallbackDPUSerialNumbers slice is forwarded to clear existing entries", func(t *testing.T) {
+		req := ExpectedMachineUpdateRequest{
+			FallbackDPUSerialNumbers: []string{},
+		}
+
+		apiReq := toStandardExpectedMachineUpdateRequest(req)
+
+		// Non-nil empty slice must be forwarded so the server clears the list
+		require.NotNil(t, apiReq.FallbackDPUSerialNumbers,
+			"An explicit empty FallbackDPUSerialNumbers slice must be forwarded to clear existing entries")
+		assert.Empty(t, apiReq.FallbackDPUSerialNumbers)
+
+		body, err := apiReq.ToMap()
+		require.NoError(t, err)
+		assert.Contains(t, body, "fallbackDPUSerialNumbers")
+	})
+
+	t.Run("full update sets all provided fields", func(t *testing.T) {
+		mac := "AA:BB:CC:DD:EE:FF"
+		serial := "CHASSIS-999"
+		sku := "sku-123"
+		req := ExpectedMachineUpdateRequest{
+			BmcMacAddress:            &mac,
+			ChassisSerialNumber:      &serial,
+			FallbackDPUSerialNumbers: []string{"DPU-A"},
+			SkuID:                    &sku,
+			Labels:                   map[string]string{"site": "dc1"},
+		}
+
+		apiReq := toStandardExpectedMachineUpdateRequest(req)
+
+		assert.True(t, apiReq.BmcMacAddress.IsSet())
+		assert.True(t, apiReq.ChassisSerialNumber.IsSet())
+		assert.Equal(t, []string{"DPU-A"}, apiReq.FallbackDPUSerialNumbers)
+		assert.True(t, apiReq.SkuId.IsSet())
+		assert.Equal(t, map[string]string{"site": "dc1"}, apiReq.Labels)
+
+		body, err := apiReq.ToMap()
+		require.NoError(t, err)
+		assert.Contains(t, body, "bmcMacAddress")
+		assert.Contains(t, body, "chassisSerialNumber")
+		assert.Contains(t, body, "fallbackDPUSerialNumbers")
+		assert.Contains(t, body, "skuId")
+		assert.Contains(t, body, "labels")
+	})
+}

--- a/sdk/simple/instance.go
+++ b/sdk/simple/instance.go
@@ -187,14 +187,26 @@ func toStandardInstanceUpdateRequest(request InstanceUpdateRequest) standard.Ins
 	if request.UserData != nil {
 		apiReq.UserData.Set(request.UserData)
 	}
-	for _, ib := range request.InfinibandInterfaces {
-		apiReq.InfinibandInterfaces = append(apiReq.InfinibandInterfaces, toStandardInfiniBandInterface(ib))
+	// Only set slice fields when provided so partial updates do not reset other attributes.
+	// When the caller passes nil, no array must be sent so the server skips the field entirely.
+	// But if the caller passes an empty array (not nil) we must also pass an empty array.
+	if request.InfinibandInterfaces != nil {
+		apiReq.InfinibandInterfaces = make([]standard.InfiniBandInterfaceCreateRequest, 0, len(request.InfinibandInterfaces))
+		for _, ib := range request.InfinibandInterfaces {
+			apiReq.InfinibandInterfaces = append(apiReq.InfinibandInterfaces, toStandardInfiniBandInterface(ib))
+		}
 	}
-	for _, nv := range request.NVLinkInterfaces {
-		apiReq.NvLinkInterfaces = append(apiReq.NvLinkInterfaces, toStandardNVLinkInterface(nv))
+	if request.NVLinkInterfaces != nil {
+		apiReq.NvLinkInterfaces = make([]standard.NVLinkInterfaceCreateRequest, 0, len(request.NVLinkInterfaces))
+		for _, nv := range request.NVLinkInterfaces {
+			apiReq.NvLinkInterfaces = append(apiReq.NvLinkInterfaces, toStandardNVLinkInterface(nv))
+		}
 	}
-	for _, d := range request.DpuExtensionServiceDeployments {
-		apiReq.DpuExtensionServiceDeployments = append(apiReq.DpuExtensionServiceDeployments, toStandardDpuExtensionDeployment(d))
+	if request.DpuExtensionServiceDeployments != nil {
+		apiReq.DpuExtensionServiceDeployments = make([]standard.DpuExtensionServiceDeploymentRequest, 0, len(request.DpuExtensionServiceDeployments))
+		for _, d := range request.DpuExtensionServiceDeployments {
+			apiReq.DpuExtensionServiceDeployments = append(apiReq.DpuExtensionServiceDeployments, toStandardDpuExtensionDeployment(d))
+		}
 	}
 	return apiReq
 }

--- a/sdk/simple/instance_test.go
+++ b/sdk/simple/instance_test.go
@@ -1,0 +1,152 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package simple
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestToStandardInstanceUpdateRequest verifies that nil slice/map fields in an
+// InstanceUpdateRequest are NOT forwarded to the standard API request. Forwarding nil as an empty
+// slice causes the backend to clear the corresponding attribute (the original reported bug).
+func TestToStandardInstanceUpdateRequest(t *testing.T) {
+	t.Run("partial update with only NVLinkInterfaces set leaves IB and DES nil", func(t *testing.T) {
+		req := InstanceUpdateRequest{
+			NVLinkInterfaces: []NVLinkInterfaceCreateOrUpdateRequest{
+				{NVLinkLogicalPartitionID: "nvlink-partition-1"},
+			},
+		}
+
+		apiReq := toStandardInstanceUpdateRequest(req)
+
+		// NVLink must be populated
+		require.NotNil(t, apiReq.NvLinkInterfaces)
+		assert.Len(t, apiReq.NvLinkInterfaces, 1)
+
+		// InfiniBand and DES must stay nil so they are omitted from the JSON body
+		assert.Nil(t, apiReq.InfinibandInterfaces,
+			"InfinibandInterfaces must be nil when not set, to avoid clearing existing IB interfaces on the server")
+		assert.Nil(t, apiReq.DpuExtensionServiceDeployments,
+			"DpuExtensionServiceDeployments must be nil when not set")
+
+		// Ensure the standard SDK's ToMap omits the unset fields entirely
+		body, err := apiReq.ToMap()
+		require.NoError(t, err)
+		assert.Contains(t, body, "nvLinkInterfaces")
+		assert.NotContains(t, body, "infinibandInterfaces",
+			"infinibandInterfaces must not appear in the serialized request when not provided")
+		assert.NotContains(t, body, "dpuExtensionServiceDeployments",
+			"dpuExtensionServiceDeployments must not appear in the serialized request when not provided")
+	})
+
+	t.Run("partial update with only InfinibandInterfaces set leaves NVLink and DES nil", func(t *testing.T) {
+		req := InstanceUpdateRequest{
+			InfinibandInterfaces: []InfiniBandInterfaceCreateOrUpdateRequest{
+				{
+					PartitionID:    "ib-partition-1",
+					Device:         "mlx5_0",
+					DeviceInstance: 0,
+					IsPhysical:     true,
+				},
+			},
+		}
+
+		apiReq := toStandardInstanceUpdateRequest(req)
+
+		require.NotNil(t, apiReq.InfinibandInterfaces)
+		assert.Len(t, apiReq.InfinibandInterfaces, 1)
+		assert.Nil(t, apiReq.NvLinkInterfaces,
+			"NvLinkInterfaces must be nil when not set, to avoid clearing existing NVLink interfaces on the server")
+		assert.Nil(t, apiReq.DpuExtensionServiceDeployments)
+
+		body, err := apiReq.ToMap()
+		require.NoError(t, err)
+		assert.Contains(t, body, "infinibandInterfaces")
+		assert.NotContains(t, body, "nvLinkInterfaces")
+		assert.NotContains(t, body, "dpuExtensionServiceDeployments")
+	})
+
+	t.Run("partial update with nil Labels leaves labels nil", func(t *testing.T) {
+		name := "new-name"
+		req := InstanceUpdateRequest{
+			Name: &name,
+		}
+
+		apiReq := toStandardInstanceUpdateRequest(req)
+
+		assert.Nil(t, apiReq.Labels,
+			"Labels must be nil when not set, to avoid clearing existing labels on the server")
+
+		body, err := apiReq.ToMap()
+		require.NoError(t, err)
+		assert.NotContains(t, body, "labels")
+	})
+
+	t.Run("explicit empty slice is forwarded as empty array to clear existing entries", func(t *testing.T) {
+		req := InstanceUpdateRequest{
+			// Explicitly setting to an empty (non-nil) slice signals intent to clear
+			InfinibandInterfaces: []InfiniBandInterfaceCreateOrUpdateRequest{},
+		}
+
+		apiReq := toStandardInstanceUpdateRequest(req)
+
+		// An explicit empty slice must be forwarded (non-nil) so the server clears the list
+		require.NotNil(t, apiReq.InfinibandInterfaces,
+			"An explicit empty InfinibandInterfaces slice must be forwarded to clear existing entries")
+		assert.Empty(t, apiReq.InfinibandInterfaces)
+
+		body, err := apiReq.ToMap()
+		require.NoError(t, err)
+		assert.Contains(t, body, "infinibandInterfaces")
+	})
+
+	t.Run("full update with all slice and map fields set", func(t *testing.T) {
+		name := "my-instance"
+		req := InstanceUpdateRequest{
+			Name:   &name,
+			Labels: map[string]string{"env": "prod"},
+			InfinibandInterfaces: []InfiniBandInterfaceCreateOrUpdateRequest{
+				{PartitionID: "ib-1", Device: "mlx5_0", DeviceInstance: 0, IsPhysical: true},
+			},
+			NVLinkInterfaces: []NVLinkInterfaceCreateOrUpdateRequest{
+				{NVLinkLogicalPartitionID: "nvlink-1"},
+			},
+			DpuExtensionServiceDeployments: []DpuExtensionServiceDeploymentRequest{},
+		}
+
+		apiReq := toStandardInstanceUpdateRequest(req)
+
+		assert.NotNil(t, apiReq.InfinibandInterfaces)
+		assert.Len(t, apiReq.InfinibandInterfaces, 1)
+		assert.NotNil(t, apiReq.NvLinkInterfaces)
+		assert.Len(t, apiReq.NvLinkInterfaces, 1)
+		assert.NotNil(t, apiReq.DpuExtensionServiceDeployments)
+		assert.Empty(t, apiReq.DpuExtensionServiceDeployments)
+		assert.NotNil(t, apiReq.Labels)
+
+		body, err := apiReq.ToMap()
+		require.NoError(t, err)
+		assert.Contains(t, body, "infinibandInterfaces")
+		assert.Contains(t, body, "nvLinkInterfaces")
+		assert.Contains(t, body, "dpuExtensionServiceDeployments")
+		assert.Contains(t, body, "labels")
+	})
+}


### PR DESCRIPTION
## Description
Ensure that if caller gives an empty array (which means reset values) then we call the underlying SDK with an empty array too.

## Type of Change
- [ ] **Feature** - New feature or functionality (feat:)
- [X] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
- [] **API** - API models or endpoints updated
- [X] **SDK** - SDK(s) for API
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
https://github.com/NVIDIA/ncx-infra-controller-rest/issues/272

## Breaking Changes: NO.

## Testing
- [X] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)
