### PR TITLE
fix: Permit NVLink deviceType on GPU capabilities for instance type

### DIFF
--- a/api/pkg/api/handler/instancetype.go
+++ b/api/pkg/api/handler/instancetype.go
@@ -324,16 +324,24 @@ func (cith CreateInstanceTypeHandler) Handle(c echo.Context) error {
 		// Validate device type for network capabilities
 		var deviceType *cwssaws.MachineCapabilityDeviceType
 		if machineCap.DeviceType != nil {
-			if machineCap.Type == cdbm.MachineCapabilityTypeNetwork {
+			switch machineCap.Type {
+			case cdbm.MachineCapabilityTypeNetwork:
 				// For Network Capability, we only support DPU
 				if *machineCap.DeviceType != cdbm.MachineCapabilityDeviceTypeDPU {
 					logger.Error().Str("Device Type", *machineCap.DeviceType).Msg("unsupported Device Type specified for Network Capability")
 					return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "Unsupported Device Type specified for Network Capability "+*machineCap.DeviceType, nil)
 				}
 				deviceType = cwssaws.MachineCapabilityDeviceType_MACHINE_CAPABILITY_DEVICE_TYPE_DPU.Enum()
-			} else {
+			case cdbm.MachineCapabilityTypeGPU:
+				// For GPU Capability, we only support NVLink
+				if *machineCap.DeviceType != cdbm.MachineCapabilityDeviceTypeNVLink {
+					logger.Error().Str("Device Type", *machineCap.DeviceType).Msg("unsupported Device Type specified for GPU Capability")
+					return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "Unsupported Device Type specified for GPU Capability "+*machineCap.DeviceType, nil)
+				}
+				deviceType = cwssaws.MachineCapabilityDeviceType_MACHINE_CAPABILITY_DEVICE_TYPE_NVLINK.Enum()
+			default:
 				logger.Error().Str("Capability Type", machineCap.Type).Str("Device Type", *machineCap.DeviceType).Msg("unsupported Device Type specified for Capability Type")
-				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("Unsupported Device Type: %s specified for Capability type %s", *machineCap.DeviceType, machineCap.Type), nil)
+				return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, fmt.Sprintf("Unsupported Device Type: %s specified for Capability type %s", *machineCap.DeviceType, machineCap.Type), nil)
 			}
 		}
 

--- a/api/pkg/api/handler/instancetype_test.go
+++ b/api/pkg/api/handler/instancetype_test.go
@@ -160,6 +160,64 @@ func TestCreateInstanceTypeHandler_Handle(t *testing.T) {
 		},
 	}
 
+	itcrValidGPUNVLink := &model.APIInstanceTypeCreateRequest{
+		Name:        "gpu-nvlink.large",
+		Description: cdb.GetStrPtr("Instance type with GPU NVLink capability"),
+		SiteID:      st.ID.String(),
+		MachineCapabilities: []model.APIMachineCapability{
+			{
+				Type:       cdbm.MachineCapabilityTypeGPU,
+				Name:       "NVIDIA GB200",
+				Capacity:   cdb.GetStrPtr("189471 MiB"),
+				Frequency:  cdb.GetStrPtr("2062 MHz"),
+				DeviceType: cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink),
+				Count:      cdb.GetIntPtr(4),
+			},
+		},
+	}
+
+	itcrInvalidGPUDeviceType := &model.APIInstanceTypeCreateRequest{
+		Name:        "gpu-bad-device.large",
+		Description: cdb.GetStrPtr("Instance type with unsupported GPU device type"),
+		SiteID:      st.ID.String(),
+		MachineCapabilities: []model.APIMachineCapability{
+			{
+				Type:       cdbm.MachineCapabilityTypeGPU,
+				Name:       "NVIDIA GB200",
+				DeviceType: cdb.GetStrPtr("DPU"),
+				Count:      cdb.GetIntPtr(4),
+			},
+		},
+	}
+
+	itcrInvalidNetworkDeviceType := &model.APIInstanceTypeCreateRequest{
+		Name:        "network-bad-device.large",
+		Description: cdb.GetStrPtr("Instance type with unsupported Network device type"),
+		SiteID:      st.ID.String(),
+		MachineCapabilities: []model.APIMachineCapability{
+			{
+				Type:       cdbm.MachineCapabilityTypeNetwork,
+				Name:       "MT43244 BlueField-3 integrated ConnectX-7 network controller",
+				DeviceType: cdb.GetStrPtr("NVLink"),
+				Count:      cdb.GetIntPtr(2),
+			},
+		},
+	}
+
+	itcrInvalidCPUDeviceType := &model.APIInstanceTypeCreateRequest{
+		Name:        "cpu-with-device-type.large",
+		Description: cdb.GetStrPtr("Instance type with device type on unsupported capability"),
+		SiteID:      st.ID.String(),
+		MachineCapabilities: []model.APIMachineCapability{
+			{
+				Type:       cdbm.MachineCapabilityTypeCPU,
+				Name:       "Intel Xeon Gold 6354",
+				DeviceType: cdb.GetStrPtr("DPU"),
+				Count:      cdb.GetIntPtr(2),
+			},
+		},
+	}
+
 	itcrValidWithoutMachineCapabilities := &model.APIInstanceTypeCreateRequest{
 		Name:        "x2.large.missing.mc",
 		Description: cdb.GetStrPtr("Test Description"),
@@ -425,6 +483,67 @@ func TestCreateInstanceTypeHandler_Handle(t *testing.T) {
 			},
 			wantErr:  false,
 			respCode: http.StatusBadRequest,
+		},
+		{
+			name: "test create Instance Type API endpoint with valid GPU NVLink device type",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        &tmocks.Client{},
+				scp:       scp,
+				cfg:       cfg,
+			},
+			args: args{
+				reqData: itcrValidGPUNVLink,
+			},
+			wantErr:                     false,
+			respCode:                    http.StatusCreated,
+			expectedResourcesCount:      2,
+			expectedMachineCapabilities: 1,
+		},
+		{
+			name: "test create Instance Type API endpoint with unsupported GPU device type",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        &tmocks.Client{},
+				scp:       scp,
+				cfg:       cfg,
+			},
+			args: args{
+				reqData: itcrInvalidGPUDeviceType,
+			},
+			wantErr:  false,
+			respCode: http.StatusBadRequest,
+			errMsg:   "Unsupported Device Type specified for GPU Capability",
+		},
+		{
+			name: "test create Instance Type API endpoint with unsupported Network device type",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        &tmocks.Client{},
+				scp:       scp,
+				cfg:       cfg,
+			},
+			args: args{
+				reqData: itcrInvalidNetworkDeviceType,
+			},
+			wantErr:  false,
+			respCode: http.StatusBadRequest,
+			errMsg:   "Unsupported Device Type specified for Network Capability",
+		},
+		{
+			name: "test create Instance Type API endpoint with device type on unsupported capability type",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        &tmocks.Client{},
+				scp:       scp,
+				cfg:       cfg,
+			},
+			args: args{
+				reqData: itcrInvalidCPUDeviceType,
+			},
+			wantErr:  false,
+			respCode: http.StatusBadRequest,
+			errMsg:   "Unsupported Device Type: DPU specified for Capability type CPU",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION


## Description
Previously, if a user tried to create an instance type with a GPU capability that had the deviceType set as NVLink, it would fail with the error `Unsupported Device Type: NVLink specified for Capability type GPU`. Given that an instance type with NVLink specified as the deviceType is a requirement for manually specifying NVLink interfaces in instance creation, this is problematic
(See this portion of api/pkg/api/handler/instance.go -- lines 1073-1080, 1092-1095 to understand how that requirement is enforced)
```
	// Fetch GPU Capabilities from Instance Type or Machine
	if instanceTypeID != nil {
		nvlCaps, nvlCapCount, err = mcDAO.GetAll(ctx, nil, nil, []uuid.UUID{*instanceTypeID}, cdb.GetStrPtr(cdbm.MachineCapabilityTypeGPU), nil, nil, nil, nil, nil, cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink), nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
		if err != nil {
			logger.Error().Err(err).Msg("error retrieving GPU Machine Capabilities from DB for Instance Type")
			return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve GPU Capabilities for Instance Type, DB error", nil)
		}
	}
....
if len(apiRequest.NVLinkInterfaces) > 0 {
		if nvlCapCount == 0 {
			return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "NVLink Interfaces cannot be specified if Instance Type doesn't have NVLink GPU Capability", nil)
		}

```

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [X] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [X] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
