### PR TITLE
fix: Enable NVLink deviceType specification in Instance Type update

### DIFF
--- a/api/pkg/api/handler/instancetype.go
+++ b/api/pkg/api/handler/instancetype.go
@@ -1352,19 +1352,28 @@ func (uith UpdateInstanceTypeHandler) Handle(c echo.Context) error {
 		// Update device type for network capabilities if provided
 		// Since we are validating the device type in the API model,
 		// we can safely set the device type to DPU for network capabilities
-		// as currently we only support DPU device type for network capabilities
+		// as currently we only support DPU device type for network capabilities.
+		// Similarly, for GPU capabilities, we only support NVLink device type.
 		var deviceType *cwssaws.MachineCapabilityDeviceType
 		if machineCap.DeviceType != nil {
-			if machineCap.Type == cdbm.MachineCapabilityTypeNetwork {
+			switch machineCap.Type {
+			case cdbm.MachineCapabilityTypeNetwork:
 				// For Network Capability, we only support DPU
 				if *machineCap.DeviceType != cdbm.MachineCapabilityDeviceTypeDPU {
 					logger.Error().Str("Device Type", *machineCap.DeviceType).Msg("unsupported Device Type specified for Network Capability")
-					return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Unsupported Device Type specified for Network Capability "+*machineCap.DeviceType, nil)
+					return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "Unsupported Device Type specified for Network Capability "+*machineCap.DeviceType, nil)
 				}
 				deviceType = cwssaws.MachineCapabilityDeviceType_MACHINE_CAPABILITY_DEVICE_TYPE_DPU.Enum()
-			} else {
+			case cdbm.MachineCapabilityTypeGPU:
+				// For GPU Capability, we only support NVLink
+				if *machineCap.DeviceType != cdbm.MachineCapabilityDeviceTypeNVLink {
+					logger.Error().Str("Device Type", *machineCap.DeviceType).Msg("unsupported Device Type specified for GPU Capability")
+					return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "Unsupported Device Type specified for GPU Capability "+*machineCap.DeviceType, nil)
+				}
+				deviceType = cwssaws.MachineCapabilityDeviceType_MACHINE_CAPABILITY_DEVICE_TYPE_NVLINK.Enum()
+			default:
 				logger.Error().Str("Capability Type", machineCap.Type).Str("Device Type", *machineCap.DeviceType).Msg("unsupported Device Type specified for Capability Type")
-				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("Unsupported Device Type: %s specified for Capability type %s", *machineCap.DeviceType, machineCap.Type), nil)
+				return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, fmt.Sprintf("Unsupported Device Type: %s specified for Capability type %s", *machineCap.DeviceType, machineCap.Type), nil)
 			}
 		}
 

--- a/api/pkg/api/handler/instancetype_test.go
+++ b/api/pkg/api/handler/instancetype_test.go
@@ -198,7 +198,7 @@ func TestCreateInstanceTypeHandler_Handle(t *testing.T) {
 			{
 				Type:       cdbm.MachineCapabilityTypeNetwork,
 				Name:       "MT43244 BlueField-3 integrated ConnectX-7 network controller",
-				DeviceType: cdb.GetStrPtr("NVLink"),
+				DeviceType: cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink),
 				Count:      cdb.GetIntPtr(2),
 			},
 		},
@@ -212,7 +212,7 @@ func TestCreateInstanceTypeHandler_Handle(t *testing.T) {
 			{
 				Type:       cdbm.MachineCapabilityTypeCPU,
 				Name:       "Intel Xeon Gold 6354",
-				DeviceType: cdb.GetStrPtr("DPU"),
+				DeviceType: cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeDPU),
 				Count:      cdb.GetIntPtr(2),
 			},
 		},
@@ -1817,6 +1817,7 @@ func TestUpdateInstanceTypeHandler_Handle(t *testing.T) {
 		fields             fields
 		args               args
 		wantRespCode       int
+		errMsg             string
 		verifyChildSpanner bool
 	}{
 		{
@@ -2088,8 +2089,174 @@ func TestUpdateInstanceTypeHandler_Handle(t *testing.T) {
 						{
 							Type:       "Network",
 							Name:       "MT43244 BlueField-3 integrated ConnectX-7 network controller",
-							DeviceType: cdb.GetStrPtr("DPU"),
+							DeviceType: cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeDPU),
 							Count:      cdb.GetIntPtr(2),
+						},
+					},
+				},
+			},
+			wantRespCode: http.StatusOK,
+		},
+		{
+			name: "test Instance Type update success with GPU NVLink device type",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        &tmocks.Client{},
+				scp:       scp,
+				cfg:       cfg,
+			},
+			args: args{
+				user:           ipu,
+				org:            org,
+				instanceTypeID: it2.ID,
+				reqData: &model.APIInstanceTypeUpdateRequest{
+					MachineCapabilities: []model.APIMachineCapability{
+						{
+							Type:       cdbm.MachineCapabilityTypeGPU,
+							Name:       "NVIDIA GB200",
+							Capacity:   cdb.GetStrPtr("189471 MiB"),
+							Frequency:  cdb.GetStrPtr("2062 MHz"),
+							DeviceType: cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink),
+							Count:      cdb.GetIntPtr(4),
+						},
+					},
+				},
+			},
+			wantRespCode: http.StatusOK,
+		},
+		{
+			name: "test Instance Type update fail with unsupported GPU device type DPU",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        &tmocks.Client{},
+				scp:       scp,
+				cfg:       cfg,
+			},
+			args: args{
+				user:           ipu,
+				org:            org,
+				instanceTypeID: it2.ID,
+				reqData: &model.APIInstanceTypeUpdateRequest{
+					MachineCapabilities: []model.APIMachineCapability{
+						{
+							Type:       cdbm.MachineCapabilityTypeGPU,
+							Name:       "NVIDIA GB200",
+							DeviceType: cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeDPU),
+							Count:      cdb.GetIntPtr(4),
+						},
+					},
+				},
+			},
+			wantRespCode: http.StatusBadRequest,
+			errMsg:       "Unsupported Device Type specified for GPU Capability",
+		},
+		{
+			name: "test Instance Type update fail with NVLink device type on Network capability",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        &tmocks.Client{},
+				scp:       scp,
+				cfg:       cfg,
+			},
+			args: args{
+				user:           ipu,
+				org:            org,
+				instanceTypeID: it2.ID,
+				reqData: &model.APIInstanceTypeUpdateRequest{
+					MachineCapabilities: []model.APIMachineCapability{
+						{
+							Type:       cdbm.MachineCapabilityTypeNetwork,
+							Name:       "MT43244 BlueField-3 integrated ConnectX-7 network controller",
+							DeviceType: cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink),
+							Count:      cdb.GetIntPtr(2),
+						},
+					},
+				},
+			},
+			wantRespCode: http.StatusBadRequest,
+			errMsg:       "Unsupported Device Type specified for Network Capability",
+		},
+		{
+			name: "test Instance Type update fail with device type on CPU capability",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        &tmocks.Client{},
+				scp:       scp,
+				cfg:       cfg,
+			},
+			args: args{
+				user:           ipu,
+				org:            org,
+				instanceTypeID: it2.ID,
+				reqData: &model.APIInstanceTypeUpdateRequest{
+					MachineCapabilities: []model.APIMachineCapability{
+						{
+							Type:       cdbm.MachineCapabilityTypeCPU,
+							Name:       "Intel Xeon Gold 6354",
+							DeviceType: cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeDPU),
+							Count:      cdb.GetIntPtr(2),
+						},
+					},
+				},
+			},
+			wantRespCode: http.StatusBadRequest,
+			errMsg:       "Unsupported Device Type: DPU specified for Capability type CPU",
+		},
+		{
+			name: "test Instance Type update success with mixed capabilities including valid device types",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        &tmocks.Client{},
+				scp:       scp,
+				cfg:       cfg,
+			},
+			args: args{
+				user:           ipu,
+				org:            org,
+				instanceTypeID: it2.ID,
+				reqData: &model.APIInstanceTypeUpdateRequest{
+					MachineCapabilities: []model.APIMachineCapability{
+						{
+							Type:       cdbm.MachineCapabilityTypeNetwork,
+							Name:       "MT43244 BlueField-3 integrated ConnectX-7 network controller",
+							DeviceType: cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeDPU),
+							Count:      cdb.GetIntPtr(2),
+						},
+						{
+							Type:       cdbm.MachineCapabilityTypeGPU,
+							Name:       "NVIDIA GB200",
+							Capacity:   cdb.GetStrPtr("189471 MiB"),
+							DeviceType: cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink),
+							Count:      cdb.GetIntPtr(4),
+						},
+						{
+							Type:  cdbm.MachineCapabilityTypeCPU,
+							Name:  "Intel Xeon Gold 6354",
+							Count: cdb.GetIntPtr(2),
+						},
+					},
+				},
+			},
+			wantRespCode: http.StatusOK,
+		},
+		{
+			name: "test Instance Type update success with Network capability without device type",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        &tmocks.Client{},
+				scp:       scp,
+				cfg:       cfg,
+			},
+			args: args{
+				user:           ipu,
+				org:            org,
+				instanceTypeID: it2.ID,
+				reqData: &model.APIInstanceTypeUpdateRequest{
+					MachineCapabilities: []model.APIMachineCapability{
+						{
+							Type:  cdbm.MachineCapabilityTypeNetwork,
+							Name:  "MT43244 BlueField-3 integrated ConnectX-7 network controller",
+							Count: cdb.GetIntPtr(2),
 						},
 					},
 				},
@@ -2128,6 +2295,10 @@ func TestUpdateInstanceTypeHandler_Handle(t *testing.T) {
 			assert.NoError(t, err)
 
 			require.Equal(t, tt.wantRespCode, rec.Code)
+
+			if tt.errMsg != "" {
+				assert.Contains(t, rec.Body.String(), tt.errMsg)
+			}
 
 			if rec.Code != http.StatusOK {
 				return


### PR DESCRIPTION
## Description
Follow-on to PR https://github.com/NVIDIA/ncx-infra-controller-rest/pull/280 to address the same issue in instance type update.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [x] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
