### PR TITLE
feat: Support task conflict detection on component-level

### DIFF
--- a/rla/internal/converter/dao/converter.go
+++ b/rla/internal/converter/dao/converter.go
@@ -155,6 +155,7 @@ func RackFrom(dao *model.Rack) *rack.Rack {
 	}
 }
 
+// NVLDomainFrom converts a DAO NVLDomain model to its domain object.
 func NVLDomainFrom(dao *model.NVLDomain) *nvldomain.NVLDomain {
 	if dao == nil {
 		return nil
@@ -184,7 +185,7 @@ func TaskFrom(dao *model.Task) *taskdef.Task {
 			Info: dao.Information,
 		},
 		RackID:         dao.RackID,
-		ComponentUUIDs: dao.ComponentUUIDs,
+		Attributes:     dao.Attributes,
 		Description:    dao.Description,
 		ExecutorType:   dao.ExecutorType,
 		ExecutionID:    dao.ExecutionID,
@@ -308,6 +309,7 @@ func NVLDomainTo(n *nvldomain.NVLDomain) *model.NVLDomain {
 	}
 }
 
+// TaskTo converts a task domain object to its DAO model.
 func TaskTo(task *taskdef.Task) *model.Task {
 	if task == nil {
 		return nil
@@ -319,7 +321,7 @@ func TaskTo(task *taskdef.Task) *model.Task {
 		Information:    task.Operation.Info,
 		Description:    task.Description,
 		RackID:         task.RackID,
-		ComponentUUIDs: task.ComponentUUIDs,
+		Attributes:     task.Attributes,
 		ExecutorType:   task.ExecutorType,
 		ExecutionID:    task.ExecutionID,
 		Status:         task.Status,

--- a/rla/internal/converter/protobuf/converter.go
+++ b/rla/internal/converter/protobuf/converter.go
@@ -237,6 +237,7 @@ func RackFrom(r *pb.Rack) *rack.Rack {
 	}
 }
 
+// PaginationFrom converts a protobuf Pagination to an internal Pagination.
 func PaginationFrom(pg *pb.Pagination) *dbquery.Pagination {
 	if pg == nil {
 		return nil
@@ -248,6 +249,7 @@ func PaginationFrom(pg *pb.Pagination) *dbquery.Pagination {
 	}
 }
 
+// StringQueryInfoFrom converts a protobuf StringQueryInfo to an internal StringQueryInfo.
 func StringQueryInfoFrom(info *pb.StringQueryInfo) *dbquery.StringQueryInfo {
 	if info == nil {
 		return nil
@@ -322,6 +324,7 @@ func componentFilterFieldToColumn(field pb.ComponentFilterField) string {
 	}
 }
 
+// IdentifierFrom converts a protobuf Identifier to an internal Identifier.
 func IdentifierFrom(info *pb.Identifier) *identifier.Identifier {
 	if info == nil {
 		return nil
@@ -330,6 +333,7 @@ func IdentifierFrom(info *pb.Identifier) *identifier.Identifier {
 	return identifier.New(UUIDFrom(info.GetId()), info.GetName())
 }
 
+// NVLDomainFrom converts a protobuf NVLDomain to an internal NVLDomain.
 func NVLDomainFrom(info *pb.NVLDomain) *nvldomain.NVLDomain {
 	if info == nil || info.GetIdentifier() == nil {
 		return nil
@@ -340,6 +344,7 @@ func NVLDomainFrom(info *pb.NVLDomain) *nvldomain.NVLDomain {
 	}
 }
 
+// PowerControlOpFrom converts a protobuf PowerControlOp to an internal PowerOperation.
 func PowerControlOpFrom(op pb.PowerControlOp) operations.PowerOperation {
 	switch op {
 	// Power On
@@ -367,6 +372,7 @@ func PowerControlOpFrom(op pb.PowerControlOp) operations.PowerOperation {
 	}
 }
 
+// TaskExecutorTypeFrom converts a protobuf TaskExecutorType to an internal ExecutorType.
 func TaskExecutorTypeFrom(et pb.TaskExecutorType) taskcommon.ExecutorType {
 	switch et {
 	case pb.TaskExecutorType_TASK_EXECUTOR_TYPE_TEMPORAL:
@@ -376,6 +382,7 @@ func TaskExecutorTypeFrom(et pb.TaskExecutorType) taskcommon.ExecutorType {
 	}
 }
 
+// TaskExecutorTypeTo converts an internal ExecutorType to a protobuf TaskExecutorType.
 func TaskExecutorTypeTo(et taskcommon.ExecutorType) pb.TaskExecutorType {
 	switch et {
 	case taskcommon.ExecutorTypeTemporal:
@@ -385,6 +392,7 @@ func TaskExecutorTypeTo(et taskcommon.ExecutorType) pb.TaskExecutorType {
 	}
 }
 
+// TaskStatusFrom converts a protobuf TaskStatus to an internal TaskStatus.
 func TaskStatusFrom(status pb.TaskStatus) taskcommon.TaskStatus {
 	switch status {
 	case pb.TaskStatus_TASK_STATUS_PENDING:
@@ -404,6 +412,7 @@ func TaskStatusFrom(status pb.TaskStatus) taskcommon.TaskStatus {
 	}
 }
 
+// TaskStatusTo converts an internal TaskStatus to a protobuf TaskStatus.
 func TaskStatusTo(status taskcommon.TaskStatus) pb.TaskStatus {
 	switch status {
 	case taskcommon.TaskStatusPending:
@@ -428,11 +437,6 @@ func TaskTo(task *taskdef.Task) *pb.Task {
 		return nil
 	}
 
-	componentIDs := make([]*pb.UUID, 0, len(task.ComponentUUIDs))
-	for _, id := range task.ComponentUUIDs {
-		componentIDs = append(componentIDs, UUIDTo(id))
-	}
-
 	var opStr string
 	operation, err := operations.New(task.Operation.Type, task.Operation.Info)
 	if err == nil {
@@ -443,7 +447,7 @@ func TaskTo(task *taskdef.Task) *pb.Task {
 		Id:             UUIDTo(task.ID),
 		Operation:      opStr,
 		RackId:         UUIDTo(task.RackID),
-		ComponentUuids: componentIDs,
+		ComponentUuids: UUIDsTo(task.Attributes.AllComponentUUIDs()),
 		Description:    task.Description,
 		ExecutorType:   TaskExecutorTypeTo(task.ExecutorType),
 		ExecutionId:    task.ExecutionID,
@@ -461,9 +465,11 @@ func TaskTo(task *taskdef.Task) *pb.Task {
 	if task.FinishedAt != nil {
 		pbTask.FinishedAt = timestamppb.New(*task.FinishedAt)
 	}
+
 	if task.QueueExpiresAt != nil {
 		pbTask.QueueExpiresAt = timestamppb.New(*task.QueueExpiresAt)
 	}
+
 	return pbTask
 }
 
@@ -620,6 +626,7 @@ func RackTo(r *rack.Rack) *pb.Rack {
 	}
 }
 
+// PaginationTo converts an internal Pagination to a protobuf Pagination.
 func PaginationTo(pg *dbquery.Pagination) *pb.Pagination {
 	if pg == nil {
 		return nil
@@ -631,6 +638,7 @@ func PaginationTo(pg *dbquery.Pagination) *pb.Pagination {
 	}
 }
 
+// StringQueryInfoTo converts an internal StringQueryInfo to a protobuf StringQueryInfo.
 func StringQueryInfoTo(info *dbquery.StringQueryInfo) *pb.StringQueryInfo {
 	if info == nil {
 		return nil
@@ -675,8 +683,8 @@ func OrderByFrom(ob *pb.OrderBy) *dbquery.OrderBy {
 type QueryType int
 
 const (
-	QueryTypeRack QueryType = iota
-	QueryTypeComponent
+	QueryTypeRack      QueryType = iota // QueryTypeRack identifies a rack-scoped query.
+	QueryTypeComponent                  // QueryTypeComponent identifies a component-scoped query.
 )
 
 // OrderByTo converts an internal OrderBy to a protobuf OrderBy
@@ -797,6 +805,7 @@ func NVLDomainTo(info *nvldomain.NVLDomain) *pb.NVLDomain {
 // Operation Rule Converters
 // ========================================
 
+// OperationTypeToProto converts an internal TaskType to a protobuf OperationType.
 func OperationTypeToProto(opType taskcommon.TaskType) pb.OperationType {
 	switch opType {
 	case taskcommon.TaskTypePowerControl:
@@ -808,6 +817,7 @@ func OperationTypeToProto(opType taskcommon.TaskType) pb.OperationType {
 	}
 }
 
+// OperationTypeFromProto converts a protobuf OperationType to an internal TaskType.
 func OperationTypeFromProto(opType pb.OperationType) taskcommon.TaskType {
 	switch opType {
 	case pb.OperationType_OPERATION_TYPE_POWER_CONTROL:
@@ -819,6 +829,7 @@ func OperationTypeFromProto(opType pb.OperationType) taskcommon.TaskType {
 	}
 }
 
+// OperationRuleTo converts an internal OperationRule to its protobuf representation.
 func OperationRuleTo(rule *operationrules.OperationRule) (*pb.OperationRule, error) {
 	if rule == nil {
 		return nil, nil
@@ -843,6 +854,7 @@ func OperationRuleTo(rule *operationrules.OperationRule) (*pb.OperationRule, err
 	}, nil
 }
 
+// OperationRuleFromProto converts a protobuf OperationRule to its internal representation.
 func OperationRuleFromProto(pbRule *pb.OperationRule) (*operationrules.OperationRule, error) {
 	if pbRule == nil {
 		return nil, nil

--- a/rla/internal/db/migrations/20260316000000_add_task_attributes.down.sql
+++ b/rla/internal/db/migrations/20260316000000_add_task_attributes.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE task DROP COLUMN IF EXISTS attributes;
+ALTER TABLE task ADD COLUMN IF NOT EXISTS component_uuids jsonb;

--- a/rla/internal/db/migrations/20260316000000_add_task_attributes.up.sql
+++ b/rla/internal/db/migrations/20260316000000_add_task_attributes.up.sql
@@ -1,0 +1,6 @@
+-- Add flexible attributes column for task metadata. New fields can be added
+-- to the Go TaskAttributes struct without further migrations.
+-- component_uuids is dropped: all component targeting is now stored in
+-- attributes.components_by_type with explicit type information.
+ALTER TABLE task ADD COLUMN IF NOT EXISTS attributes jsonb NOT NULL DEFAULT '{}';
+ALTER TABLE task DROP COLUMN IF EXISTS component_uuids;

--- a/rla/internal/db/model/task.go
+++ b/rla/internal/db/model/task.go
@@ -40,23 +40,24 @@ var defaultTaskPagination = dbquery.Pagination{
 type Task struct {
 	bun.BaseModel `bun:"table:task,alias:t"`
 
-	ID             uuid.UUID               `bun:"id,pk,type:uuid,default:gen_random_uuid()"`
-	Type           taskcommon.TaskType     `bun:"type,type:varchar(64),notnull"`
-	ExecutorType   taskcommon.ExecutorType `bun:"executor_type,type:varchar(64),nullzero"`
-	Information    json.RawMessage         `bun:"information,type:jsonb,json_use_number"`
-	Description    string                  `bun:"description,nullzero"`
-	RackID         uuid.UUID               `bun:"rack_id,type:uuid,notnull"`  // The rack this task operates on
-	ComponentUUIDs []uuid.UUID             `bun:"component_uuids,type:jsonb"` // Component UUIDs in this rack
-	ExecutionID    string                  `bun:"execution_id,notnull"`
-	Status         taskcommon.TaskStatus   `bun:"status,type:varchar(32),notnull"`
-	Message        string                  `bun:"message,nullzero"`
-	AppliedRuleID  *uuid.UUID              `bun:"applied_rule_id,type:uuid"` // Which operation rule was applied
-	CreatedAt      time.Time               `bun:"created_at,nullzero,notnull,default:current_timestamp"`
-	UpdatedAt      time.Time               `bun:"updated_at,nullzero,notnull,default:current_timestamp"`
-	StartedAt      *time.Time              `bun:"started_at"`
-	FinishedAt     *time.Time              `bun:"finished_at"`
-	// QueueExpiresAt is set only for waiting tasks. After this time, the Promoter
-	// will discard the task instead of promoting it.
+	ID            uuid.UUID                 `bun:"id,pk,type:uuid,default:gen_random_uuid()"`
+	Type          taskcommon.TaskType       `bun:"type,type:varchar(64),notnull"`
+	ExecutorType  taskcommon.ExecutorType   `bun:"executor_type,type:varchar(64),nullzero"`
+	Information   json.RawMessage           `bun:"information,type:jsonb,json_use_number"`
+	Description   string                    `bun:"description,nullzero"`
+	RackID        uuid.UUID                 `bun:"rack_id,type:uuid,notnull"` // The rack this task operates on
+	Attributes    taskcommon.TaskAttributes `bun:"attributes,type:jsonb"`
+	ExecutionID   string                    `bun:"execution_id,notnull"`
+	Status        taskcommon.TaskStatus     `bun:"status,type:varchar(32),notnull"`
+	Message       string                    `bun:"message,nullzero"`
+	AppliedRuleID *uuid.UUID                `bun:"applied_rule_id,type:uuid"` // Which operation rule was applied
+	CreatedAt     time.Time                 `bun:"created_at,nullzero,notnull,default:current_timestamp"`
+	UpdatedAt     time.Time                 `bun:"updated_at,nullzero,notnull,default:current_timestamp"`
+	StartedAt     *time.Time                `bun:"started_at"`
+	FinishedAt    *time.Time                `bun:"finished_at"`
+
+	// QueueExpiresAt is set only for waiting tasks. After this time, the
+	// Promoter will discard the task instead of promoting it.
 	QueueExpiresAt *time.Time `bun:"queue_expires_at"`
 }
 

--- a/rla/internal/task/common/common.go
+++ b/rla/internal/task/common/common.go
@@ -100,6 +100,34 @@ type OperationRuleListOptions struct {
 	IsDefault     *bool
 }
 
+// TaskAttributes holds flexible task metadata stored as a single jsonb
+// column. New fields can be added here without requiring a DB migration.
+type TaskAttributes struct {
+	// ComponentsByType maps each targeted component type to its UUIDs.
+	// Nil means the task targets no specific components.
+	ComponentsByType map[devicetypes.ComponentType][]uuid.UUID `json:"components_by_type,omitempty"` //nolint:lll
+}
+
+// AllComponentUUIDs returns a flat slice of all component UUIDs across every
+// component type, in no guaranteed order.
+func (a TaskAttributes) AllComponentUUIDs() []uuid.UUID {
+	total := 0
+	for _, ids := range a.ComponentsByType {
+		total += len(ids)
+	}
+
+	if total == 0 {
+		return nil
+	}
+
+	uuids := make([]uuid.UUID, 0, total)
+	for _, ids := range a.ComponentsByType {
+		uuids = append(uuids, ids...)
+	}
+
+	return uuids //nolint:gocritic
+}
+
 type ComponentInfo struct {
 	Type        devicetypes.ComponentType
 	DeviceInfo  deviceinfo.DeviceInfo

--- a/rla/internal/task/conflict/conflict.go
+++ b/rla/internal/task/conflict/conflict.go
@@ -17,197 +17,310 @@
 
 // Package conflict provides data-driven task conflict detection for RLA.
 //
-// The core abstraction is ConflictRule, a declarative struct that defines which
-// operation pairs cannot coexist and at what scope (dimension). A single
-// EvaluateConflict function interprets the rule — no interface hierarchy needed.
+// The core abstraction is Rule, a declarative struct that defines which
+// operation pairs cannot coexist and at what scope.
+// Rule.Conflicts() evaluates the rule against a set of active tasks.
 //
-// V1 default: exclusive access per rack (any active task blocks a new one).
-// Future: per-pair scoping, configurable allowed-pairs, DB-backed rules.
+// Conflict semantics are intrinsic to what operations do to shared hardware
+// and are therefore defined in code, not configurable by users. The built-in
+// rule (builtinRule) captures these semantics as explicit operation pairs.
+//
+// Convention: any new TaskType or ComponentType added to the codebase MUST be
+// assessed and the appropriate pairs added to builtinRule in the same PR.
 package conflict
 
 import (
 	"context"
 
-	"github.com/google/uuid"
-
+	taskcommon "github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/common"
 	taskstore "github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/store"
 	taskdef "github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/task"
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/pkg/common/devicetypes"
+	"github.com/google/uuid"
 )
 
-// OperationSpec matches an operation by type and code.
-// The wildcard value "*" matches any value in that field.
-type OperationSpec struct {
-	OperationType string // e.g. "power_control", "*"
-	OperationCode string // e.g. "power_on", "*"
+// builtinRule is the code-defined selective conflict policy for RLA.
+// Only explicitly listed operation pairs conflict; everything else may coexist.
+//
+// All active tasks passed to Conflicts() are already pre-filtered to the same
+// rack by ListActiveTasksForRack, so rack-level scoping is implicit.
+// RequireComponentOverlap is only needed when operations are isolated to their
+// targeted components and parallel execution on disjoint sets is safe.
+//
+// ComponentType assignment rationale:
+//   - PowerShelf power ops have RequireComponentOverlap=false (rack-level):
+//     cutting power to a shelf affects all components regardless of UUIDs.
+//   - Compute / NVLSwitch power and firmware ops use
+//     RequireComponentOverlap=true: isolated to their targeted components.
+//   - BringUp has RequireComponentOverlap=false (rack-level): comprehensive.
+//   - ComponentTypeUnknown (zero value) acts as a wildcard — matches any
+//     component type including tasks with nil ComponentsByType (old tasks).
+//
+// IMPORTANT: when adding a new TaskType or ComponentType, update this table
+// in the same PR after assessing which operations it cannot coexist with.
+var builtinRule = &Rule{ //nolint
+	ConflictingPairs: []Entry{
+		// PowerShelf power ops block all power ops on the rack: cutting
+		// power to a shelf affects every component.
+		{
+			A: OperationSpec{
+				OperationType: string(taskcommon.TaskTypePowerControl),
+				ComponentType: devicetypes.ComponentTypePowerShelf,
+			},
+			B: OperationSpec{
+				OperationType: string(taskcommon.TaskTypePowerControl),
+			},
+		},
+		// PowerShelf power ops block all firmware upgrades on the rack:
+		// unsafe to flash any component while shelf power is in flux.
+		{
+			A: OperationSpec{
+				OperationType: string(taskcommon.TaskTypePowerControl),
+				ComponentType: devicetypes.ComponentTypePowerShelf,
+			},
+			B: OperationSpec{
+				OperationType: string(
+					taskcommon.TaskTypeFirmwareControl),
+			},
+		},
+		// Compute power ops block each other on overlapping components.
+		{
+			A: OperationSpec{
+				OperationType: string(taskcommon.TaskTypePowerControl),
+				ComponentType: devicetypes.ComponentTypeCompute,
+			},
+			B: OperationSpec{
+				OperationType: string(taskcommon.TaskTypePowerControl),
+				ComponentType: devicetypes.ComponentTypeCompute,
+			},
+			RequireComponentOverlap: true,
+		},
+		// NVLSwitch power ops block each other on overlapping components.
+		{
+			A: OperationSpec{
+				OperationType: string(taskcommon.TaskTypePowerControl),
+				ComponentType: devicetypes.ComponentTypeNVLSwitch,
+			},
+			B: OperationSpec{
+				OperationType: string(taskcommon.TaskTypePowerControl),
+				ComponentType: devicetypes.ComponentTypeNVLSwitch,
+			},
+			RequireComponentOverlap: true,
+		},
+		// Compute power ops block firmware upgrades on overlapping
+		// compute components.
+		{
+			A: OperationSpec{
+				OperationType: string(taskcommon.TaskTypePowerControl),
+				ComponentType: devicetypes.ComponentTypeCompute,
+			},
+			B: OperationSpec{
+				OperationType: string(
+					taskcommon.TaskTypeFirmwareControl),
+				ComponentType: devicetypes.ComponentTypeCompute,
+			},
+			RequireComponentOverlap: true,
+		},
+		// NVLSwitch power ops block firmware upgrades on overlapping
+		// NVLSwitch components.
+		{
+			A: OperationSpec{
+				OperationType: string(taskcommon.TaskTypePowerControl),
+				ComponentType: devicetypes.ComponentTypeNVLSwitch,
+			},
+			B: OperationSpec{
+				OperationType: string(
+					taskcommon.TaskTypeFirmwareControl),
+				ComponentType: devicetypes.ComponentTypeNVLSwitch,
+			},
+			RequireComponentOverlap: true,
+		},
+		// Firmware upgrades block each other on overlapping components
+		// regardless of component type: flashing the same hardware
+		// concurrently is unsafe.
+		{
+			A: OperationSpec{
+				OperationType: string(
+					taskcommon.TaskTypeFirmwareControl),
+			},
+			B: OperationSpec{
+				OperationType: string(
+					taskcommon.TaskTypeFirmwareControl),
+			},
+			RequireComponentOverlap: true,
+		},
+		// BringUp is comprehensive and blocks all other operations.
+		{
+			A: OperationSpec{
+				OperationType: string(taskcommon.TaskTypeBringUp),
+			},
+			B: OperationSpec{
+				OperationType: "*",
+			},
+		},
+	},
 }
 
-// Matches returns true if this spec matches the given operation.
+// OperationSpec matches an operation by type, code, and component type.
+// The wildcard value "*" matches any string field; ComponentTypeUnknown (0)
+// matches any component type (including tasks with nil ComponentsByType).
+type OperationSpec struct {
+	OperationType string                    // e.g. "power_control", "*"
+	OperationCode string                    // e.g. "power_on", "*"; "" = wildcard
+	ComponentType devicetypes.ComponentType // ComponentTypeUnknown = wildcard
+}
+
+// Matches returns true if this spec matches the given operation type and code.
+// ComponentType is NOT checked here — it is evaluated separately against the
+// task's Attributes.ComponentsByType in Rule.Conflicts().
 func (s OperationSpec) Matches(op OperationSpec) bool {
 	typeMatch := s.OperationType == "*" || s.OperationType == op.OperationType
-	codeMatch := s.OperationCode == "*" || s.OperationCode == op.OperationCode
+	codeMatch := s.OperationCode == "" ||
+		s.OperationCode == "*" ||
+		s.OperationCode == op.OperationCode
 	return typeMatch && codeMatch
 }
 
-// ConflictDimension defines the scope for conflict checking via an extractor
-// function. Two tasks are "in scope" only when their extracted key sets share
-// at least one element.
-type ConflictDimension struct {
-	// Name is used for logging and configuration (e.g. "rack").
-	Name string
-	// ExtractKeys returns the set of scope keys for a task.
-	// For DimensionRack this is always a single element (the rack UUID).
-	// For DimensionComponentUUID it returns all targeted component UUIDs.
-	ExtractKeys func(t *taskdef.Task) []string
-}
-
-// Overlaps returns true when tasks a and b share at least one scope key.
-func (d *ConflictDimension) Overlaps(a, b *taskdef.Task) bool {
-	keysA := d.ExtractKeys(a)
-	keysB := d.ExtractKeys(b)
-	setB := make(map[string]struct{}, len(keysB))
-	for _, k := range keysB {
-		setB[k] = struct{}{}
-	}
-	for _, k := range keysA {
-		if _, ok := setB[k]; ok {
-			return true
-		}
-	}
-	return false
-}
-
-// Built-in dimensions.
-var (
-	// DimensionRack: tasks conflict when they target the same rack.
-	// This is the default and most common scope for conflict detection.
-	DimensionRack = &ConflictDimension{
-		Name: "rack",
-		ExtractKeys: func(t *taskdef.Task) []string {
-			return []string{t.RackID.String()}
-		},
-	}
-
-	// DimensionComponentUUID: tasks conflict when they target at least one
-	// common component UUID. Requires ComponentUUIDs to be populated.
-	DimensionComponentUUID = &ConflictDimension{
-		Name: "component_uuid",
-		ExtractKeys: func(t *taskdef.Task) []string {
-			keys := make([]string, len(t.ComponentUUIDs))
-			for i, id := range t.ComponentUUIDs {
-				keys[i] = id.String()
-			}
-			return keys
-		},
-	}
-)
-
-// ConflictEntry is a symmetric pair of operations that cannot coexist
-// when the scope condition is satisfied.
-type ConflictEntry struct {
+// Entry is a symmetric pair of operations that cannot coexist when the scope
+// condition is satisfied.
+type Entry struct {
 	A OperationSpec
 	B OperationSpec
-	// Scope overrides the rule-level RequireOverlapOn for this specific pair.
-	// If nil, inherits RequireOverlapOn from the parent ConflictRule.
-	Scope *ConflictDimension
+
+	// RequireComponentOverlap narrows conflict detection to task pairs
+	// that share at least one component UUID. When false, any two
+	// matching tasks on the same rack conflict (rack pre-filtering by
+	// ListActiveTasksForRack makes an explicit rack check unnecessary).
+	RequireComponentOverlap bool
 }
 
-// Matches returns true if (p, q) or (q, p) matches (A, B).
-// ConflictEntry is symmetric — the order of A and B does not matter.
-func (e ConflictEntry) Matches(p, q OperationSpec) bool {
-	return (e.A.Matches(p) && e.B.Matches(q)) ||
-		(e.A.Matches(q) && e.B.Matches(p))
-}
-
-// ConflictRule declaratively defines when operations conflict.
+// Rule declaratively defines when operations conflict.
 // Empty ConflictingPairs means exclusive mode: any active task is a conflict.
-type ConflictRule struct {
-	// RequireOverlapOn is the default dimension for scope checking.
-	// Nil defaults to DimensionRack.
-	RequireOverlapOn *ConflictDimension
-
+type Rule struct {
 	// ConflictingPairs lists operation pairs that cannot coexist within
-	// the scope. Each entry is symmetric — the order of A and B does not
-	// matter. Empty = all operations conflict (exclusive mode).
-	ConflictingPairs []ConflictEntry
+	// the scope. Each entry is evaluated symmetrically. Empty = all
+	// active operations conflict (exclusive mode).
+	ConflictingPairs []Entry
 
 	// AtomicAcrossRacks: when true, conflict checking spans all racks in
-	// the same task group. V2 feature — currently always false.
+	// the same task group — the entire multi-rack operation is rejected or
+	// queued as a unit if any rack has a conflict. For V3 in the future,
+	// currently always false.
 	AtomicAcrossRacks bool
 }
 
-// Conflicts returns true if incomingOp conflicts with any of the active tasks
-// under this rule.
+// Conflicts returns true if the incoming task conflicts with any of the active
+// tasks under this rule. A conflict requires:
+//  1. The operation pair matches a ConflictingPairs entry (type, code, and
+//     component type all match for the respective tasks).
+//  2. If RequireComponentOverlap is true, the two tasks must share at least
+//     one component UUID.
 //
-// Exclusive mode (empty ConflictingPairs): any active task is a conflict.
-// Pair mode: conflict only when an active task's operation matches one of
-// the listed ConflictEntry pairs.
-func (r *ConflictRule) Conflicts(
-	incomingOp OperationSpec,
+// All tasks in activeTasks are assumed to be on the same rack as incoming
+// (pre-filtered by ListActiveTasksForRack).
+//
+// Special case: empty ConflictingPairs is exclusive mode — any active task
+// is a conflict.
+func (r *Rule) Conflicts(
+	incoming *taskdef.Task,
 	activeTasks []*taskdef.Task,
 ) bool {
 	if len(r.ConflictingPairs) == 0 {
 		return len(activeTasks) > 0
 	}
 
-	for _, activeTask := range activeTasks {
+	incomingOp := OperationSpec{
+		OperationType: string(incoming.Operation.Type),
+		OperationCode: incoming.Operation.Code,
+	}
+
+	for _, active := range activeTasks {
 		activeOp := OperationSpec{
-			OperationType: string(activeTask.Operation.Type),
-			OperationCode: activeTask.Operation.Code,
+			OperationType: string(active.Operation.Type),
+			OperationCode: active.Operation.Code,
 		}
 		for _, entry := range r.ConflictingPairs {
-			if entry.Matches(incomingOp, activeOp) {
+			// Forward: A qualifies incoming, B qualifies active.
+			forward := entry.A.Matches(incomingOp) &&
+				hasComponentType(incoming, entry.A.ComponentType) &&
+				entry.B.Matches(activeOp) &&
+				hasComponentType(active, entry.B.ComponentType)
+
+			// Reverse: symmetric — A qualifies active, B qualifies incoming.
+			reverse := entry.A.Matches(activeOp) &&
+				hasComponentType(active, entry.A.ComponentType) &&
+				entry.B.Matches(incomingOp) &&
+				hasComponentType(incoming, entry.B.ComponentType)
+
+			if (forward || reverse) &&
+				(!entry.RequireComponentOverlap ||
+					componentUUIDsOverlap(incoming, active)) {
 				return true
 			}
 		}
 	}
+
 	return false
 }
 
-// defaultConflictRule is the V1 default: exclusive access per rack.
-// Any active task on the rack blocks a new one.
-var defaultConflictRule = &ConflictRule{
-	RequireOverlapOn: DimensionRack,
-	// ConflictingPairs is nil → exclusive mode
+// componentUUIDsOverlap returns true when tasks a and b share at least one
+// component UUID across all component types.
+func componentUUIDsOverlap(a, b *taskdef.Task) bool {
+	uuidsA := a.Attributes.AllComponentUUIDs()
+	if len(uuidsA) == 0 {
+		return false
+	}
+
+	setA := make(map[uuid.UUID]struct{}, len(uuidsA))
+	for _, id := range uuidsA {
+		setA[id] = struct{}{}
+	}
+
+	for _, id := range b.Attributes.AllComponentUUIDs() {
+		if _, ok := setA[id]; ok {
+			return true
+		}
+	}
+
+	return false
 }
 
-// ConflictResolver determines whether an incoming operation conflicts with
-// active tasks on a rack. It fetches the applicable rule and evaluates it.
-// V1: always applies the hardcoded exclusive default rule.
-// V2: will query DB for a rack-specific or global default rule.
-type ConflictResolver struct {
+// hasComponentType returns true if task t includes at least one component of
+// the given type. ComponentTypeUnknown in the entry spec is a wildcard —
+// it matches any task regardless of component type.
+func hasComponentType(
+	t *taskdef.Task,
+	ct devicetypes.ComponentType,
+) bool {
+	if ct == devicetypes.ComponentTypeUnknown {
+		return true // entry wildcard
+	}
+	return len(t.Attributes.ComponentsByType[ct]) > 0
+}
+
+// Resolver determines whether an incoming operation conflicts with active
+// tasks on a rack using the code-defined builtinRule.
+type Resolver struct {
 	store taskstore.Store
 }
 
-// NewConflictResolver creates a new ConflictResolver backed by the given store.
-func NewConflictResolver(store taskstore.Store) *ConflictResolver {
-	return &ConflictResolver{store: store}
+// NewResolver creates a new Resolver backed by the given store.
+func NewResolver(store taskstore.Store) *Resolver {
+	return &Resolver{store: store}
 }
 
-// ruleFor returns the conflict rule for the given rack.
-// V1 always returns the exclusive default rule.
-func (r *ConflictResolver) ruleFor(
-	_ context.Context,
-	_ uuid.UUID,
-) (*ConflictRule, error) {
-	return defaultConflictRule, nil
-}
-
-// HasConflict returns true if incomingOp would conflict with an existing
-// active task on rackID under the applicable conflict rule.
-func (r *ConflictResolver) HasConflict(
+// HasConflict returns true if the incoming task would conflict with any
+// existing active task on the same rack under the builtin conflict rule.
+func (r *Resolver) HasConflict(
 	ctx context.Context,
-	incomingOp OperationSpec,
-	rackID uuid.UUID,
+	incoming *taskdef.Task,
 ) (bool, error) {
-	rule, err := r.ruleFor(ctx, rackID)
+	activeTasks, err := r.store.ListActiveTasksForRack(
+		ctx, incoming.RackID,
+	)
 	if err != nil {
 		return false, err
 	}
 
-	activeTasks, err := r.store.ListActiveTasksForRack(ctx, rackID)
-	if err != nil {
-		return false, err
-	}
-
-	return rule.Conflicts(incomingOp, activeTasks), nil
+	return builtinRule.Conflicts(incoming, activeTasks), nil
 }

--- a/rla/internal/task/conflict/conflict_test.go
+++ b/rla/internal/task/conflict/conflict_test.go
@@ -29,19 +29,59 @@ import (
 	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/operation"
 	taskcommon "github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/common"
 	taskdef "github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/task"
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/pkg/common/devicetypes"
 )
 
-// makeTask is a test helper that constructs a minimal Task for conflict tests.
-func makeTask(rackID uuid.UUID, opType taskcommon.TaskType, opCode string, componentUUIDs ...uuid.UUID) *taskdef.Task {
-	return &taskdef.Task{
-		ID:             uuid.New(),
-		RackID:         rackID,
-		ComponentUUIDs: componentUUIDs,
+// makeTask builds a minimal Task for conflict tests.
+// Component UUIDs, when provided, are stored under ComponentTypeCompute.
+// Pass no UUIDs to get a task with nil ComponentsByType (old-task fallback).
+func makeTask(
+	rackID uuid.UUID,
+	opType taskcommon.TaskType,
+	opCode string,
+	componentUUIDs ...uuid.UUID,
+) *taskdef.Task {
+	t := &taskdef.Task{
+		ID:     uuid.New(),
+		RackID: rackID,
 		Operation: operation.Wrapper{
 			Type: opType,
 			Code: opCode,
 		},
 		Status: taskcommon.TaskStatusRunning,
+	}
+	if len(componentUUIDs) > 0 {
+		t.Attributes = taskcommon.TaskAttributes{
+			ComponentsByType: map[devicetypes.ComponentType][]uuid.UUID{
+				devicetypes.ComponentTypeCompute: componentUUIDs,
+			},
+		}
+	}
+	return t
+}
+
+// makeTaskWithType builds a Task whose components are stored under the
+// specified ComponentType. Use this for component-type-specific tests.
+func makeTaskWithType(
+	rackID uuid.UUID,
+	opType taskcommon.TaskType,
+	opCode string,
+	ct devicetypes.ComponentType,
+	componentUUIDs ...uuid.UUID,
+) *taskdef.Task {
+	return &taskdef.Task{
+		ID:     uuid.New(),
+		RackID: rackID,
+		Operation: operation.Wrapper{
+			Type: opType,
+			Code: opCode,
+		},
+		Status: taskcommon.TaskStatusRunning,
+		Attributes: taskcommon.TaskAttributes{
+			ComponentsByType: map[devicetypes.ComponentType][]uuid.UUID{
+				ct: componentUUIDs,
+			},
+		},
 	}
 }
 
@@ -97,37 +137,7 @@ func TestOperationSpec_Matches(t *testing.T) {
 	}
 }
 
-func TestConflictDimension_Overlaps_Rack(t *testing.T) {
-	sharedRack := uuid.New()
-
-	tests := []struct {
-		name     string
-		a        *taskdef.Task
-		b        *taskdef.Task
-		expected bool
-	}{
-		{
-			name:     "same rack overlaps",
-			a:        makeTask(sharedRack, taskcommon.TaskTypePowerControl, "power_on"),
-			b:        makeTask(sharedRack, taskcommon.TaskTypePowerControl, "power_off"),
-			expected: true,
-		},
-		{
-			name:     "different racks do not overlap",
-			a:        makeTask(uuid.New(), taskcommon.TaskTypePowerControl, "power_on"),
-			b:        makeTask(uuid.New(), taskcommon.TaskTypePowerControl, "power_on"),
-			expected: false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, DimensionRack.Overlaps(tc.a, tc.b))
-		})
-	}
-}
-
-func TestConflictDimension_Overlaps_ComponentUUID(t *testing.T) {
+func TestComponentUUIDsOverlap(t *testing.T) {
 	rackID := uuid.New()
 	shared := uuid.New()
 
@@ -138,15 +148,23 @@ func TestConflictDimension_Overlaps_ComponentUUID(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "shared component UUID overlaps",
-			a:        makeTask(rackID, taskcommon.TaskTypePowerControl, "power_on", shared, uuid.New()),
-			b:        makeTask(rackID, taskcommon.TaskTypePowerControl, "power_on", uuid.New(), shared),
+			name: "shared component UUID overlaps",
+			a: makeTask(rackID,
+				taskcommon.TaskTypePowerControl, "power_on",
+				shared, uuid.New()),
+			b: makeTask(rackID,
+				taskcommon.TaskTypePowerControl, "power_on",
+				uuid.New(), shared),
 			expected: true,
 		},
 		{
-			name:     "no shared component UUIDs do not overlap",
-			a:        makeTask(rackID, taskcommon.TaskTypePowerControl, "power_on", uuid.New()),
-			b:        makeTask(rackID, taskcommon.TaskTypePowerControl, "power_on", uuid.New()),
+			name: "no shared component UUIDs do not overlap",
+			a: makeTask(rackID,
+				taskcommon.TaskTypePowerControl, "power_on",
+				uuid.New()),
+			b: makeTask(rackID,
+				taskcommon.TaskTypePowerControl, "power_on",
+				uuid.New()),
 			expected: false,
 		},
 		{
@@ -159,54 +177,20 @@ func TestConflictDimension_Overlaps_ComponentUUID(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, DimensionComponentUUID.Overlaps(tc.a, tc.b))
+			assert.Equal(
+				t, tc.expected,
+				componentUUIDsOverlap(tc.a, tc.b),
+			)
 		})
 	}
 }
 
-func TestConflictEntry_Matches(t *testing.T) {
-	entry := ConflictEntry{
-		A: OperationSpec{OperationType: "power_control", OperationCode: "power_on"},
-		B: OperationSpec{OperationType: "firmware_control", OperationCode: "upgrade"},
-	}
-
-	tests := []struct {
-		name     string
-		p        OperationSpec
-		q        OperationSpec
-		expected bool
-	}{
-		{
-			name:     "forward match",
-			p:        OperationSpec{OperationType: "power_control", OperationCode: "power_on"},
-			q:        OperationSpec{OperationType: "firmware_control", OperationCode: "upgrade"},
-			expected: true,
-		},
-		{
-			name:     "reversed match (symmetric)",
-			p:        OperationSpec{OperationType: "firmware_control", OperationCode: "upgrade"},
-			q:        OperationSpec{OperationType: "power_control", OperationCode: "power_on"},
-			expected: true,
-		},
-		{
-			name:     "no match",
-			p:        OperationSpec{OperationType: "power_control", OperationCode: "power_on"},
-			q:        OperationSpec{OperationType: "power_control", OperationCode: "power_off"},
-			expected: false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, entry.Matches(tc.p, tc.q))
-		})
-	}
-}
-
-func TestConflictRule_Conflicts_ExclusiveMode(t *testing.T) {
-	rule := &ConflictRule{} // empty ConflictingPairs → exclusive mode
+func TestRule_Conflicts_ExclusiveMode(t *testing.T) {
+	// Exclusive mode: any active task is a conflict regardless of type.
+	// Rack pre-filtering is done by the store, not by the rule.
+	rule := &Rule{}
 	rackID := uuid.New()
-	incoming := OperationSpec{OperationType: "power_control", OperationCode: "power_on"}
+	incoming := makeTask(rackID, taskcommon.TaskTypePowerControl, "power_on")
 
 	tests := []struct {
 		name        string
@@ -214,24 +198,24 @@ func TestConflictRule_Conflicts_ExclusiveMode(t *testing.T) {
 		expected    bool
 	}{
 		{
-			name:        "nil active tasks",
+			name:        "nil active tasks — no conflict",
 			activeTasks: nil,
 			expected:    false,
 		},
 		{
-			name:        "empty active tasks",
+			name:        "empty active tasks — no conflict",
 			activeTasks: []*taskdef.Task{},
 			expected:    false,
 		},
 		{
-			name: "one active task",
+			name: "one active task — conflict",
 			activeTasks: []*taskdef.Task{
 				makeTask(rackID, taskcommon.TaskTypeFirmwareControl, "upgrade"),
 			},
 			expected: true,
 		},
 		{
-			name: "multiple active tasks",
+			name: "multiple active tasks — conflict",
 			activeTasks: []*taskdef.Task{
 				makeTask(rackID, taskcommon.TaskTypePowerControl, "power_off"),
 				makeTask(rackID, taskcommon.TaskTypeFirmwareControl, "upgrade"),
@@ -247,10 +231,10 @@ func TestConflictRule_Conflicts_ExclusiveMode(t *testing.T) {
 	}
 }
 
-func TestConflictRule_Conflicts_PairMode(t *testing.T) {
+func TestRule_Conflicts_PairMode(t *testing.T) {
 	rackID := uuid.New()
-	rule := &ConflictRule{
-		ConflictingPairs: []ConflictEntry{
+	rule := &Rule{
+		ConflictingPairs: []Entry{
 			{
 				A: OperationSpec{OperationType: "power_control", OperationCode: "*"},
 				B: OperationSpec{OperationType: "firmware_control", OperationCode: "*"},
@@ -264,35 +248,43 @@ func TestConflictRule_Conflicts_PairMode(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		incoming    OperationSpec
+		incoming    *taskdef.Task
 		activeTasks []*taskdef.Task
 		expected    bool
 	}{
 		{
-			name:        "no active tasks",
-			incoming:    OperationSpec{OperationType: "power_control", OperationCode: "power_on"},
+			name: "no active tasks",
+			incoming: makeTask(
+				rackID, taskcommon.TaskTypePowerControl, "power_on",
+			),
 			activeTasks: []*taskdef.Task{},
 			expected:    false,
 		},
 		{
-			name:     "active task matches a pair",
-			incoming: OperationSpec{OperationType: "power_control", OperationCode: "power_on"},
+			name: "active task matches a pair",
+			incoming: makeTask(
+				rackID, taskcommon.TaskTypePowerControl, "power_on",
+			),
 			activeTasks: []*taskdef.Task{
 				makeTask(rackID, taskcommon.TaskTypeFirmwareControl, "upgrade"),
 			},
 			expected: true,
 		},
 		{
-			name:     "active task does not match any pair",
-			incoming: OperationSpec{OperationType: "power_control", OperationCode: "power_on"},
+			name: "active task does not match any pair",
+			incoming: makeTask(
+				rackID, taskcommon.TaskTypePowerControl, "power_on",
+			),
 			activeTasks: []*taskdef.Task{
 				makeTask(rackID, taskcommon.TaskTypePowerControl, "power_off"),
 			},
 			expected: false,
 		},
 		{
-			name:     "active task matches second pair",
-			incoming: OperationSpec{OperationType: "bring_up", OperationCode: "full"},
+			name: "active task matches second pair",
+			incoming: makeTask(
+				rackID, taskcommon.TaskTypeBringUp, "full",
+			),
 			activeTasks: []*taskdef.Task{
 				makeTask(rackID, taskcommon.TaskTypeBringUp, "full"),
 			},
@@ -307,52 +299,324 @@ func TestConflictRule_Conflicts_PairMode(t *testing.T) {
 	}
 }
 
-func TestConflictResolver_HasConflict(t *testing.T) {
+func TestBuiltinRule(t *testing.T) {
+	rackID := uuid.New()
+	sharedComp := uuid.New()
+
+	tests := []struct {
+		name        string
+		incoming    *taskdef.Task
+		activeTasks []*taskdef.Task
+		expected    bool
+	}{
+		{
+			name: "no active tasks — no conflict",
+			incoming: makeTask(
+				rackID, taskcommon.TaskTypePowerControl, "power_on",
+			),
+			activeTasks: nil,
+			expected:    false,
+		},
+		{
+			// PowerShelf power blocks all power ops at rack scope.
+			name: "power blocks power",
+			incoming: makeTaskWithType(
+				rackID, taskcommon.TaskTypePowerControl, "power_on",
+				devicetypes.ComponentTypePowerShelf, uuid.New(),
+			),
+			activeTasks: []*taskdef.Task{
+				makeTaskWithType(rackID,
+					taskcommon.TaskTypePowerControl, "power_off",
+					devicetypes.ComponentTypePowerShelf, uuid.New()),
+			},
+			expected: true,
+		},
+		{
+			// PowerShelf power blocks all firmware ops at rack scope.
+			name: "power blocks firmware",
+			incoming: makeTaskWithType(
+				rackID, taskcommon.TaskTypePowerControl, "power_on",
+				devicetypes.ComponentTypePowerShelf, uuid.New(),
+			),
+			activeTasks: []*taskdef.Task{
+				makeTask(rackID,
+					taskcommon.TaskTypeFirmwareControl, "upgrade"),
+			},
+			expected: true,
+		},
+		{
+			// Symmetric: active PowerShelf power blocks incoming firmware.
+			name: "firmware blocks power (symmetric)",
+			incoming: makeTask(
+				rackID, taskcommon.TaskTypeFirmwareControl, "upgrade",
+			),
+			activeTasks: []*taskdef.Task{
+				makeTaskWithType(rackID,
+					taskcommon.TaskTypePowerControl, "power_on",
+					devicetypes.ComponentTypePowerShelf, uuid.New()),
+			},
+			expected: true,
+		},
+		{
+			name: "firmware blocks firmware (overlapping components)",
+			incoming: makeTask(
+				rackID, taskcommon.TaskTypeFirmwareControl, "upgrade",
+				sharedComp,
+			),
+			activeTasks: []*taskdef.Task{
+				makeTask(rackID,
+					taskcommon.TaskTypeFirmwareControl, "upgrade",
+					sharedComp),
+			},
+			expected: true,
+		},
+		{
+			// Firmware upgrades on disjoint component sets are safe to
+			// run in parallel: no component UUID overlap.
+			name: "firmware does not block firmware (different components)",
+			incoming: makeTask(
+				rackID, taskcommon.TaskTypeFirmwareControl, "upgrade",
+				uuid.New(),
+			),
+			activeTasks: []*taskdef.Task{
+				makeTask(rackID,
+					taskcommon.TaskTypeFirmwareControl, "upgrade",
+					uuid.New()),
+			},
+			expected: false,
+		},
+		{
+			name: "bring_up blocks power",
+			incoming: makeTask(
+				rackID, taskcommon.TaskTypeBringUp, "full",
+			),
+			activeTasks: []*taskdef.Task{
+				makeTask(rackID,
+					taskcommon.TaskTypePowerControl, "power_on"),
+			},
+			expected: true,
+		},
+		{
+			name: "power blocks bring_up (symmetric)",
+			incoming: makeTask(
+				rackID, taskcommon.TaskTypePowerControl, "power_on",
+			),
+			activeTasks: []*taskdef.Task{
+				makeTask(rackID,
+					taskcommon.TaskTypeBringUp, "full"),
+			},
+			expected: true,
+		},
+		{
+			name: "inject_expectation does not conflict with power",
+			incoming: makeTask(
+				rackID, taskcommon.TaskTypeInjectExpectation, "inject",
+			),
+			activeTasks: []*taskdef.Task{
+				makeTask(rackID,
+					taskcommon.TaskTypePowerControl, "power_on"),
+			},
+			expected: false,
+		},
+		{
+			name: "inject_expectation does not conflict with firmware",
+			incoming: makeTask(
+				rackID, taskcommon.TaskTypeInjectExpectation, "inject",
+			),
+			activeTasks: []*taskdef.Task{
+				makeTask(rackID,
+					taskcommon.TaskTypeFirmwareControl, "upgrade"),
+			},
+			expected: false,
+		},
+		// --- Component-type-specific entries ---
+		{
+			// PowerShelf power cuts rack power → blocks any power op
+			// at rack scope regardless of component type.
+			name: "powershelf power blocks compute power (rack scope)",
+			incoming: makeTaskWithType(
+				rackID,
+				taskcommon.TaskTypePowerControl, "power_on",
+				devicetypes.ComponentTypeCompute, uuid.New(),
+			),
+			activeTasks: []*taskdef.Task{
+				makeTaskWithType(rackID,
+					taskcommon.TaskTypePowerControl, "power_off",
+					devicetypes.ComponentTypePowerShelf, uuid.New()),
+			},
+			expected: true,
+		},
+		{
+			// PowerShelf power blocks firmware at rack scope:
+			// unsafe to flash any component while shelf power is in flux.
+			name: "powershelf power blocks compute firmware (rack scope)",
+			incoming: makeTaskWithType(
+				rackID,
+				taskcommon.TaskTypeFirmwareControl, "upgrade",
+				devicetypes.ComponentTypeCompute, uuid.New(),
+			),
+			activeTasks: []*taskdef.Task{
+				makeTaskWithType(rackID,
+					taskcommon.TaskTypePowerControl, "power_off",
+					devicetypes.ComponentTypePowerShelf, uuid.New()),
+			},
+			expected: true,
+		},
+		{
+			// Compute power ops block each other only when they target
+			// overlapping component UUIDs.
+			name: "compute power blocks compute power (shared component)",
+			incoming: makeTaskWithType(
+				rackID,
+				taskcommon.TaskTypePowerControl, "power_on",
+				devicetypes.ComponentTypeCompute, sharedComp,
+			),
+			activeTasks: []*taskdef.Task{
+				makeTaskWithType(rackID,
+					taskcommon.TaskTypePowerControl, "power_off",
+					devicetypes.ComponentTypeCompute, sharedComp),
+			},
+			expected: true,
+		},
+		{
+			// Compute power on disjoint components is safe in parallel.
+			name: "compute power safe with compute power (no overlap)",
+			incoming: makeTaskWithType(
+				rackID,
+				taskcommon.TaskTypePowerControl, "power_on",
+				devicetypes.ComponentTypeCompute, uuid.New(),
+			),
+			activeTasks: []*taskdef.Task{
+				makeTaskWithType(rackID,
+					taskcommon.TaskTypePowerControl, "power_on",
+					devicetypes.ComponentTypeCompute, uuid.New()),
+			},
+			expected: false,
+		},
+		{
+			// Compute and NVLSwitch power ops are isolated — no entry
+			// covers cross-type conflicts at component scope.
+			name: "compute power safe with nvlswitch power",
+			incoming: makeTaskWithType(
+				rackID,
+				taskcommon.TaskTypePowerControl, "power_on",
+				devicetypes.ComponentTypeCompute, uuid.New(),
+			),
+			activeTasks: []*taskdef.Task{
+				makeTaskWithType(rackID,
+					taskcommon.TaskTypePowerControl, "power_on",
+					devicetypes.ComponentTypeNVLSwitch, uuid.New()),
+			},
+			expected: false,
+		},
+		{
+			// Compute power blocks firmware on overlapping compute
+			// components.
+			name: "compute power blocks compute firmware (shared comp)",
+			incoming: makeTaskWithType(
+				rackID,
+				taskcommon.TaskTypePowerControl, "power_on",
+				devicetypes.ComponentTypeCompute, sharedComp,
+			),
+			activeTasks: []*taskdef.Task{
+				makeTaskWithType(rackID,
+					taskcommon.TaskTypeFirmwareControl, "upgrade",
+					devicetypes.ComponentTypeCompute, sharedComp),
+			},
+			expected: true,
+		},
+		{
+			// Compute power on disjoint component set does not block
+			// firmware on non-overlapping compute components.
+			name: "compute power safe with compute firmware (no overlap)",
+			incoming: makeTaskWithType(
+				rackID,
+				taskcommon.TaskTypePowerControl, "power_on",
+				devicetypes.ComponentTypeCompute, uuid.New(),
+			),
+			activeTasks: []*taskdef.Task{
+				makeTaskWithType(rackID,
+					taskcommon.TaskTypeFirmwareControl, "upgrade",
+					devicetypes.ComponentTypeCompute, uuid.New()),
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(
+				t, tc.expected,
+				builtinRule.Conflicts(
+					tc.incoming, tc.activeTasks,
+				),
+			)
+		})
+	}
+}
+
+func TestResolver_HasConflict(t *testing.T) {
 	rackA := uuid.New()
 	rackB := uuid.New()
 
 	tests := []struct {
 		name          string
 		setupStore    func(*mockStore)
-		rackID        uuid.UUID
+		incoming      *taskdef.Task
 		expectedValue bool
 		expectedErr   bool
 	}{
 		{
-			name:          "no active tasks on rack",
-			setupStore:    func(_ *mockStore) {},
-			rackID:        rackA,
+			name:       "no active tasks on rack",
+			setupStore: func(_ *mockStore) {},
+			incoming: makeTask(
+				rackA, taskcommon.TaskTypePowerControl, "power_on",
+			),
 			expectedValue: false,
 		},
 		{
-			name: "one active task on rack",
+			name: "conflicting active task on rack",
 			setupStore: func(s *mockStore) {
 				s.activeTasks[rackA] = []*taskdef.Task{
-					makeTask(rackA, taskcommon.TaskTypePowerControl, "power_off"),
+					makeTaskWithType(rackA,
+						taskcommon.TaskTypePowerControl,
+						"power_off",
+						devicetypes.ComponentTypePowerShelf,
+						uuid.New()),
 				}
 			},
-			rackID:        rackA,
+			incoming: makeTaskWithType(
+				rackA, taskcommon.TaskTypePowerControl, "power_on",
+				devicetypes.ComponentTypePowerShelf, uuid.New(),
+			),
 			expectedValue: true,
 		},
 		{
-			name: "multiple active tasks on rack",
+			name: "non-conflicting active task on rack",
 			setupStore: func(s *mockStore) {
 				s.activeTasks[rackA] = []*taskdef.Task{
-					makeTask(rackA, taskcommon.TaskTypePowerControl, "power_off"),
-					makeTask(rackA, taskcommon.TaskTypeFirmwareControl, "upgrade"),
+					makeTask(rackA,
+						taskcommon.TaskTypeInjectExpectation,
+						"inject"),
 				}
 			},
-			rackID:        rackA,
-			expectedValue: true,
+			incoming: makeTask(
+				rackA, taskcommon.TaskTypeInjectExpectation, "inject",
+			),
+			expectedValue: false,
 		},
 		{
-			name: "active task on different rack does not affect checked rack",
+			name: "active task on different rack — no conflict",
 			setupStore: func(s *mockStore) {
 				s.activeTasks[rackA] = []*taskdef.Task{
-					makeTask(rackA, taskcommon.TaskTypePowerControl, "power_on"),
+					makeTask(rackA,
+						taskcommon.TaskTypePowerControl,
+						"power_on"),
 				}
 			},
-			rackID:        rackB,
+			incoming: makeTask(
+				rackB, taskcommon.TaskTypePowerControl, "power_on",
+			),
 			expectedValue: false,
 		},
 		{
@@ -360,7 +624,9 @@ func TestConflictResolver_HasConflict(t *testing.T) {
 			setupStore: func(s *mockStore) {
 				s.listActiveErr = errors.New("db connection lost")
 			},
-			rackID:      rackA,
+			incoming: makeTask(
+				rackA, taskcommon.TaskTypePowerControl, "power_on",
+			),
 			expectedErr: true,
 		},
 	}
@@ -369,12 +635,11 @@ func TestConflictResolver_HasConflict(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			store := newMockStore()
 			tc.setupStore(store)
-			resolver := NewConflictResolver(store)
+			resolver := NewResolver(store)
 
 			hasConflict, err := resolver.HasConflict(
 				context.Background(),
-				OperationSpec{OperationType: "power_control", OperationCode: "power_on"},
-				tc.rackID,
+				tc.incoming,
 			)
 
 			if tc.expectedErr {

--- a/rla/internal/task/conflict/promoter.go
+++ b/rla/internal/task/conflict/promoter.go
@@ -189,17 +189,15 @@ func (p *Promoter) sweepAllRacks(ctx context.Context) {
 }
 
 // processRack fetches all waiting tasks for a rack once, terminates expired
-// ones, then promotes eligible candidates in FIFO order stopping at the first
-// conflict.
+// ones, then promotes eligible candidates using the builtinRule.
 //
-// For the current exclusive rule (V1), this promotes at most one task per
-// event since the promoted task immediately occupies the rack. The loop
-// structure is V2-ready: once pair-based rules are introduced, multiple
-// non-conflicting tasks can be promoted in a single pass.
-//
-// TODO(V2): inject ConflictResolver so the conflict check inside the
-// transaction uses ConflictRule.Conflicts() instead of the hardcoded
-// exclusive-mode check (len(workingActive) > 0).
+// Candidates are evaluated in FIFO order. Promotion continues as long as
+// consecutive candidates do not conflict with the current active set
+// (including tasks promoted earlier in this pass). The loop stops at the
+// first conflicting candidate — tasks behind it are not promoted even if
+// they would not conflict themselves. This preserves strict submission
+// ordering at the cost of some parallelism, which is the right trade-off
+// for hardware operations where users expect sequential execution.
 func (p *Promoter) processRack(ctx context.Context, rackID uuid.UUID) {
 	waiting, err := p.store.ListWaitingTasksForRack(ctx, rackID)
 	if err != nil {
@@ -232,8 +230,8 @@ func (p *Promoter) processRack(ctx context.Context, rackID uuid.UUID) {
 		return
 	}
 
-	// Atomically fetch the active set and promote candidates in FIFO order,
-	// stopping at the first conflict.
+	// Atomically fetch the active set and promote candidates in FIFO
+	// order, stopping at the first conflict.
 	var toExecute []*taskdef.Task
 	txErr := p.store.RunInTransaction(ctx, func(txCtx context.Context) error {
 		toExecute = nil // reset on retry
@@ -243,24 +241,28 @@ func (p *Promoter) processRack(ctx context.Context, rackID uuid.UUID) {
 			return err
 		}
 
-		// workingActive grows as candidates are promoted within this round,
-		// so each subsequent candidate is checked against an up-to-date set.
-		// TODO(V2): replace len(workingActive) > 0 with
-		//   ConflictRule.Conflicts(candidateOp, workingActive).
-		workingActive := len(active)
+		// workingActive grows as candidates are promoted within this
+		// pass, so each subsequent candidate is checked against an
+		// up-to-date effective active set.
+		workingActive := make([]*taskdef.Task, len(active))
+		copy(workingActive, active)
 		for _, candidate := range candidates {
-			if workingActive > 0 {
-				break // FIFO: stop at first conflict
+			if builtinRule.Conflicts(candidate, workingActive) {
+				break // stop; preserve FIFO ordering
 			}
-			if err := p.store.UpdateTaskStatus(txCtx, &taskdef.TaskStatusUpdate{
-				ID:      candidate.ID,
-				Status:  taskcommon.TaskStatusPending,
-				Message: "Promoted: rack is now available",
-			}); err != nil {
+
+			if err := p.store.UpdateTaskStatus(txCtx,
+				&taskdef.TaskStatusUpdate{
+					ID:     candidate.ID,
+					Status: taskcommon.TaskStatusPending,
+					Message: "Promoted: no conflicting" +
+						" active tasks",
+				},
+			); err != nil {
 				return err
 			}
 			toExecute = append(toExecute, candidate)
-			workingActive++
+			workingActive = append(workingActive, candidate)
 		}
 		return nil
 	})

--- a/rla/internal/task/conflict/promoter_test.go
+++ b/rla/internal/task/conflict/promoter_test.go
@@ -28,6 +28,7 @@ import (
 
 	taskcommon "github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/common"
 	taskdef "github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/task"
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/pkg/common/devicetypes"
 )
 
 func TestPromoterConfig_ApplyDefaults(t *testing.T) {
@@ -176,17 +177,21 @@ func TestPromoter_ProcessRack(t *testing.T) {
 			wantPromotedCount: 1,
 		},
 		{
-			name: "no promotion when rack has active tasks",
+			name: "no promotion when rack has conflicting active task",
 			setupStore: func(s *mockStore, rackID uuid.UUID) {
-				waiting := &taskdef.Task{
-					ID:             uuid.New(),
-					RackID:         rackID,
-					QueueExpiresAt: &future,
-					Status:         taskcommon.TaskStatusWaiting,
-				}
+				waiting := makeTaskWithType(
+					rackID,
+					taskcommon.TaskTypePowerControl, "power_on",
+					devicetypes.ComponentTypePowerShelf, uuid.New(),
+				)
+				waiting.QueueExpiresAt = &future
+				waiting.Status = taskcommon.TaskStatusWaiting
 				s.waitingTasks[rackID] = []*taskdef.Task{waiting}
 				s.activeTasks[rackID] = []*taskdef.Task{
-					makeTask(rackID, taskcommon.TaskTypePowerControl, "power_on"),
+					makeTaskWithType(rackID,
+						taskcommon.TaskTypePowerControl, "power_on",
+						devicetypes.ComponentTypePowerShelf,
+						uuid.New()),
 				}
 			},
 			wantStatusUpdates: nil,
@@ -216,26 +221,61 @@ func TestPromoter_ProcessRack(t *testing.T) {
 			wantPromotedCount: 1,
 		},
 		{
-			name: "FIFO — only oldest promoted when multiple waiting",
+			name: "FIFO — only oldest promoted when ops conflict",
 			setupStore: func(s *mockStore, rackID uuid.UUID) {
-				older := &taskdef.Task{
-					ID:             uuid.New(),
-					RackID:         rackID,
-					QueueExpiresAt: &future,
-					Status:         taskcommon.TaskStatusWaiting,
+				// Both are PowerShelf power_control: they conflict
+				// at rack scope. Older is promoted; newer blocks
+				// the queue so nothing behind it runs.
+				older := makeTaskWithType(
+					rackID,
+					taskcommon.TaskTypePowerControl, "power_on",
+					devicetypes.ComponentTypePowerShelf, uuid.New(),
+				)
+				older.QueueExpiresAt = &future
+				older.Status = taskcommon.TaskStatusWaiting
+				newer := makeTaskWithType(
+					rackID,
+					taskcommon.TaskTypePowerControl, "power_on",
+					devicetypes.ComponentTypePowerShelf, uuid.New(),
+				)
+				newer.QueueExpiresAt = &future
+				newer.Status = taskcommon.TaskStatusWaiting
+				s.waitingTasks[rackID] = []*taskdef.Task{
+					older, newer,
 				}
-				newer := &taskdef.Task{
-					ID:             uuid.New(),
-					RackID:         rackID,
-					QueueExpiresAt: &future,
-					Status:         taskcommon.TaskStatusWaiting,
-				}
-				s.waitingTasks[rackID] = []*taskdef.Task{older, newer}
 			},
 			wantStatusUpdates: []taskdef.TaskStatusUpdate{
 				{Status: taskcommon.TaskStatusPending},
 			},
 			wantPromotedCount: 1,
+		},
+		{
+			name: "multiple non-conflicting tasks promoted in one pass",
+			setupStore: func(s *mockStore, rackID uuid.UUID) {
+				// inject_expectation does not appear in any
+				// builtinRule pair, so two such tasks
+				// can be promoted simultaneously.
+				t1 := makeTask(
+					rackID,
+					taskcommon.TaskTypeInjectExpectation,
+					"inject",
+				)
+				t1.QueueExpiresAt = &future
+				t1.Status = taskcommon.TaskStatusWaiting
+				t2 := makeTask(
+					rackID,
+					taskcommon.TaskTypeInjectExpectation,
+					"inject",
+				)
+				t2.QueueExpiresAt = &future
+				t2.Status = taskcommon.TaskStatusWaiting
+				s.waitingTasks[rackID] = []*taskdef.Task{t1, t2}
+			},
+			wantStatusUpdates: []taskdef.TaskStatusUpdate{
+				{Status: taskcommon.TaskStatusPending},
+				{Status: taskcommon.TaskStatusPending},
+			},
+			wantPromotedCount: 2,
 		},
 		{
 			name: "list waiting error — no panics, no updates",

--- a/rla/internal/task/manager/manager.go
+++ b/rla/internal/task/manager/manager.go
@@ -37,6 +37,7 @@ import (
 	taskstore "github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/store"
 	taskdef "github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/task"
 	identifier "github.com/NVIDIA/ncx-infra-controller-rest/rla/pkg/common/Identifier"
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/pkg/common/devicetypes"
 	"github.com/NVIDIA/ncx-infra-controller-rest/rla/pkg/inventoryobjects/rack"
 )
 
@@ -73,6 +74,7 @@ func (c *Config) applyDefaults() {
 	}
 }
 
+// Validate returns an error if the Config is missing required fields.
 func (c *Config) Validate() error {
 	if c == nil {
 		return fmt.Errorf("configuration is nil")
@@ -100,7 +102,7 @@ type Manager struct {
 	taskStore        taskstore.Store      // For task persistence
 	executor         executor.Executor
 	ruleResolver     *operationrules.Resolver // Resolves operation rules (created internally)
-	conflictResolver *conflict.ConflictResolver
+	conflictResolver *conflict.Resolver
 	promoter         *conflict.Promoter
 
 	maxWaitingPerRack   int
@@ -126,7 +128,7 @@ func New(ctx context.Context, conf *Config) (*Manager, error) {
 
 	// Create rule resolver internally (queries DB for operation rules)
 	ruleResolver := operationrules.NewResolver(conf.TaskStore)
-	conflictResolver := conflict.NewConflictResolver(conf.TaskStore)
+	conflictResolver := conflict.NewResolver(conf.TaskStore)
 
 	m := &Manager{
 		inventoryStore:      conf.InventoryStore,
@@ -239,21 +241,26 @@ func (m *Manager) createAndExecuteTask(
 	req *operation.Request,
 	targetRack *rack.Rack,
 ) (uuid.UUID, error) {
-	// Extract component UUIDs for tracking
-	componentUUIDs := make([]uuid.UUID, 0, len(targetRack.Components))
+	// Build component map by type for fine-grained conflict detection.
+	compsByType := make(
+		map[devicetypes.ComponentType][]uuid.UUID,
+		len(targetRack.Components),
+	)
 	for _, c := range targetRack.Components {
-		componentUUIDs = append(componentUUIDs, c.Info.ID)
+		compsByType[c.Type] = append(compsByType[c.Type], c.Info.ID)
 	}
 
 	// Build the task record (status and rule are determined below).
 	task := taskdef.Task{
-		ID:             uuid.New(),
-		Operation:      req.Operation,
-		RackID:         targetRack.Info.ID,
-		ComponentUUIDs: componentUUIDs,
-		Description:    req.Description,
-		ExecutorType:   taskcommon.ExecutorTypeUnknown,
-		ExecutionID:    "",
+		ID:        uuid.New(),
+		Operation: req.Operation,
+		RackID:    targetRack.Info.ID,
+		Attributes: taskcommon.TaskAttributes{
+			ComponentsByType: compsByType,
+		},
+		Description:  req.Description,
+		ExecutorType: taskcommon.ExecutorTypeUnknown,
+		ExecutionID:  "",
 	}
 
 	// Check for conflicts inside a transaction to avoid a race between the
@@ -262,12 +269,7 @@ func (m *Manager) createAndExecuteTask(
 		ctx,
 		func(txCtx context.Context) error {
 			hasConflict, err := m.conflictResolver.HasConflict(
-				txCtx,
-				conflict.OperationSpec{
-					OperationType: string(req.Operation.Type),
-					OperationCode: req.Operation.Code,
-				},
-				targetRack.Info.ID,
+				txCtx, &task,
 			)
 			if err != nil {
 				return err
@@ -444,7 +446,7 @@ func (m *Manager) CancelTask(ctx context.Context, taskID uuid.UUID) error {
 }
 
 // loadRackForTask re-fetches the rack for a task and filters its component
-// list to only those tracked in task.ComponentUUIDs.
+// list to only those tracked in task.Attributes.
 func (m *Manager) loadRackForTask(
 	ctx context.Context,
 	task *taskdef.Task,
@@ -459,8 +461,9 @@ func (m *Manager) loadRackForTask(
 	}
 
 	// Filter to the components originally targeted by the task.
-	uuidSet := make(map[uuid.UUID]struct{}, len(task.ComponentUUIDs))
-	for _, id := range task.ComponentUUIDs {
+	allUUIDs := task.Attributes.AllComponentUUIDs()
+	uuidSet := make(map[uuid.UUID]struct{}, len(allUUIDs))
+	for _, id := range allUUIDs {
 		uuidSet[id] = struct{}{}
 	}
 

--- a/rla/internal/task/task/task.go
+++ b/rla/internal/task/task/task.go
@@ -34,7 +34,7 @@ import (
 // -- ID: The unique identifier of the task.
 // -- Operation: The operation to be performed by the task.
 // -- RackID: The rack this task operates on (1 task = 1 rack).
-// -- ComponentUUIDs: The component UUIDs in this rack.
+// -- Attributes: Flexible metadata including targeted components by type.
 // -- Description: The description of the task provided by the user.
 // -- ExecutorType: The type of executor to be used for the task.
 // -- ExecutionID: The identifier of the execution of the task.
@@ -42,20 +42,20 @@ import (
 // -- Message: Status message or error details.
 // -- AppliedRuleID: The ID of the operation rule that was applied (if any).
 type Task struct {
-	ID             uuid.UUID
-	Operation      operation.Wrapper
-	RackID         uuid.UUID   // The rack this task operates on (1 task = 1 rack)
-	ComponentUUIDs []uuid.UUID // Component UUIDs in this rack
-	Description    string
-	ExecutorType   taskcommon.ExecutorType
-	ExecutionID    string
-	Status         taskcommon.TaskStatus
-	Message        string
-	AppliedRuleID  *uuid.UUID // The ID of the operation rule that was applied
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
-	StartedAt      *time.Time
-	FinishedAt     *time.Time
+	ID            uuid.UUID
+	Operation     operation.Wrapper
+	RackID        uuid.UUID // The rack this task operates on (1 task = 1 rack)
+	Attributes    taskcommon.TaskAttributes
+	Description   string
+	ExecutorType  taskcommon.ExecutorType
+	ExecutionID   string
+	Status        taskcommon.TaskStatus
+	Message       string
+	AppliedRuleID *uuid.UUID // The ID of the operation rule that was applied
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+	StartedAt     *time.Time
+	FinishedAt    *time.Time
 
 	// QueueExpiresAt is the deadline for a waiting task to be promoted.
 	// After this time the Promoter terminates the task automatically.
@@ -79,15 +79,18 @@ type ExecutionInfo struct {
 	RuleDefinition *operationrules.RuleDefinition
 }
 
+// ExecutionRequest holds the parameters for submitting a task for execution.
 type ExecutionRequest struct {
 	Info  ExecutionInfo
 	Async bool
 }
 
+// ExecutionResponse holds the result of a task execution submission.
 type ExecutionResponse struct {
 	ExecutionID string
 }
 
+// Validate returns an error if the ExecutionRequest is missing required fields.
 func (r *ExecutionRequest) Validate() error {
 	if r == nil {
 		return fmt.Errorf("request is nil")
@@ -104,6 +107,7 @@ func (r *ExecutionRequest) Validate() error {
 	return nil
 }
 
+// IsValid reports whether the ExecutionResponse contains a non-empty execution ID.
 func (r *ExecutionResponse) IsValid() bool {
 	if r == nil {
 		return false
@@ -116,12 +120,15 @@ func (r *ExecutionResponse) IsValid() bool {
 	return true
 }
 
+// TaskStatusUpdate carries the fields needed to update a task's status.
 type TaskStatusUpdate struct {
 	ID      uuid.UUID
 	Status  taskcommon.TaskStatus
 	Message string
 }
 
+// TaskStatusUpdater is implemented by any store that can persist task status changes.
 type TaskStatusUpdater interface {
+	// UpdateTaskStatus persists the status change described by arg.
 	UpdateTaskStatus(ctx context.Context, arg *TaskStatusUpdate) error
 }

--- a/rla/pkg/common/devicetypes/component.go
+++ b/rla/pkg/common/devicetypes/component.go
@@ -87,6 +87,8 @@ func ComponentTypeToString(ct ComponentType) string {
 	return componentTypeStrings[ct]
 }
 
+// IsValidComponentTypeString reports whether str maps to a known, non-Unknown
+// ComponentType.
 func IsValidComponentTypeString(str string) bool {
 	return ComponentTypeFromString(str) != ComponentTypeUnknown
 }
@@ -97,12 +99,44 @@ func (ct ComponentType) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON parses a ComponentType from its string name (e.g. "compute").
+// Returns an error only if the string is unrecognized (i.e. not a valid
+// component type name and not the canonical "Unknown" string), so that
+// round-trip serialization of ComponentTypeUnknown is preserved.
 func (ct *ComponentType) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
 		return fmt.Errorf("component_type must be a string: %w", err)
 	}
-	*ct = ComponentTypeFromString(s)
+
+	result := ComponentTypeFromString(s)
+	if result == ComponentTypeUnknown &&
+		!strings.EqualFold(s, componentTypeStrings[ComponentTypeUnknown]) {
+		return fmt.Errorf("unknown component type: %q", s)
+	}
+
+	*ct = result
+	return nil
+}
+
+// MarshalText serializes ComponentType as its string name for use as a JSON
+// map key (e.g. map[ComponentType]... → {"Compute": ...}).
+func (ct ComponentType) MarshalText() ([]byte, error) {
+	return []byte(ComponentTypeToString(ct)), nil
+}
+
+// UnmarshalText parses a ComponentType from its string name when used as a
+// JSON map key. Returns an error only if the string is unrecognized (i.e. not
+// a valid component type name and not the canonical "Unknown" string), so that
+// round-trip serialization of ComponentTypeUnknown is preserved.
+func (ct *ComponentType) UnmarshalText(data []byte) error {
+	s := string(data)
+	result := ComponentTypeFromString(s)
+	if result == ComponentTypeUnknown &&
+		!strings.EqualFold(s, componentTypeStrings[ComponentTypeUnknown]) {
+		return fmt.Errorf("unknown component type: %q", s)
+	}
+
+	*ct = result
 	return nil
 }
 


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
- add task_attributes in task table to keep track of component types which are needed for conflict detection. NOTE: we intentionally ignore the backward compatibility since there is no production deployment for the service yet.
- create the built-in conflict rules for task conflict detection.
- when a task is completed, promoter is triggered to promotes non-conflict tasks in FIFO ordering.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [ ] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [x] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
