### PR TITLE
fix: Load RLA Temporal client certificates using cert module

### DIFF
--- a/rla/cmd/root.go
+++ b/rla/cmd/root.go
@@ -39,11 +39,12 @@ const (
 // configure the gRPC client target; cert flags configure mTLS for both client
 // commands and the serve listener.
 var (
-	globalHost    string
-	globalPort    int
-	globalCACert  string
-	globalTLSCert string
-	globalTLSKey  string
+	globalHost       string
+	globalPort       int
+	globalCACert     string
+	globalTLSCert    string
+	globalTLSKey     string
+	globalServerName string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -68,14 +69,16 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&globalCACert, "ca-cert", "", "Path to CA certificate file")
 	rootCmd.PersistentFlags().StringVar(&globalTLSCert, "tls-cert", "", "Path to TLS certificate file")
 	rootCmd.PersistentFlags().StringVar(&globalTLSKey, "tls-key", "", "Path to TLS private key file")
+	rootCmd.PersistentFlags().StringVar(&globalServerName, "server-name", "", "Server name for TLS verification; when empty, TLS uses the dial target hostname")
 	rootCmd.MarkFlagsRequiredTogether("ca-cert", "tls-cert", "tls-key")
 }
 
 // newGlobalClientConfig builds a client.Config from the global persistent flags.
 func newGlobalClientConfig() client.Config {
 	return client.Config{
-		Host: globalHost,
-		Port: globalPort,
+		Host:       globalHost,
+		Port:       globalPort,
+		ServerName: globalServerName,
 		CertConfig: pkgcerts.Config{
 			CACert:  globalCACert,
 			TLSCert: globalTLSCert,

--- a/rla/internal/certs/certs.go
+++ b/rla/internal/certs/certs.go
@@ -66,7 +66,8 @@ func ResolveServer(c pkgcerts.Config) (*tls.Config, string, error) {
 func TLSConfig() (*tls.Config, string, error) {
 	return tlsConfigFromDir(
 		func(c pkgcerts.Config) (*tls.Config, error) {
-			return c.TLSConfig()
+			// Pass empty server name: gRPC derives it from the dial URL's hostname.
+			return c.TLSConfig("")
 		},
 	)
 }

--- a/rla/internal/clients/temporal/certificate.go
+++ b/rla/internal/clients/temporal/certificate.go
@@ -19,76 +19,25 @@ package temporal
 
 import (
 	"crypto/tls"
-	"crypto/x509"
-	"fmt"
-	"os"
+	"path/filepath"
 
-	"github.com/rs/zerolog/log"
+	pkgcerts "github.com/NVIDIA/ncx-infra-controller-rest/rla/pkg/certs"
 )
 
 const (
 	caCertificateFileName     = "ca.crt"
 	clientCertificateFileName = "tls.crt"
 	clientKeyFileName         = "tls.key"
-	caCertificateDirName      = "ca"
-	clientCertificateDirName  = "client"
 )
-
-func loadClientCertificate(clientCertPath string) (tls.Certificate, error) {
-	log.Info().Msgf("Loading client certificate from %s", clientCertPath)
-	cert, err := tls.LoadX509KeyPair(
-		clientCertPath+"/"+clientCertificateFileName,
-		clientCertPath+"/"+clientKeyFileName,
-	)
-
-	if err != nil {
-		log.Error().Msgf("Failed to load client certificate: %v", err)
-		return tls.Certificate{}, err
-	}
-
-	log.Info().Msgf("Client certificate loaded successfully")
-	return cert, nil
-}
-
-func loadCACertificate(caCertPath string) (*x509.CertPool, error) {
-	log.Info().Msgf("Loading CA certificate from %s", caCertPath)
-	caCert, err := os.ReadFile(caCertPath + "/" + caCertificateFileName)
-	if err != nil {
-		log.Error().Msgf("Failed to load CA certificate: %v", err)
-		return nil, err
-	}
-
-	log.Info().Msgf("CA certificate loaded successfully")
-
-	certPool := x509.NewCertPool()
-	if !certPool.AppendCertsFromPEM(caCert) {
-		log.Error().Msgf("Failed to append CA certificate to pool")
-		return nil, fmt.Errorf("failed to append CA certificate to pool")
-	}
-
-	return certPool, nil
-}
 
 func buildTLSConfig(c Config) (*tls.Config, error) {
 	if !c.EnableTLS {
 		return nil, nil
 	}
 
-	caCertPath := c.Endpoint.CACertificatePath + "/" + caCertificateDirName
-	caCert, err := loadCACertificate(caCertPath)
-	if err != nil {
-		return nil, err
-	}
-
-	clientCertPath := c.Endpoint.CACertificatePath + "/" + clientCertificateDirName
-	clientCert, err := loadClientCertificate(clientCertPath)
-	if err != nil {
-		return nil, err
-	}
-
-	return &tls.Config{
-		Certificates: []tls.Certificate{clientCert},
-		ServerName:   c.ServerName,
-		RootCAs:      caCert,
-	}, nil
+	return pkgcerts.Config{
+		CACert:  filepath.Join(c.Endpoint.CACertificatePath, caCertificateFileName),
+		TLSCert: filepath.Join(c.Endpoint.CACertificatePath, clientCertificateFileName),
+		TLSKey:  filepath.Join(c.Endpoint.CACertificatePath, clientKeyFileName),
+	}.TLSConfig(c.ServerName)
 }

--- a/rla/internal/clients/temporal/certificate_test.go
+++ b/rla/internal/clients/temporal/certificate_test.go
@@ -1,0 +1,138 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package temporal
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/ncx-infra-controller-rest/common/pkg/endpoint"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeCertDir generates a self-signed CA and client cert/key, writing them
+// into dir using the file names expected by buildTLSConfig.
+func writeCertDir(t *testing.T, dir string) {
+	t.Helper()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	caTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "Test CA"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IsCA:         true,
+		KeyUsage:     x509.KeyUsageCertSign,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	clientKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "Test Client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	clientDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caTemplate, &clientKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	clientKeyDER, err := x509.MarshalECPrivateKey(clientKey)
+	require.NoError(t, err)
+
+	writePEM(t, filepath.Join(dir, caCertificateFileName), "CERTIFICATE", caDER)
+	writePEM(t, filepath.Join(dir, clientCertificateFileName), "CERTIFICATE", clientDER)
+	writePEM(t, filepath.Join(dir, clientKeyFileName), "EC PRIVATE KEY", clientKeyDER)
+}
+
+func writePEM(t *testing.T, path, pemType string, der []byte) {
+	t.Helper()
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+	require.NoError(t, pem.Encode(f, &pem.Block{Type: pemType, Bytes: der}))
+}
+
+func TestBuildTLSConfig(t *testing.T) {
+	t.Run("TLS disabled returns nil", func(t *testing.T) {
+		cfg := Config{EnableTLS: false}
+		tlsConfig, err := buildTLSConfig(cfg)
+		require.NoError(t, err)
+		assert.Nil(t, tlsConfig)
+	})
+
+	t.Run("TLS enabled with valid cert dir", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCertDir(t, dir)
+
+		cfg := Config{
+			EnableTLS:  true,
+			ServerName: "temporal.example.com",
+			Endpoint:   endpoint.Config{CACertificatePath: dir},
+		}
+		tlsConfig, err := buildTLSConfig(cfg)
+		require.NoError(t, err)
+		assert.NotNil(t, tlsConfig)
+		assert.NotNil(t, tlsConfig.RootCAs)
+		assert.NotNil(t, tlsConfig.GetClientCertificate)
+		assert.Equal(t, "temporal.example.com", tlsConfig.ServerName)
+	})
+
+	t.Run("TLS enabled with trailing slash in path", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCertDir(t, dir)
+
+		cfg := Config{
+			EnableTLS:  true,
+			ServerName: "temporal.example.com",
+			Endpoint:   endpoint.Config{CACertificatePath: dir + "/"},
+		}
+		tlsConfig, err := buildTLSConfig(cfg)
+		require.NoError(t, err)
+		assert.NotNil(t, tlsConfig)
+		assert.Equal(t, "temporal.example.com", tlsConfig.ServerName)
+	})
+
+	t.Run("TLS enabled with missing cert files returns error", func(t *testing.T) {
+		dir := t.TempDir()
+		// dir exists but contains no cert files
+
+		cfg := Config{
+			EnableTLS:  true,
+			ServerName: "temporal.example.com",
+			Endpoint:   endpoint.Config{CACertificatePath: dir},
+		}
+		_, err := buildTLSConfig(cfg)
+		require.Error(t, err)
+	})
+}

--- a/rla/pkg/certs/certs.go
+++ b/rla/pkg/certs/certs.go
@@ -92,7 +92,7 @@ func (c Config) loadCerts() (*x509.CertPool, tls.Certificate, error) {
 // connection with "certificate required". GetClientCertificate bypasses this
 // matching and unconditionally returns the certificate, leaving verification to
 // the server.
-func (c Config) TLSConfig() (*tls.Config, error) {
+func (c Config) TLSConfig(serverName string) (*tls.Config, error) {
 	certPool, cert, err := c.loadCerts()
 	if err != nil {
 		return nil, err
@@ -103,7 +103,8 @@ func (c Config) TLSConfig() (*tls.Config, error) {
 		GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
 			return &cert, nil
 		},
-		RootCAs: certPool,
+		RootCAs:    certPool,
+		ServerName: serverName,
 	}, nil
 }
 

--- a/rla/pkg/certs/certs_test.go
+++ b/rla/pkg/certs/certs_test.go
@@ -179,16 +179,24 @@ func TestConfig_Validate(t *testing.T) {
 func TestConfig_TLSConfig(t *testing.T) {
 	t.Run("valid certs", func(t *testing.T) {
 		caFile, certFile, keyFile := generateTestCerts(t)
-		tlsConfig, err := Config{CACert: caFile, TLSCert: certFile, TLSKey: keyFile}.TLSConfig()
+		tlsConfig, err := Config{CACert: caFile, TLSCert: certFile, TLSKey: keyFile}.TLSConfig("")
 		require.NoError(t, err)
 		assert.NotNil(t, tlsConfig.RootCAs)
 		assert.NotNil(t, tlsConfig.GetClientCertificate)
 		assert.Equal(t, tls.NoClientCert, tlsConfig.ClientAuth) // client config: no ClientAuth
+		assert.Empty(t, tlsConfig.ServerName)
+	})
+
+	t.Run("server name is set", func(t *testing.T) {
+		caFile, certFile, keyFile := generateTestCerts(t)
+		tlsConfig, err := Config{CACert: caFile, TLSCert: certFile, TLSKey: keyFile}.TLSConfig("temporal.example.com")
+		require.NoError(t, err)
+		assert.Equal(t, "temporal.example.com", tlsConfig.ServerName)
 	})
 
 	t.Run("non-existent ca cert", func(t *testing.T) {
 		_, certFile, keyFile := generateTestCerts(t)
-		_, err := Config{CACert: "/nonexistent/ca.crt", TLSCert: certFile, TLSKey: keyFile}.TLSConfig()
+		_, err := Config{CACert: "/nonexistent/ca.crt", TLSCert: certFile, TLSKey: keyFile}.TLSConfig("")
 		require.Error(t, err)
 		assert.ErrorIs(t, err, os.ErrNotExist)
 	})
@@ -198,13 +206,13 @@ func TestConfig_TLSConfig(t *testing.T) {
 		badCA := filepath.Join(dir, "ca.crt")
 		require.NoError(t, os.WriteFile(badCA, []byte("not a certificate"), 0600))
 		_, certFile, keyFile := generateTestCerts(t)
-		_, err := Config{CACert: badCA, TLSCert: certFile, TLSKey: keyFile}.TLSConfig()
+		_, err := Config{CACert: badCA, TLSCert: certFile, TLSKey: keyFile}.TLSConfig("")
 		require.Error(t, err)
 	})
 
 	t.Run("non-existent client cert", func(t *testing.T) {
 		caFile, _, keyFile := generateTestCerts(t)
-		_, err := Config{CACert: caFile, TLSCert: "/nonexistent/tls.crt", TLSKey: keyFile}.TLSConfig()
+		_, err := Config{CACert: caFile, TLSCert: "/nonexistent/tls.crt", TLSKey: keyFile}.TLSConfig("")
 		require.Error(t, err)
 	})
 }

--- a/rla/pkg/client/client.go
+++ b/rla/pkg/client/client.go
@@ -52,7 +52,7 @@ func New(c Config) (*Client, error) {
 
 	var creds credentials.TransportCredentials
 	if c.CertConfig.IsSet() {
-		tlsConfig, err := c.CertConfig.TLSConfig()
+		tlsConfig, err := c.CertConfig.TLSConfig(c.ServerName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build TLS config: %w", err)
 		}

--- a/rla/pkg/client/config.go
+++ b/rla/pkg/client/config.go
@@ -27,8 +27,9 @@ import (
 // Config represents the configuration needed to create a new RLA service
 // gRPC client.
 type Config struct {
-	Host string
-	Port int
+	Host       string
+	Port       int
+	ServerName string // overrides the server name used for TLS SNI and certificate verification
 
 	// CertConfig holds certificate file paths for mTLS. Either all three
 	// fields must be set (mTLS enabled) or all must be empty (insecure).


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
Generate the certificate/key file paths based on the de-facto standard for k8s workload.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [x] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [ ] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [x] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
