### PR TITLE
feat: Add mTLS support to RLA CLI and refactor cert packages

### DIFF
--- a/rla/cmd/component.go
+++ b/rla/cmd/component.go
@@ -25,6 +25,7 @@ import (
 	"github.com/NVIDIA/ncx-infra-controller-rest/rla/pkg/types"
 )
 
+// componentCmd is the parent command for component operation subcommands.
 var componentCmd = &cobra.Command{
 	Use:   "component",
 	Short: "Component operations",

--- a/rla/cmd/component_add.go
+++ b/rla/cmd/component_add.go
@@ -46,10 +46,10 @@ var (
 	addBmcMAC          string
 	addBmcIP           string
 	addBmcType         string
-	addHost            string
-	addPort            int
 )
 
+// newAddCmd returns a configured cobra.Command for adding a new component
+// to an existing rack in the inventory.
 func newAddCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add",
@@ -102,8 +102,6 @@ Examples:
 	cmd.Flags().StringVar(&addBmcMAC, "bmc-mac", "", "BMC MAC address")
 	cmd.Flags().StringVar(&addBmcIP, "bmc-ip", "", "BMC IP address")
 	cmd.Flags().StringVar(&addBmcType, "bmc-type", "host", "BMC type: host, dpu")
-	cmd.Flags().StringVar(&addHost, "host", "localhost", "RLA server host")
-	cmd.Flags().IntVar(&addPort, "port", 50051, "RLA server port")
 
 	_ = cmd.MarkFlagRequired("rack-id")
 	_ = cmd.MarkFlagRequired("name")
@@ -118,6 +116,8 @@ func init() {
 	componentCmd.AddCommand(newAddCmd())
 }
 
+// doAddComponent builds a types.Component from the CLI flags and calls
+// AddComponent via the gRPC client, printing the created component as JSON.
 func doAddComponent() {
 	rackID, err := uuid.Parse(addRackID)
 	if err != nil {
@@ -168,10 +168,7 @@ func doAddComponent() {
 		comp.BMCs = []types.BMC{bmc}
 	}
 
-	c, err := client.New(client.Config{
-		Host: addHost,
-		Port: addPort,
-	})
+	c, err := client.New(newGlobalClientConfig())
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to create client")
 	}

--- a/rla/cmd/component_delete.go
+++ b/rla/cmd/component_delete.go
@@ -30,10 +30,10 @@ import (
 
 var (
 	deleteComponentID string
-	deleteHost        string
-	deletePort        int
 )
 
+// newDeleteCmd returns a configured cobra.Command for soft-deleting a component
+// from the inventory by UUID.
 func newDeleteCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
@@ -52,8 +52,6 @@ Examples:
 	}
 
 	cmd.Flags().StringVar(&deleteComponentID, "id", "", "Component UUID (required)")
-	cmd.Flags().StringVar(&deleteHost, "host", "localhost", "RLA server host")
-	cmd.Flags().IntVar(&deletePort, "port", 50051, "RLA server port")
 
 	_ = cmd.MarkFlagRequired("id")
 
@@ -64,16 +62,15 @@ func init() {
 	componentCmd.AddCommand(newDeleteCmd())
 }
 
+// doDeleteComponent parses the component UUID from the flag and calls
+// DeleteComponent via the gRPC client.
 func doDeleteComponent() {
 	compID, err := uuid.Parse(deleteComponentID)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Invalid component UUID")
 	}
 
-	c, err := client.New(client.Config{
-		Host: deleteHost,
-		Port: deletePort,
-	})
+	c, err := client.New(newGlobalClientConfig())
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to create client")
 	}

--- a/rla/cmd/component_diff.go
+++ b/rla/cmd/component_diff.go
@@ -75,8 +75,6 @@ Examples:
 	diffComponentIDs  string
 	diffComponentType string
 	diffOutput        string
-	diffHost          string
-	diffPort          int
 )
 
 func init() {
@@ -87,10 +85,11 @@ func init() {
 	diffCmd.Flags().StringVar(&diffComponentIDs, "component-ids", "", "Comma-separated list of component IDs")
 	diffCmd.Flags().StringVarP(&diffComponentType, "type", "t", "", "Component type (required): compute")
 	diffCmd.Flags().StringVarP(&diffOutput, "output", "o", "json", "Output format: json, table")
-	diffCmd.Flags().StringVar(&diffHost, "host", "localhost", "RLA server host")
-	diffCmd.Flags().IntVar(&diffPort, "port", 50051, "RLA server port")
 }
 
+// doDiffComponents validates the CLI inputs, calls the appropriate
+// ValidateComponents client method, and prints the result in the requested
+// output format.
 func doDiffComponents() {
 	// Validate input - exactly one of rack-ids, rack-names, or component-ids must be provided
 	optionCount := 0
@@ -123,10 +122,7 @@ func doDiffComponents() {
 	}
 
 	// Create client
-	c, err := client.New(client.Config{
-		Host: diffHost,
-		Port: diffPort,
-	})
+	c, err := client.New(newGlobalClientConfig())
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to create client")
 	}
@@ -176,6 +172,7 @@ func doDiffComponents() {
 	}
 }
 
+// outputDiffJSON prints the ValidateComponentsResult as indented JSON to stdout.
 func outputDiffJSON(result *client.ValidateComponentsResult) {
 	output := struct {
 		TotalDiffs          int                    `json:"total_diffs"`
@@ -200,6 +197,8 @@ func outputDiffJSON(result *client.ValidateComponentsResult) {
 	fmt.Println(string(data))
 }
 
+// outputDiffTable prints the ValidateComponentsResult as a human-readable
+// table with a summary header and per-diff rows to stdout.
 func outputDiffTable(result *client.ValidateComponentsResult) {
 	// Summary
 	fmt.Println("Summary:")

--- a/rla/cmd/component_expected.go
+++ b/rla/cmd/component_expected.go
@@ -76,8 +76,6 @@ Examples:
 	expectedComponentIDs  string
 	expectedComponentType string
 	expectedOutput        string
-	expectedHost          string
-	expectedPort          int
 )
 
 func init() {
@@ -88,10 +86,11 @@ func init() {
 	expectedCmd.Flags().StringVar(&expectedComponentIDs, "component-ids", "", "Comma-separated list of component IDs")
 	expectedCmd.Flags().StringVarP(&expectedComponentType, "type", "t", "", "Component type: compute, nvlswitch, powershelf, torswitch, ums, cdu")
 	expectedCmd.Flags().StringVarP(&expectedOutput, "output", "o", "json", "Output format: json, table")
-	expectedCmd.Flags().StringVar(&expectedHost, "host", "localhost", "RLA server host")
-	expectedCmd.Flags().IntVar(&expectedPort, "port", 50051, "RLA server port")
 }
 
+// doGetExpectedComponents validates the CLI inputs, calls the appropriate
+// GetExpectedComponents client method, and prints the result in the requested
+// output format.
 func doGetExpectedComponents() {
 	// Validate input - exactly one of rack-ids, rack-names, or component-ids must be provided
 	optionCount := 0
@@ -121,10 +120,7 @@ func doGetExpectedComponents() {
 	componentType := parseComponentTypeToTypes(expectedComponentType)
 
 	// Create client
-	c, err := client.New(client.Config{
-		Host: expectedHost,
-		Port: expectedPort,
-	})
+	c, err := client.New(newGlobalClientConfig())
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to create client")
 	}
@@ -174,6 +170,7 @@ func doGetExpectedComponents() {
 	}
 }
 
+// outputExpectedJSON prints the GetExpectedComponentsResult as indented JSON to stdout.
 func outputExpectedJSON(result *client.GetExpectedComponentsResult) {
 	output := struct {
 		Total      int         `json:"total"`
@@ -190,6 +187,8 @@ func outputExpectedJSON(result *client.GetExpectedComponentsResult) {
 	fmt.Println(string(data))
 }
 
+// outputExpectedTable prints the GetExpectedComponentsResult as a human-readable
+// table to stdout.
 func outputExpectedTable(result *client.GetExpectedComponentsResult) {
 	fmt.Printf("Total: %d components\n", result.Total)
 	fmt.Println(strings.Repeat("-", 100))

--- a/rla/cmd/component_update.go
+++ b/rla/cmd/component_update.go
@@ -37,10 +37,10 @@ var (
 	updateHostID          int
 	updateDescription     string
 	updateRackID          string
-	updateHost            string
-	updatePort            int
 )
 
+// newUpdateCmd returns a configured cobra.Command for patching a component's
+// fields (firmware version, position, description, or rack assignment).
 func newUpdateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
@@ -83,8 +83,6 @@ Examples:
 	cmd.Flags().IntVar(&updateHostID, "host-id", 0, "New host ID")
 	cmd.Flags().StringVar(&updateDescription, "description", "", "New description (JSON string)")
 	cmd.Flags().StringVar(&updateRackID, "rack-id", "", "Re-assign to a different rack (UUID)")
-	cmd.Flags().StringVar(&updateHost, "host", "localhost", "RLA server host")
-	cmd.Flags().IntVar(&updatePort, "port", 50051, "RLA server port")
 
 	_ = cmd.MarkFlagRequired("id")
 
@@ -95,6 +93,8 @@ func init() {
 	componentCmd.AddCommand(newUpdateCmd())
 }
 
+// doUpdateComponent builds a PatchComponentOpts from the changed flags and
+// calls PatchComponent via the gRPC client, printing the updated component as JSON.
 func doUpdateComponent(cmd *cobra.Command) {
 	// Parse component ID
 	compID, err := uuid.Parse(updateComponentID)
@@ -148,10 +148,7 @@ func doUpdateComponent(cmd *cobra.Command) {
 	}
 
 	// Create client
-	c, err := client.New(client.Config{
-		Host: updateHost,
-		Port: updatePort,
-	})
+	c, err := client.New(newGlobalClientConfig())
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to create client")
 	}

--- a/rla/cmd/db.go
+++ b/rla/cmd/db.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// dbCmd is the parent command for database management subcommands.
 var dbCmd = &cobra.Command{
 	Use:   "db",
 	Short: "Database operations",

--- a/rla/cmd/db_migrate.go
+++ b/rla/cmd/db_migrate.go
@@ -31,7 +31,7 @@ import (
 var (
 	rollBack string
 
-	// migrateCmd represents the migrate command
+	// migrateCmd is the subcommand that runs database migrations.
 	migrateCmd = &cobra.Command{
 		Use:   "migrate",
 		Short: "Run the db migration",
@@ -48,6 +48,9 @@ func init() {
 	migrateCmd.Flags().StringVarP(&rollBack, "rollback", "r", "", "Roll back the schema to the way it was at the specified time.  This is the application time, not from the ID.  Format 2006-01-02T15:04:05")
 }
 
+// doMigration connects to the database and runs pending migrations. If the
+// --rollback flag is set, it rolls back the schema to the specified time
+// instead of migrating forward.
 func doMigration() {
 	dbConf, err := cdb.ConfigFromEnv()
 	if err != nil {

--- a/rla/cmd/firmware.go
+++ b/rla/cmd/firmware.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// firmwareCmd is the parent command for firmware management subcommands.
 var firmwareCmd = &cobra.Command{
 	Use:   "firmware",
 	Short: "Firmware operations",

--- a/rla/cmd/firmware_update.go
+++ b/rla/cmd/firmware_update.go
@@ -53,6 +53,4 @@ func init() {
 	firmwareUpdateCmd.Flags().String("component-ids", "", "Comma-separated list of component IDs")
 	firmwareUpdateCmd.Flags().StringP("type", "t", "", "Component type: compute, nvlswitch, powershelf")
 	firmwareUpdateCmd.Flags().StringP("version", "v", "", "Target firmware version")
-	firmwareUpdateCmd.Flags().String("host", "localhost", "RLA server host")
-	firmwareUpdateCmd.Flags().Int("port", 50051, "RLA server port")
 }

--- a/rla/cmd/firmware_upgrade.go
+++ b/rla/cmd/firmware_upgrade.go
@@ -77,8 +77,6 @@ Examples:
 	firmwareUpgradeComponentType string
 	firmwareUpgradeStartTime     string
 	firmwareUpgradeEndTime       string
-	firmwareUpgradeHost          string
-	firmwareUpgradePort          int
 )
 
 func init() {
@@ -90,8 +88,6 @@ func init() {
 	firmwareUpgradeCmd.Flags().StringVarP(&firmwareUpgradeComponentType, "type", "t", "", "Component type: compute, nvlswitch, powershelf (required for rack-ids/rack-names)")
 	firmwareUpgradeCmd.Flags().StringVarP(&firmwareUpgradeStartTime, "start", "s", "", "Start time (default: now)")
 	firmwareUpgradeCmd.Flags().StringVarP(&firmwareUpgradeEndTime, "end", "e", "", "End time (default: start + 24h)")
-	firmwareUpgradeCmd.Flags().StringVar(&firmwareUpgradeHost, "host", "localhost", "RLA service host")
-	firmwareUpgradeCmd.Flags().IntVarP(&firmwareUpgradePort, "port", "p", defaultServicePort, "RLA service port")
 }
 
 // parseTimeString parses time string in the following formats:
@@ -113,6 +109,9 @@ func parseTimeString(s string) (time.Time, error) {
 	return time.Time{}, fmt.Errorf("unable to parse time '%s': expected format 2025-01-02T03:04:05 or 2025-01-02T03:04:05+0000", s)
 }
 
+// doFirmwareUpgrade validates the CLI inputs, resolves the upgrade time window,
+// and calls the appropriate UpgradeFirmware client method based on whether the
+// caller specified rack IDs, rack names, or component IDs.
 func doFirmwareUpgrade() {
 	// Validate inputs - only one of the three options can be specified
 	hasRackIDs := firmwareUpgradeRackIDs != ""
@@ -175,10 +174,7 @@ func doFirmwareUpgrade() {
 	ctx := context.Background()
 
 	// Create RLA client
-	rlaClient, err := client.New(client.Config{
-		Host: firmwareUpgradeHost,
-		Port: firmwareUpgradePort,
-	})
+	rlaClient, err := client.New(newGlobalClientConfig())
 	if err != nil {
 		log.Fatal().Msgf("Failed to create RLA client: %v", err)
 	}

--- a/rla/cmd/firmware_version.go
+++ b/rla/cmd/firmware_version.go
@@ -53,6 +53,4 @@ func init() {
 	firmwareVersionCmd.Flags().String("component-ids", "", "Comma-separated list of component IDs")
 	firmwareVersionCmd.Flags().StringP("type", "t", "", "Component type: compute, nvlswitch, powershelf")
 	firmwareVersionCmd.Flags().StringP("output", "o", "json", "Output format: json, table")
-	firmwareVersionCmd.Flags().String("host", "localhost", "RLA server host")
-	firmwareVersionCmd.Flags().Int("port", 50051, "RLA server port")
 }

--- a/rla/cmd/ingest.go
+++ b/rla/cmd/ingest.go
@@ -56,8 +56,6 @@ Examples:
 	ingestRackIDs     string
 	ingestRackNames   string
 	ingestDescription string
-	ingestHost        string
-	ingestPort        int
 )
 
 func init() {
@@ -66,10 +64,10 @@ func init() {
 	ingestCmd.Flags().StringVar(&ingestRackIDs, "rack-ids", "", "Comma-separated list of rack UUIDs")
 	ingestCmd.Flags().StringVar(&ingestRackNames, "rack-names", "", "Comma-separated list of rack names")
 	ingestCmd.Flags().StringVar(&ingestDescription, "description", "", "Task description")
-	ingestCmd.Flags().StringVar(&ingestHost, "host", "localhost", "RLA service host")
-	ingestCmd.Flags().IntVarP(&ingestPort, "port", "p", defaultServicePort, "RLA service port")
 }
 
+// doIngest validates the CLI inputs and calls IngestRackByRackIDs or
+// IngestRackByRackNames via the gRPC client, logging the submitted task IDs.
 func doIngest() {
 	hasRackIDs := ingestRackIDs != ""
 	hasRackNames := ingestRackNames != ""
@@ -83,10 +81,7 @@ func doIngest() {
 
 	ctx := context.Background()
 
-	rlaClient, err := client.New(client.Config{
-		Host: ingestHost,
-		Port: ingestPort,
-	})
+	rlaClient, err := client.New(newGlobalClientConfig())
 	if err != nil {
 		log.Fatal().Msgf("Failed to create RLA client: %v", err)
 	}

--- a/rla/cmd/inventory.go
+++ b/rla/cmd/inventory.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// inventoryCmd is the parent command for rack inventory management subcommands.
 var inventoryCmd = &cobra.Command{
 	Use:   "inventory",
 	Short: "Inventory management",

--- a/rla/cmd/power.go
+++ b/rla/cmd/power.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// powerCmd is the parent command for power management subcommands.
 var powerCmd = &cobra.Command{
 	Use:   "power",
 	Short: "Power operations",

--- a/rla/cmd/power_control.go
+++ b/rla/cmd/power_control.go
@@ -84,8 +84,6 @@ Examples:
 	powerControlComponentIDs  string
 	powerControlComponentType string
 	powerControlOp            string
-	powerControlHost          string
-	powerControlPort          int
 )
 
 func init() {
@@ -96,12 +94,12 @@ func init() {
 	powerControlCmd.Flags().StringVar(&powerControlComponentIDs, "component-ids", "", "Comma-separated list of component IDs")
 	powerControlCmd.Flags().StringVarP(&powerControlComponentType, "type", "t", "", "Component type: compute, nvlswitch, powershelf (required for rack-ids/rack-names)")
 	powerControlCmd.Flags().StringVar(&powerControlOp, "op", "", "Power operation: on, off, force-off, reset, force-reset, ac-powercycle")
-	powerControlCmd.Flags().StringVar(&powerControlHost, "host", "localhost", "RLA service host")
-	powerControlCmd.Flags().IntVarP(&powerControlPort, "port", "p", defaultServicePort, "RLA service port")
 
 	powerControlCmd.MarkFlagRequired("op") //nolint
 }
 
+// parsePowerOpToTypes converts a power operation string (e.g. "on", "force-off",
+// "cold-reset") to types.PowerControlOp. Returns an empty string for unrecognised values.
 func parsePowerOpToTypes(op string) types.PowerControlOp {
 	switch strings.ToLower(op) {
 	// Power On
@@ -129,6 +127,9 @@ func parsePowerOpToTypes(op string) types.PowerControlOp {
 	}
 }
 
+// doPowerControl validates the CLI inputs and calls the appropriate
+// PowerControl client method based on whether the caller specified rack IDs,
+// rack names, or component IDs.
 func doPowerControl() {
 	// Validate inputs - only one of the options can be specified
 	hasRackIDs := powerControlRackIDs != ""
@@ -169,10 +170,7 @@ func doPowerControl() {
 	ctx := context.Background()
 
 	// Create RLA client
-	rlaClient, err := client.New(client.Config{
-		Host: powerControlHost,
-		Port: powerControlPort,
-	})
+	rlaClient, err := client.New(newGlobalClientConfig())
 	if err != nil {
 		log.Fatal().Msgf("Failed to create RLA client: %v", err)
 	}

--- a/rla/cmd/power_stats.go
+++ b/rla/cmd/power_stats.go
@@ -53,6 +53,4 @@ func init() {
 	powerStatsCmd.Flags().String("component-ids", "", "Comma-separated list of component IDs")
 	powerStatsCmd.Flags().StringP("type", "t", "", "Component type: compute, nvlswitch, powershelf")
 	powerStatsCmd.Flags().StringP("output", "o", "json", "Output format: json, table")
-	powerStatsCmd.Flags().String("host", "localhost", "RLA server host")
-	powerStatsCmd.Flags().Int("port", 50051, "RLA server port")
 }

--- a/rla/cmd/power_status.go
+++ b/rla/cmd/power_status.go
@@ -53,6 +53,4 @@ func init() {
 	powerStatusCmd.Flags().String("component-ids", "", "Comma-separated list of component IDs")
 	powerStatusCmd.Flags().StringP("type", "t", "", "Component type: compute, nvlswitch, powershelf")
 	powerStatusCmd.Flags().StringP("output", "o", "json", "Output format: json, table")
-	powerStatusCmd.Flags().String("host", "localhost", "RLA server host")
-	powerStatusCmd.Flags().Int("port", 50051, "RLA server port")
 }

--- a/rla/cmd/rack.go
+++ b/rla/cmd/rack.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// rackCmd is the parent command for rack inventory subcommands.
 var rackCmd = &cobra.Command{
 	Use:   "rack",
 	Short: "Rack operations",

--- a/rla/cmd/rack_create.go
+++ b/rla/cmd/rack_create.go
@@ -31,10 +31,10 @@ import (
 var (
 	rackCreateFile string
 	rackCreateJSON string
-	rackCreateHost string
-	rackCreatePort int
 )
 
+// newRackCreateCmd returns a configured cobra.Command for creating a new
+// expected rack from a JSON file or inline JSON string.
 func newRackCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -66,15 +66,6 @@ Examples:
 		&rackCreateJSON, "json", "j", "",
 		"Inline JSON string containing rack definition",
 	)
-	cmd.Flags().StringVar(
-		&rackCreateHost, "host", "localhost",
-		"RLA server host",
-	)
-	cmd.Flags().IntVar(
-		&rackCreatePort, "port", 50051,
-		"RLA server port",
-	)
-
 	cmd.MarkFlagsOneRequired("file", "json")
 	cmd.MarkFlagsMutuallyExclusive("file", "json")
 
@@ -85,6 +76,8 @@ func init() {
 	rackCmd.AddCommand(newRackCreateCmd())
 }
 
+// doCreateRack reads the rack JSON input, parses it, and calls CreateExpectedRack
+// via the gRPC client, printing the newly created rack's UUID on success.
 func doCreateRack() {
 	data, err := readRackJSONData(rackCreateFile, rackCreateJSON)
 	if err != nil {
@@ -96,10 +89,7 @@ func doCreateRack() {
 		log.Fatal().Err(err).Msg("Failed to parse rack JSON")
 	}
 
-	c, err := client.New(client.Config{
-		Host: rackCreateHost,
-		Port: rackCreatePort,
-	})
+	c, err := client.New(newGlobalClientConfig())
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to create client")
 	}

--- a/rla/cmd/rack_json.go
+++ b/rla/cmd/rack_json.go
@@ -48,6 +48,7 @@ type rackInput struct {
 	Components []rackComponentInput `json:"components"`
 }
 
+// rackComponentInput is the JSON input structure for a single component within a rack definition.
 type rackComponentInput struct {
 	Type            string `json:"type"`
 	FirmwareVersion string `json:"firmware_version"`
@@ -68,6 +69,7 @@ type rackComponentInput struct {
 	BMCs []rackBMCInput `json:"bmcs"`
 }
 
+// rackBMCInput is the JSON input structure for a BMC entry within a component definition.
 type rackBMCInput struct {
 	Type string `json:"type"`
 	MAC  string `json:"mac"`
@@ -130,6 +132,8 @@ func parseRackJSON(data []byte) (*types.Rack, error) {
 	return &rack, nil
 }
 
+// parseRackComponentInput converts a rackComponentInput to a types.Component,
+// validating the component type and BMC fields in the process.
 func parseRackComponentInput(
 	ci rackComponentInput,
 ) (types.Component, error) {
@@ -180,6 +184,8 @@ func parseRackComponentInput(
 	return comp, nil
 }
 
+// parseRackBMCInput converts a rackBMCInput to a types.BMC, validating
+// the MAC address and IP address fields if present.
 func parseRackBMCInput(bi rackBMCInput) (types.BMC, error) {
 	var bmc types.BMC
 
@@ -210,6 +216,9 @@ func parseRackBMCInput(bi rackBMCInput) (types.BMC, error) {
 	return bmc, nil
 }
 
+// parseBMCTypeToTypes converts a BMC type string (e.g. "host", "dpu") to
+// types.BMCType. An empty string is treated as "host". An unrecognised value
+// returns types.BMCTypeUnknown.
 func parseBMCTypeToTypes(s string) types.BMCType {
 	switch strings.ToLower(s) {
 	case "host", "":

--- a/rla/cmd/root.go
+++ b/rla/cmd/root.go
@@ -15,15 +15,35 @@
  * limitations under the License.
  */
 
-/*
-Copyright © 2025 NAME HERE <EMAIL ADDRESS>
-*/
+// Package cmd implements the rla CLI commands using Cobra. It provides
+// subcommands for rack, component, firmware, power, rule, and ingest
+// operations, as well as a serve subcommand that starts the gRPC server.
 package cmd
 
 import (
 	"os"
 
 	"github.com/spf13/cobra"
+
+	pkgcerts "github.com/NVIDIA/ncx-infra-controller-rest/rla/pkg/certs"
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/pkg/client"
+)
+
+// Flag names for the global persistent flags.
+const (
+	flagHost = "host"
+	flagPort = "port"
+)
+
+// Global persistent flags inherited by all subcommands. Host and port
+// configure the gRPC client target; cert flags configure mTLS for both client
+// commands and the serve listener.
+var (
+	globalHost    string
+	globalPort    int
+	globalCACert  string
+	globalTLSCert string
+	globalTLSKey  string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -43,13 +63,23 @@ func Execute() {
 }
 
 func init() {
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
+	rootCmd.PersistentFlags().StringVarP(&globalHost, flagHost, "H", "localhost", "RLA server host")
+	rootCmd.PersistentFlags().IntVarP(&globalPort, flagPort, "P", 50051, "RLA server port")
+	rootCmd.PersistentFlags().StringVar(&globalCACert, "ca-cert", "", "Path to CA certificate file")
+	rootCmd.PersistentFlags().StringVar(&globalTLSCert, "tls-cert", "", "Path to TLS certificate file")
+	rootCmd.PersistentFlags().StringVar(&globalTLSKey, "tls-key", "", "Path to TLS private key file")
+	rootCmd.MarkFlagsRequiredTogether("ca-cert", "tls-cert", "tls-key")
+}
 
-	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.rla.yaml)")
-
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	// rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+// newGlobalClientConfig builds a client.Config from the global persistent flags.
+func newGlobalClientConfig() client.Config {
+	return client.Config{
+		Host: globalHost,
+		Port: globalPort,
+		CertConfig: pkgcerts.Config{
+			CACert:  globalCACert,
+			TLSCert: globalTLSCert,
+			TLSKey:  globalTLSKey,
+		},
+	}
 }

--- a/rla/cmd/rule.go
+++ b/rla/cmd/rule.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// ruleCmd is the parent command for operation rule management subcommands.
 var ruleCmd = &cobra.Command{
 	Use:   "rule",
 	Short: "Operation rule management",

--- a/rla/cmd/rule_associate.go
+++ b/rla/cmd/rule_associate.go
@@ -41,8 +41,6 @@ Example:
 }
 
 var (
-	assocHost   string
-	assocPort   int
 	assocRackID string
 	assocRuleID string
 )
@@ -50,8 +48,6 @@ var (
 func init() {
 	ruleCmd.AddCommand(ruleAssociateCmd)
 
-	ruleAssociateCmd.Flags().StringVar(&assocHost, "host", "localhost", "RLA service host")
-	ruleAssociateCmd.Flags().IntVar(&assocPort, "port", 50051, "RLA service port")
 	ruleAssociateCmd.Flags().StringVar(&assocRackID, "rack-id", "", "Rack ID (required)")
 	ruleAssociateCmd.Flags().StringVar(&assocRuleID, "rule-id", "", "Rule ID (required)")
 
@@ -59,11 +55,10 @@ func init() {
 	ruleAssociateCmd.MarkFlagRequired("rule-id")
 }
 
+// runRuleAssociate is the RunE handler for ruleAssociateCmd. It parses the
+// rack and rule IDs from flags and calls AssociateRuleWithRack via the client.
 func runRuleAssociate(cmd *cobra.Command, args []string) error {
-	rlaClient, err := client.New(client.Config{
-		Host: assocHost,
-		Port: assocPort,
-	})
+	rlaClient, err := client.New(newGlobalClientConfig())
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)
 	}

--- a/rla/cmd/rule_create.go
+++ b/rla/cmd/rule_create.go
@@ -60,8 +60,6 @@ The --overwrite flag will replace existing rules with the same operation_type an
 }
 
 var (
-	createHost        string
-	createPort        int
 	createName        string
 	createDescription string
 	createOpType      string
@@ -75,10 +73,6 @@ var (
 
 func init() {
 	ruleCmd.AddCommand(ruleCreateCmd)
-
-	// Common flags
-	ruleCreateCmd.Flags().StringVar(&createHost, "host", "localhost", "RLA service host")
-	ruleCreateCmd.Flags().IntVar(&createPort, "port", 50051, "RLA service port")
 
 	// Single rule mode flags
 	ruleCreateCmd.Flags().StringVar(&createName, "name", "", "Rule name (required for single mode)")
@@ -101,6 +95,8 @@ func init() {
 	ruleCreateCmd.MarkFlagsMutuallyExclusive("is-default", "from-yaml")
 }
 
+// runRuleCreate is the RunE handler for ruleCreateCmd. It dispatches to
+// createRulesFromYAML (batch mode) or createSingleRule (single mode).
 func runRuleCreate(cmd *cobra.Command, args []string) error {
 	if createFromYAML != "" {
 		return createRulesFromYAML()
@@ -108,6 +104,8 @@ func runRuleCreate(cmd *cobra.Command, args []string) error {
 	return createSingleRule()
 }
 
+// createSingleRule creates one operation rule using the individual flag values
+// (--name, --operation-type, --operation, --rule-file).
 func createSingleRule() error {
 	// Validate required flags for single mode
 	if createName == "" {
@@ -146,10 +144,7 @@ func createSingleRule() error {
 		return fmt.Errorf("invalid operation type: %s (must be power_control or firmware_control)", createOpType)
 	}
 
-	rlaClient, err := client.New(client.Config{
-		Host: createHost,
-		Port: createPort,
-	})
+	rlaClient, err := client.New(newGlobalClientConfig())
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)
 	}
@@ -175,6 +170,8 @@ func createSingleRule() error {
 	return nil
 }
 
+// createRulesFromYAML loads rules from the YAML file specified by --from-yaml
+// and creates each rule via the gRPC client. Supports --dry-run and --overwrite.
 func createRulesFromYAML() error {
 	// Validate flags
 	if createOverwrite && createFromYAML == "" {
@@ -205,10 +202,7 @@ func createRulesFromYAML() error {
 	}
 
 	// Create client
-	rlaClient, err := client.New(client.Config{
-		Host: createHost,
-		Port: createPort,
-	})
+	rlaClient, err := client.New(newGlobalClientConfig())
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)
 	}
@@ -283,6 +277,8 @@ func createRulesFromYAML() error {
 	return nil
 }
 
+// showDryRunOutput prints a preview of the rules that would be created,
+// without making any API calls.
 func showDryRunOutput(rules map[taskcommon.TaskType]map[string]*operationrules.OperationRule) error {
 	fmt.Println("✅ Validation successful!")
 	fmt.Println()
@@ -317,6 +313,8 @@ func showDryRunOutput(rules map[taskcommon.TaskType]map[string]*operationrules.O
 	return nil
 }
 
+// findExistingRule searches the server's rule list for a rule matching the
+// given operation type and operation code. Returns nil if none is found.
 func findExistingRule(ctx context.Context, rlaClient *client.Client, opType taskcommon.TaskType, operation string) *types.OperationRule {
 	// List all rules and find matching one
 	rules, _, err := rlaClient.ListOperationRules(ctx, nil, nil, nil, nil)
@@ -334,6 +332,8 @@ func findExistingRule(ctx context.Context, rlaClient *client.Client, opType task
 	return nil
 }
 
+// taskTypeToOperationType converts a taskcommon.TaskType to the corresponding
+// types.OperationType used in the RLA API.
 func taskTypeToOperationType(taskType taskcommon.TaskType) types.OperationType {
 	switch taskType {
 	case taskcommon.TaskTypePowerControl:

--- a/rla/cmd/rule_delete.go
+++ b/rla/cmd/rule_delete.go
@@ -35,18 +35,12 @@ var ruleDeleteCmd = &cobra.Command{
 	RunE:  runRuleDelete,
 }
 
-var (
-	ruleDeleteHost string
-	ruleDeletePort int
-)
-
 func init() {
 	ruleCmd.AddCommand(ruleDeleteCmd)
-
-	ruleDeleteCmd.Flags().StringVar(&ruleDeleteHost, "host", "localhost", "RLA service host")
-	ruleDeleteCmd.Flags().IntVar(&ruleDeletePort, "port", 50051, "RLA service port")
 }
 
+// runRuleDelete is the RunE handler for ruleDeleteCmd. It parses the rule ID
+// from the positional argument and calls DeleteOperationRule via the client.
 func runRuleDelete(cmd *cobra.Command, args []string) error {
 	ruleIDStr := args[0]
 
@@ -55,10 +49,7 @@ func runRuleDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid rule ID: %w", err)
 	}
 
-	rlaClient, err := client.New(client.Config{
-		Host: ruleDeleteHost,
-		Port: ruleDeletePort,
-	})
+	rlaClient, err := client.New(newGlobalClientConfig())
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)
 	}

--- a/rla/cmd/rule_disassociate.go
+++ b/rla/cmd/rule_disassociate.go
@@ -36,8 +36,6 @@ var ruleDisassociateCmd = &cobra.Command{
 }
 
 var (
-	disassocHost      string
-	disassocPort      int
 	disassocRackID    string
 	disassocOpType    string
 	disassocOperation string
@@ -46,8 +44,6 @@ var (
 func init() {
 	ruleCmd.AddCommand(ruleDisassociateCmd)
 
-	ruleDisassociateCmd.Flags().StringVar(&disassocHost, "host", "localhost", "RLA service host")
-	ruleDisassociateCmd.Flags().IntVar(&disassocPort, "port", 50051, "RLA service port")
 	ruleDisassociateCmd.Flags().StringVar(&disassocRackID, "rack-id", "", "Rack ID (required)")
 	ruleDisassociateCmd.Flags().StringVar(&disassocOpType, "operation-type", "", "Operation type: power_control or firmware_control (required)")
 	ruleDisassociateCmd.Flags().StringVar(&disassocOperation, "operation", "", "Operation code: power_on, power_off, upgrade, etc. (required)")
@@ -57,6 +53,9 @@ func init() {
 	ruleDisassociateCmd.MarkFlagRequired("operation")
 }
 
+// runRuleDisassociate is the RunE handler for ruleDisassociateCmd. It parses
+// the rack ID, operation type, and operation code from flags and calls
+// DisassociateRuleFromRack via the client.
 func runRuleDisassociate(cmd *cobra.Command, args []string) error {
 	var opType types.OperationType
 	switch disassocOpType {
@@ -73,10 +72,7 @@ func runRuleDisassociate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid rack ID: %w", err)
 	}
 
-	rlaClient, err := client.New(client.Config{
-		Host: disassocHost,
-		Port: disassocPort,
-	})
+	rlaClient, err := client.New(newGlobalClientConfig())
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)
 	}

--- a/rla/cmd/rule_get.go
+++ b/rla/cmd/rule_get.go
@@ -37,18 +37,13 @@ var ruleGetCmd = &cobra.Command{
 	RunE:  runRuleGet,
 }
 
-var (
-	getHost string
-	getPort int
-)
-
 func init() {
 	ruleCmd.AddCommand(ruleGetCmd)
-
-	ruleGetCmd.Flags().StringVar(&getHost, "host", "localhost", "RLA service host")
-	ruleGetCmd.Flags().IntVar(&getPort, "port", 50051, "RLA service port")
 }
 
+// runRuleGet is the RunE handler for ruleGetCmd. It parses the rule ID from
+// the positional argument, fetches the rule via the client, and prints its
+// details to stdout.
 func runRuleGet(cmd *cobra.Command, args []string) error {
 	ruleIDStr := args[0]
 
@@ -57,10 +52,7 @@ func runRuleGet(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid rule ID: %w", err)
 	}
 
-	rlaClient, err := client.New(client.Config{
-		Host: getHost,
-		Port: getPort,
-	})
+	rlaClient, err := client.New(newGlobalClientConfig())
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)
 	}

--- a/rla/cmd/rule_list.go
+++ b/rla/cmd/rule_list.go
@@ -37,8 +37,6 @@ var ruleListCmd = &cobra.Command{
 }
 
 var (
-	listHost          string
-	listPort          int
 	listOperationType string
 	listIsDefault     bool
 	listOffset        int32
@@ -48,19 +46,16 @@ var (
 func init() {
 	ruleCmd.AddCommand(ruleListCmd)
 
-	ruleListCmd.Flags().StringVar(&listHost, "host", "localhost", "RLA service host")
-	ruleListCmd.Flags().IntVar(&listPort, "port", 50051, "RLA service port")
 	ruleListCmd.Flags().StringVar(&listOperationType, "operation-type", "", "Filter by operation type (power_control, firmware_control)")
 	ruleListCmd.Flags().BoolVar(&listIsDefault, "default-only", false, "Show only default rules")
 	ruleListCmd.Flags().Int32Var(&listOffset, "offset", 0, "Pagination offset")
 	ruleListCmd.Flags().Int32Var(&listLimit, "limit", 100, "Pagination limit")
 }
 
+// runRuleList is the RunE handler for ruleListCmd. It calls ListOperationRules
+// with any provided filters and prints the results as a tab-aligned table.
 func runRuleList(cmd *cobra.Command, args []string) error {
-	rlaClient, err := client.New(client.Config{
-		Host: listHost,
-		Port: listPort,
-	})
+	rlaClient, err := client.New(newGlobalClientConfig())
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)
 	}

--- a/rla/cmd/rule_set_default.go
+++ b/rla/cmd/rule_set_default.go
@@ -43,31 +43,26 @@ Example:
 }
 
 var (
-	setDefaultHost   string
-	setDefaultPort   int
 	setDefaultRuleID string
 )
 
 func init() {
 	ruleCmd.AddCommand(ruleSetDefaultCmd)
 
-	ruleSetDefaultCmd.Flags().StringVar(&setDefaultHost, "host", "localhost", "RLA service host")
-	ruleSetDefaultCmd.Flags().IntVar(&setDefaultPort, "port", 50051, "RLA service port")
 	ruleSetDefaultCmd.Flags().StringVar(&setDefaultRuleID, "id", "", "Rule ID (required)")
 
 	ruleSetDefaultCmd.MarkFlagRequired("id")
 }
 
+// runRuleSetDefault is the RunE handler for ruleSetDefaultCmd. It parses the
+// rule ID from the --id flag and calls SetRuleAsDefault via the client.
 func runRuleSetDefault(cmd *cobra.Command, args []string) error {
 	ruleID, err := uuid.Parse(setDefaultRuleID)
 	if err != nil {
 		return fmt.Errorf("invalid rule ID: %w", err)
 	}
 
-	rlaClient, err := client.New(client.Config{
-		Host: setDefaultHost,
-		Port: setDefaultPort,
-	})
+	rlaClient, err := client.New(newGlobalClientConfig())
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)
 	}

--- a/rla/cmd/serve.go
+++ b/rla/cmd/serve.go
@@ -45,6 +45,7 @@ import (
 	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager/providers/nvswitchmanager"
 	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager/providers/psm"
 	temporalmanager "github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/executor/temporalworkflow/manager"
+	pkgcerts "github.com/NVIDIA/ncx-infra-controller-rest/rla/pkg/certs"
 )
 
 const (
@@ -56,11 +57,23 @@ var (
 	port               int
 	componentMgrConfig string
 
+	// clientOnlyFlags are the global persistent flags that apply only to
+	// client commands. They are hidden from serve's help and rejected if set.
+	clientOnlyFlags = []string{flagHost, flagPort}
+
 	// serveCmd represents the serve command
 	serveCmd = &cobra.Command{
 		Use:   "serve",
 		Short: "Start the RLA gPRC server",
 		Long:  `Start the gRPC server to allow other services to manage the racks`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			for _, name := range clientOnlyFlags {
+				if cmd.Root().PersistentFlags().Changed(name) {
+					return fmt.Errorf("--%s is not applicable to 'rla serve'", name)
+				}
+			}
+			return nil
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			doServe()
 		},
@@ -70,7 +83,12 @@ var (
 func init() {
 	rootCmd.AddCommand(serveCmd)
 
-	serveCmd.Flags().IntVarP(&port, "port", "p", defaultServicePort, "Port for the gRPC server") //nolint
+	// Hide client-only persistent flags from serve's help output.
+	for _, name := range clientOnlyFlags {
+		_ = serveCmd.InheritedFlags().MarkHidden(name)
+	}
+
+	serveCmd.Flags().IntVarP(&port, "listen-port", "p", defaultServicePort, "Port for the gRPC server") //nolint
 	// Component manager config: priority is CLI flag > env var > default prod config
 	serveCmd.Flags().StringVarP(&componentMgrConfig, "component-config", "c", "", "Path to component manager config file (YAML)") //nolint
 }
@@ -207,8 +225,9 @@ func loadComponentManagerConfig() (componentmanager.Config, error) {
 	return componentmanager.DefaultProdConfig(), nil
 }
 
-// createOperationRulesLoader creates a rule loader from configuration file.
-// Returns a loader that will be used by the resolver to load rules during Start().
+// doServe is the main entry point for the serve subcommand. It loads all
+// configuration, initialises provider and component manager registries, builds
+// the service, and blocks until a termination signal is received.
 func doServe() {
 	dbConf, err := cdb.ConfigFromEnv()
 	if err != nil {
@@ -286,6 +305,11 @@ func doServe() {
 			ExecutorConf:  &temporalManagerConf,
 			CarbideClient: clients.carbide,
 			PSMClient:     clients.psm,
+			CertConfig: pkgcerts.Config{
+				CACert:  globalCACert,
+				TLSCert: globalTLSCert,
+				TLSKey:  globalTLSKey,
+			},
 		},
 	)
 

--- a/rla/internal/certs/certs.go
+++ b/rla/internal/certs/certs.go
@@ -15,45 +15,98 @@
  * limitations under the License.
  */
 
+// Package certs provides TLS configuration resolution using deployment-specific
+// defaults: the CERTDIR environment variable and the Kubernetes SPIFFE secret
+// path. For explicit path-based loading, use pkg/certs.
 package certs
 
 import (
 	"crypto/tls"
-	"crypto/x509"
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+
+	pkgcerts "github.com/NVIDIA/ncx-infra-controller-rest/rla/pkg/certs"
 )
 
-var ErrNotPresent = errors.New("Certificates are not present")
+// Default certificate directory and file names for the Kubernetes SPIFFE
+// workload identity secret mount.
+const (
+	defaultCertDir  = "/var/run/secrets/spiffe.io"
+	defaultCACert   = "ca.crt"
+	defaultCertFile = "tls.crt"
+	defaultKeyFile  = "tls.key"
+)
 
-func TLSConfig() (tlsConfig *tls.Config, certDir string, err error) {
-	certDir = os.Getenv("CERTDIR")
+// ErrNotPresent is returned when no certificate files are found at the
+// resolved directory. Callers may use errors.Is(err, ErrNotPresent) to
+// detect this case and fall back to non-mTLS.
+var ErrNotPresent = errors.New("certificates are not present")
+
+// ResolveServer returns a server-side TLS config and source description. If c
+// has explicit paths set, uses them via pkg/certs.ServerTLSConfig; otherwise
+// falls back to the CERTDIR env var / k8s default via ServerTLSConfig.
+func ResolveServer(c pkgcerts.Config) (*tls.Config, string, error) {
+	if err := c.Validate(); err != nil {
+		return nil, "", err
+	}
+
+	if c.IsSet() {
+		tlsConfig, err := c.ServerTLSConfig()
+		return tlsConfig, c.CACert, err
+	}
+
+	return ServerTLSConfig()
+}
+
+// TLSConfig resolves cert paths from the CERTDIR environment variable, falling
+// back to the k8s default /var/run/secrets/spiffe.io, and returns a client-side
+// tls.Config. Returns ErrNotPresent if no cert files are found.
+func TLSConfig() (*tls.Config, string, error) {
+	return tlsConfigFromDir(
+		func(c pkgcerts.Config) (*tls.Config, error) {
+			return c.TLSConfig()
+		},
+	)
+}
+
+// ServerTLSConfig resolves cert paths from the CERTDIR environment variable,
+// falling back to the k8s default /var/run/secrets/spiffe.io, and returns a
+// server-side tls.Config. Returns ErrNotPresent if no cert files are found.
+func ServerTLSConfig() (*tls.Config, string, error) {
+	return tlsConfigFromDir(
+		func(c pkgcerts.Config) (*tls.Config, error) {
+			return c.ServerTLSConfig()
+		},
+	)
+}
+
+// tlsConfigFromDir resolves the cert directory from CERTDIR (falling back to
+// defaultCertDir), builds a pkgcerts.Config with the standard file names, and
+// calls build to produce the tls.Config. Returns ErrNotPresent if any cert
+// file is missing, or a wrapped error for other load failures.
+func tlsConfigFromDir(
+	build func(pkgcerts.Config) (*tls.Config, error),
+) (*tls.Config, string, error) {
+	certDir := os.Getenv("CERTDIR")
 	if certDir == "" {
-		// Cert directory in k8s
-		certDir = "/var/run/secrets/spiffe.io"
+		certDir = defaultCertDir
 	}
 
-	caCert, err := os.ReadFile(certDir + "/ca.crt")
+	tlsConfig, err := build(
+		pkgcerts.Config{
+			CACert:  filepath.Join(certDir, defaultCACert),
+			TLSCert: filepath.Join(certDir, defaultCertFile),
+			TLSKey:  filepath.Join(certDir, defaultKeyFile),
+		},
+	)
 	if err != nil {
-		return nil, certDir, ErrNotPresent
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, certDir, ErrNotPresent
+		}
+		return nil, certDir, fmt.Errorf("loading certs from %q: %w", certDir, err)
 	}
 
-	clientCert, err := tls.LoadX509KeyPair(certDir+"/tls.crt", certDir+"/tls.key")
-	if err != nil {
-		return nil, certDir, fmt.Errorf("Invalid certs present: %w", err)
-	}
-
-	certPool := x509.NewCertPool()
-	if !certPool.AppendCertsFromPEM(caCert) {
-		return nil, certDir, fmt.Errorf("Invalid CA cert present: %w", err)
-	}
-
-	return &tls.Config{
-		Certificates: []tls.Certificate{clientCert},
-		RootCAs:      certPool,
-		ClientAuth:   tls.RequireAndVerifyClientCert,
-		ClientCAs:    certPool,
-	}, certDir, nil
-
+	return tlsConfig, certDir, nil
 }

--- a/rla/internal/certs/certs_test.go
+++ b/rla/internal/certs/certs_test.go
@@ -1,0 +1,174 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package certs
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgcerts "github.com/NVIDIA/ncx-infra-controller-rest/rla/pkg/certs"
+)
+
+// generateTestCerts creates a self-signed CA and a client cert/key in a temp
+// directory using the standard file names (ca.crt, tls.crt, tls.key).
+// Returns the directory path.
+func generateTestCerts(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	caTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "Test CA"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IsCA:         true,
+		KeyUsage:     x509.KeyUsageCertSign,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	clientKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "Test Client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	clientDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caTemplate, &clientKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	clientKeyDER, err := x509.MarshalECPrivateKey(clientKey)
+	require.NoError(t, err)
+
+	writePEM(t, filepath.Join(dir, defaultCACert), "CERTIFICATE", caDER)
+	writePEM(t, filepath.Join(dir, defaultCertFile), "CERTIFICATE", clientDER)
+	writePEM(t, filepath.Join(dir, defaultKeyFile), "EC PRIVATE KEY", clientKeyDER)
+
+	return dir
+}
+
+func writePEM(t *testing.T, path, pemType string, der []byte) {
+	t.Helper()
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+	require.NoError(t, pem.Encode(f, &pem.Block{Type: pemType, Bytes: der}))
+}
+
+func TestTLSConfig(t *testing.T) {
+	t.Run("CERTDIR set with valid certs", func(t *testing.T) {
+		dir := generateTestCerts(t)
+		t.Setenv("CERTDIR", dir)
+
+		tlsConfig, source, err := TLSConfig()
+		require.NoError(t, err)
+		assert.Equal(t, dir, source)
+		assert.NotNil(t, tlsConfig)
+	})
+
+	t.Run("CERTDIR set but no certs present", func(t *testing.T) {
+		t.Setenv("CERTDIR", t.TempDir())
+
+		tlsConfig, source, err := TLSConfig()
+		assert.ErrorIs(t, err, ErrNotPresent)
+		assert.NotEmpty(t, source)
+		assert.Nil(t, tlsConfig)
+	})
+
+	t.Run("CERTDIR not set falls back to default path", func(t *testing.T) {
+		t.Setenv("CERTDIR", "")
+
+		tlsConfig, source, err := TLSConfig()
+		assert.ErrorIs(t, err, ErrNotPresent)
+		assert.Equal(t, defaultCertDir, source)
+		assert.Nil(t, tlsConfig)
+	})
+}
+
+func TestServerTLSConfig(t *testing.T) {
+	t.Run("CERTDIR set with valid certs", func(t *testing.T) {
+		dir := generateTestCerts(t)
+		t.Setenv("CERTDIR", dir)
+
+		tlsConfig, source, err := ServerTLSConfig()
+		require.NoError(t, err)
+		assert.Equal(t, dir, source)
+		assert.NotEmpty(t, tlsConfig.Certificates)
+		assert.NotNil(t, tlsConfig.ClientCAs)
+	})
+
+	t.Run("CERTDIR set but no certs present", func(t *testing.T) {
+		t.Setenv("CERTDIR", t.TempDir())
+
+		tlsConfig, source, err := ServerTLSConfig()
+		assert.ErrorIs(t, err, ErrNotPresent)
+		assert.NotEmpty(t, source)
+		assert.Nil(t, tlsConfig)
+	})
+}
+
+func TestResolveServer(t *testing.T) {
+	t.Run("explicit paths used when set returns server config", func(t *testing.T) {
+		dir := generateTestCerts(t)
+		c := pkgcerts.Config{
+			CACert:  filepath.Join(dir, defaultCACert),
+			TLSCert: filepath.Join(dir, defaultCertFile),
+			TLSKey:  filepath.Join(dir, defaultKeyFile),
+		}
+
+		tlsConfig, source, err := ResolveServer(c)
+		require.NoError(t, err)
+		assert.Equal(t, c.CACert, source)
+		assert.NotEmpty(t, tlsConfig.Certificates) // server config
+		assert.NotNil(t, tlsConfig.ClientCAs)      // server config
+		assert.Nil(t, tlsConfig.RootCAs)           // not client config
+	})
+
+	t.Run("empty config falls back to env/default", func(t *testing.T) {
+		t.Setenv("CERTDIR", t.TempDir()) // empty dir → ErrNotPresent
+
+		_, _, err := ResolveServer(pkgcerts.Config{})
+		assert.ErrorIs(t, err, ErrNotPresent)
+	})
+
+	t.Run("partial config returns validation error", func(t *testing.T) {
+		c := pkgcerts.Config{CACert: "ca.crt"} // missing tls-cert and tls-key
+
+		_, _, err := ResolveServer(c)
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, ErrNotPresent)
+	})
+}

--- a/rla/internal/service/config.go
+++ b/rla/internal/service/config.go
@@ -28,9 +28,11 @@ import (
 	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/clients/temporal"
 	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/psmapi"
 	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/executor"
+	pkgcerts "github.com/NVIDIA/ncx-infra-controller-rest/rla/pkg/certs"
 )
 
 const (
+	// DefaultPort is the default port the RLA gRPC server listens on.
 	DefaultPort = 50051
 )
 
@@ -45,8 +47,16 @@ type Config struct {
 	ExecutorConf  executor.ExecutorConfig
 	CarbideClient carbideapi.Client
 	PSMClient     psmapi.Client
+
+	// CertConfig holds certificate file paths for the gRPC server listener.
+	// When set, these take precedence over CERTDIR / the k8s default.
+	// Either all three fields must be set or none.
+	CertConfig pkgcerts.Config
 }
 
+// BuildTemporalConfigFromEnv builds a Temporal client configuration from
+// environment variables: TEMPORAL_HOST, TEMPORAL_PORT, TEMPORAL_NAMESPACE,
+// TEMPORAL_CERT_PATH, TEMPORAL_ENABLE_TLS, and TEMPORAL_SERVER_NAME.
 func BuildTemporalConfigFromEnv() (*temporal.Config, error) {
 	host := os.Getenv("TEMPORAL_HOST")
 	if host == "" {

--- a/rla/internal/service/service.go
+++ b/rla/internal/service/service.go
@@ -19,6 +19,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 
@@ -38,6 +39,8 @@ import (
 	pb "github.com/NVIDIA/ncx-infra-controller-rest/rla/pkg/proto/v1"
 )
 
+// Service is the top-level RLA service. It owns the gRPC server, database
+// session, inventory manager, and task manager and coordinates their lifecycles.
 type Service struct {
 	conf             Config
 	grpcServer       *grpc.Server
@@ -47,6 +50,9 @@ type Service struct {
 	taskManager      *taskmanager.Manager
 }
 
+// New creates and initialises a Service from the provided Config. It opens the
+// database connection, runs pending migrations, and wires up the inventory and
+// task managers. The returned service is ready to Start.
 func New(ctx context.Context, c Config) (*Service, error) {
 	// 1. Create shared PostgreSQL connection
 	session, err := cdb.NewSessionFromConfig(ctx, c.DBConf)
@@ -79,10 +85,7 @@ func New(ctx context.Context, c Config) (*Service, error) {
 		},
 	)
 	if err != nil {
-		// XXX -- ignore the error for now until we have access to the temporal server
-		// in the real deployment.
-		log.Error().Err(err).Msg("failed to create task manager (ignore the error for now)")
-		taskManager = nil
+		return nil, fmt.Errorf("failed to create task manager: %w", err)
 	}
 
 	return &Service{
@@ -94,6 +97,9 @@ func New(ctx context.Context, c Config) (*Service, error) {
 	}, nil
 }
 
+// Start starts the inventory manager, task manager, and inventory sync
+// goroutine, then begins serving gRPC requests on the configured port.
+// It blocks until the gRPC server stops.
 func (s *Service) Start(ctx context.Context) error {
 	log.Logger = log.With().Caller().Logger()
 
@@ -147,6 +153,8 @@ func (s *Service) Start(ctx context.Context) error {
 	return nil
 }
 
+// Stop gracefully shuts down the gRPC server, task manager, inventory manager,
+// and database session.
 func (s *Service) Stop(ctx context.Context) {
 	log.Info().Msg("Starting graceful shutdown now...")
 
@@ -161,15 +169,20 @@ func (s *Service) Stop(ctx context.Context) {
 	}
 }
 
+// certOption resolves the TLS configuration for the gRPC server listener.
+// If explicit certificate paths are set in the config they take precedence;
+// otherwise CERTDIR / the k8s SPIFFE default is used. Returns an empty
+// ServerOption (no TLS) when no certificates are found.
 func (s *Service) certOption() grpc.ServerOption {
-	tlsConfig, certDir, err := certs.TLSConfig()
+	tlsConfig, source, err := certs.ResolveServer(s.conf.CertConfig)
 	if err != nil {
-		if err == certs.ErrNotPresent {
+		if errors.Is(err, certs.ErrNotPresent) {
 			log.Info().Msg("Certs not present, using non-mTLS")
 			return grpc.EmptyServerOption{}
 		}
 		log.Fatal().Msg(err.Error())
 	}
-	log.Info().Msgf("Using certificates from %s", certDir)
+
+	log.Info().Msgf("Using certificates from %s", source)
 	return grpc.Creds(credentials.NewTLS(tlsConfig))
 }

--- a/rla/pkg/certs/certs.go
+++ b/rla/pkg/certs/certs.go
@@ -1,0 +1,126 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package certs provides TLS configuration building from explicit certificate
+// file paths. It has no environment or deployment assumptions — callers supply
+// all paths directly.
+package certs
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"os"
+)
+
+// Config holds explicit file paths for the CA cert, TLS cert, and TLS key.
+// The same cert/key pair is used for both client and server roles in mTLS.
+type Config struct {
+	CACert  string // path to CA certificate file
+	TLSCert string // path to TLS certificate file
+	TLSKey  string // path to TLS private key file
+}
+
+// IsSet reports whether all three certificate paths are set.
+func (c Config) IsSet() bool {
+	return c.CACert != "" && c.TLSCert != "" && c.TLSKey != ""
+}
+
+// Validate checks that all three certificate paths are set.
+// Either all must be non-empty or none — partial configuration is an error.
+func (c Config) Validate() error {
+	set := 0
+	if c.CACert != "" {
+		set++
+	}
+	if c.TLSCert != "" {
+		set++
+	}
+	if c.TLSKey != "" {
+		set++
+	}
+
+	if set != 0 && set != 3 {
+		return errors.New("ca-cert, tls-cert, and tls-key must all be provided together")
+	}
+
+	return nil
+}
+
+// loadCerts reads the CA cert pool and the cert/key pair from the file paths in c.
+func (c Config) loadCerts() (*x509.CertPool, tls.Certificate, error) {
+	caCert, err := os.ReadFile(c.CACert)
+	if err != nil {
+		return nil, tls.Certificate{}, fmt.Errorf("failed to read CA cert %q: %w", c.CACert, err)
+	}
+
+	certPool := x509.NewCertPool()
+	if !certPool.AppendCertsFromPEM(caCert) {
+		return nil, tls.Certificate{}, fmt.Errorf("failed to parse CA cert %q", c.CACert)
+	}
+
+	cert, err := tls.LoadX509KeyPair(c.TLSCert, c.TLSKey)
+	if err != nil {
+		return nil, tls.Certificate{}, fmt.Errorf("failed to load cert/key (%q, %q): %w", c.TLSCert, c.TLSKey, err)
+	}
+
+	return certPool, cert, nil
+}
+
+// TLSConfig builds a client-side tls.Config from the explicit file paths in c.
+// RootCAs is set to verify the server certificate. GetClientCertificate is used
+// instead of Certificates to ensure the client always presents its certificate
+// during the TLS handshake. With the Certificates field, Go's TLS stack only
+// selects a certificate if its issuer matches the acceptable CA list sent by
+// the server in its CertificateRequest message. When no match is found, Go
+// silently sends an empty certificate list, causing the server to reject the
+// connection with "certificate required". GetClientCertificate bypasses this
+// matching and unconditionally returns the certificate, leaving verification to
+// the server.
+func (c Config) TLSConfig() (*tls.Config, error) {
+	certPool, cert, err := c.loadCerts()
+	if err != nil {
+		return nil, err
+	}
+
+	return &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return &cert, nil
+		},
+		RootCAs: certPool,
+	}, nil
+}
+
+// ServerTLSConfig builds a server-side tls.Config from the explicit file paths
+// in c. Certificates is set so the server can present its certificate during
+// the TLS handshake. ClientAuth and ClientCAs are set to require and verify the
+// client certificate.
+func (c Config) ServerTLSConfig() (*tls.Config, error) {
+	certPool, cert, err := c.loadCerts()
+	if err != nil {
+		return nil, err
+	}
+
+	return &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		Certificates: []tls.Certificate{cert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    certPool,
+	}, nil
+}

--- a/rla/pkg/certs/certs_test.go
+++ b/rla/pkg/certs/certs_test.go
@@ -1,0 +1,229 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package certs
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// generateTestCerts creates a self-signed CA and a client cert/key in a temp
+// directory, returning paths to ca.crt, tls.crt, and tls.key.
+func generateTestCerts(t *testing.T) (caFile, certFile, keyFile string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	caTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "Test CA"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IsCA:         true,
+		KeyUsage:     x509.KeyUsageCertSign,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	clientKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "Test Client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	clientDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caTemplate, &clientKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	clientKeyDER, err := x509.MarshalECPrivateKey(clientKey)
+	require.NoError(t, err)
+
+	caFile = filepath.Join(dir, "ca.crt")
+	writePEM(t, caFile, "CERTIFICATE", caDER)
+
+	certFile = filepath.Join(dir, "tls.crt")
+	writePEM(t, certFile, "CERTIFICATE", clientDER)
+
+	keyFile = filepath.Join(dir, "tls.key")
+	writePEM(t, keyFile, "EC PRIVATE KEY", clientKeyDER)
+
+	return caFile, certFile, keyFile
+}
+
+func writePEM(t *testing.T, path, pemType string, der []byte) {
+	t.Helper()
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+	require.NoError(t, pem.Encode(f, &pem.Block{Type: pemType, Bytes: der}))
+}
+
+func TestConfig_IsSet(t *testing.T) {
+	testCases := map[string]struct {
+		config Config
+		want   bool
+	}{
+		"all fields set": {
+			config: Config{CACert: "ca.crt", TLSCert: "tls.crt", TLSKey: "tls.key"},
+			want:   true,
+		},
+		"empty config": {
+			config: Config{},
+			want:   false,
+		},
+		"only ca-cert": {
+			config: Config{CACert: "ca.crt"},
+			want:   false,
+		},
+		"only tls-cert and tls-key": {
+			config: Config{TLSCert: "tls.crt", TLSKey: "tls.key"},
+			want:   false,
+		},
+		"missing tls-key": {
+			config: Config{CACert: "ca.crt", TLSCert: "tls.crt"},
+			want:   false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.config.IsSet())
+		})
+	}
+}
+
+func TestConfig_Validate(t *testing.T) {
+	testCases := map[string]struct {
+		config  Config
+		wantErr bool
+	}{
+		"empty config (no certs)": {
+			config:  Config{},
+			wantErr: false,
+		},
+		"all fields set": {
+			config:  Config{CACert: "ca.crt", TLSCert: "tls.crt", TLSKey: "tls.key"},
+			wantErr: false,
+		},
+		"only ca-cert": {
+			config:  Config{CACert: "ca.crt"},
+			wantErr: true,
+		},
+		"only tls-cert": {
+			config:  Config{TLSCert: "tls.crt"},
+			wantErr: true,
+		},
+		"only tls-key": {
+			config:  Config{TLSKey: "tls.key"},
+			wantErr: true,
+		},
+		"missing tls-key": {
+			config:  Config{CACert: "ca.crt", TLSCert: "tls.crt"},
+			wantErr: true,
+		},
+		"missing tls-cert": {
+			config:  Config{CACert: "ca.crt", TLSKey: "tls.key"},
+			wantErr: true,
+		},
+		"missing ca-cert": {
+			config:  Config{TLSCert: "tls.crt", TLSKey: "tls.key"},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			err := tc.config.Validate()
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestConfig_TLSConfig(t *testing.T) {
+	t.Run("valid certs", func(t *testing.T) {
+		caFile, certFile, keyFile := generateTestCerts(t)
+		tlsConfig, err := Config{CACert: caFile, TLSCert: certFile, TLSKey: keyFile}.TLSConfig()
+		require.NoError(t, err)
+		assert.NotNil(t, tlsConfig.RootCAs)
+		assert.NotNil(t, tlsConfig.GetClientCertificate)
+		assert.Equal(t, tls.NoClientCert, tlsConfig.ClientAuth) // client config: no ClientAuth
+	})
+
+	t.Run("non-existent ca cert", func(t *testing.T) {
+		_, certFile, keyFile := generateTestCerts(t)
+		_, err := Config{CACert: "/nonexistent/ca.crt", TLSCert: certFile, TLSKey: keyFile}.TLSConfig()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrNotExist)
+	})
+
+	t.Run("invalid ca cert content", func(t *testing.T) {
+		dir := t.TempDir()
+		badCA := filepath.Join(dir, "ca.crt")
+		require.NoError(t, os.WriteFile(badCA, []byte("not a certificate"), 0600))
+		_, certFile, keyFile := generateTestCerts(t)
+		_, err := Config{CACert: badCA, TLSCert: certFile, TLSKey: keyFile}.TLSConfig()
+		require.Error(t, err)
+	})
+
+	t.Run("non-existent client cert", func(t *testing.T) {
+		caFile, _, keyFile := generateTestCerts(t)
+		_, err := Config{CACert: caFile, TLSCert: "/nonexistent/tls.crt", TLSKey: keyFile}.TLSConfig()
+		require.Error(t, err)
+	})
+}
+
+func TestConfig_ServerTLSConfig(t *testing.T) {
+	t.Run("valid certs", func(t *testing.T) {
+		caFile, certFile, keyFile := generateTestCerts(t)
+		tlsConfig, err := Config{CACert: caFile, TLSCert: certFile, TLSKey: keyFile}.ServerTLSConfig()
+		require.NoError(t, err)
+		assert.NotEmpty(t, tlsConfig.Certificates)
+		assert.NotNil(t, tlsConfig.ClientCAs)
+		assert.Equal(t, tls.RequireAndVerifyClientCert, tlsConfig.ClientAuth)
+		assert.Nil(t, tlsConfig.RootCAs) // server config: no RootCAs
+	})
+
+	t.Run("non-existent ca cert", func(t *testing.T) {
+		_, certFile, keyFile := generateTestCerts(t)
+		_, err := Config{CACert: "/nonexistent/ca.crt", TLSCert: certFile, TLSKey: keyFile}.ServerTLSConfig()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrNotExist)
+	})
+}

--- a/rla/pkg/client/client.go
+++ b/rla/pkg/client/client.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -42,16 +43,25 @@ type Client struct {
 	conn   *grpc.ClientConn
 }
 
-// New creates a new client with the given configuration.
+// New creates a new RLA gRPC client. If CertConfig is set, the connection uses
+// mTLS; otherwise it falls back to insecure (plaintext) transport.
 func New(c Config) (*Client, error) {
 	if err := c.Validate(); err != nil {
 		return nil, err
 	}
 
-	conn, err := grpc.NewClient(
-		c.Target(),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
+	var creds credentials.TransportCredentials
+	if c.CertConfig.IsSet() {
+		tlsConfig, err := c.CertConfig.TLSConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to build TLS config: %w", err)
+		}
+		creds = credentials.NewTLS(tlsConfig)
+	} else {
+		creds = insecure.NewCredentials()
+	}
+
+	conn, err := grpc.NewClient(c.Target(), grpc.WithTransportCredentials(creds))
 	if err != nil {
 		return nil, err
 	}
@@ -743,6 +753,8 @@ func (c *Client) GetExpectedComponentsByComponentIDs(
 	return convertGetComponentsResponse(rsp), nil
 }
 
+// convertGetComponentsResponse converts a protobuf GetComponentsResponse into
+// a GetExpectedComponentsResult.
 func convertGetComponentsResponse(rsp *pb.GetComponentsResponse) *GetExpectedComponentsResult {
 	components := make([]*types.Component, 0, len(rsp.Components))
 	for _, c := range rsp.Components {
@@ -858,6 +870,8 @@ func (c *Client) ValidateComponentsByComponentIDs(
 	return convertValidateComponentsResponse(rsp), nil
 }
 
+// convertValidateComponentsResponse converts a protobuf ValidateComponentsResponse
+// into a ValidateComponentsResult.
 func convertValidateComponentsResponse(rsp *pb.ValidateComponentsResponse) *ValidateComponentsResult {
 	diffs := make([]*types.ComponentDiff, 0, len(rsp.Diffs))
 	for _, d := range rsp.Diffs {

--- a/rla/pkg/client/config.go
+++ b/rla/pkg/client/config.go
@@ -20,6 +20,8 @@ package client
 import (
 	"errors"
 	"fmt"
+
+	pkgcerts "github.com/NVIDIA/ncx-infra-controller-rest/rla/pkg/certs"
 )
 
 // Config represents the configuration needed to create a new RLA service
@@ -27,6 +29,11 @@ import (
 type Config struct {
 	Host string
 	Port int
+
+	// CertConfig holds certificate file paths for mTLS. Either all three
+	// fields must be set (mTLS enabled) or all must be empty (insecure).
+	// Providing only some is a validation error.
+	CertConfig pkgcerts.Config
 }
 
 // Validate checks if the config fields are set correctly.
@@ -39,7 +46,7 @@ func (c *Config) Validate() error {
 		return errors.New("port must be within (0, 65535]")
 	}
 
-	return nil
+	return c.CertConfig.Validate()
 }
 
 // Target builds the target string for connecting to RLA gRPC server.


### PR DESCRIPTION

## Description
<!-- Describe what this PR does -->
- Add persistent --host, --port, --ca-cert, --client-cert, --client-key flags to root command, inherited by all subcommands; remove per-command host/port flags
- Add --ca-cert, --client-cert, --client-key flags to rla serve for the server listener
- Introduce pkg/certs with Config.IsSet(), Validate(), TLSConfig() (client), and ServerTLSConfig() (server) — no env/deployment assumptions
- Refactor internal/certs to delegate to pkg/certs; add ResolveServer(), ServerTLSConfig(), and shared tlsConfigFromDir() helper; TLSConfig() remains for client use by carbideapi/nsmapi/psmapi
- Add unit tests for pkg/certs and internal/certs

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [ ] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [x] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ x Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
