### PR TITLE
fix: Strip leading comma from Docker image tags in CI

### DIFF
--- a/.github/workflows/build-push-service.yml
+++ b/.github/workflows/build-push-service.yml
@@ -125,6 +125,7 @@ jobs:
             TAGS="${TAGS},${{ inputs.target_registry }}/${{ inputs.service_name }}:${{ inputs.branch_sha_tag }}"
           fi
 
+          TAGS="${TAGS#,}"
           echo "tags=$TAGS" >> $GITHUB_OUTPUT
 
       - name: Build and push ${{ inputs.service_name }} (multi-arch)


### PR DESCRIPTION
## Description
The `TAGS` variable was initialized to an empty string and then concatenated with a leading comma on every append, producing tags like `,nvcr.io/.../image:tag`. This pr would strip leading comma from Docker image tags in CI. 

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [x] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [x] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [ ] **API** - API models or endpoints updated
- [x] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
Example: https://github.com/NVIDIA/ncx-infra-controller-rest/actions/runs/23813946969/job/69409367775
<img width="1159" height="22" alt="image" src="https://github.com/user-attachments/assets/e98e8e35-ddaf-4348-b601-d202bd0088a6" />

