### PR TITLE
fix: Add 10 MiB request body size limit to prevent OOM

### DIFF
--- a/api/internal/server/server.go
+++ b/api/internal/server/server.go
@@ -138,6 +138,9 @@ func InitAPIServer(cfg *config.Config, dbSession *cdb.Session, tc tsdkClient.Cli
 	// Secure middleware configures echo with secure headers
 	e.Use(middleware.Secure())
 
+	// Limit request body size to prevent OOM from oversized payloads
+	e.Use(echoMiddleware.BodyLimit("10M"))
+
 	// Rate limiter middleware (if enabled)
 	rateLimiterConfig := cfg.GetRateLimiterConfig()
 	if rateLimiterConfig.Enabled {

--- a/api/internal/server/server_test.go
+++ b/api/internal/server/server_test.go
@@ -18,6 +18,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -182,6 +183,34 @@ func Test_Audit(t *testing.T) {
 	assert.Equal(t, count, 1)
 	assert.Equal(t, entries[0].OrgName, "wdksahew1rqv")
 	assert.Equal(t, entries[0].StatusCode, 401)
+}
+
+func Test_BodyLimit(t *testing.T) {
+	cfg := common.GetTestConfig()
+	dbSession := cdbu.GetTestDBSession(t, true)
+	defer dbSession.Close()
+
+	tc := &tmocks.Client{}
+	tnc := &tmocks.NamespaceClient{}
+
+	tcfg, _ := cfg.GetTemporalConfig()
+	scp := sc.NewClientPool(tcfg)
+
+	srv := InitAPIServer(cfg, dbSession, tc, tnc, scp)
+
+	oversizedBody := make([]byte, 11<<20) // 11 MiB, exceeds the 10 MiB limit
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/%s/org/test-org/%s/site", cfg.GetAPIRouteVersion(), cfg.GetAPIName()), bytes.NewReader(oversizedBody))
+	req.Header.Set("Content-Type", "application/json")
+	srv.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+
+	normalBody := []byte(`{"name":"test"}`)
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/%s/org/test-org/%s/site", cfg.GetAPIRouteVersion(), cfg.GetAPIName()), bytes.NewReader(normalBody))
+	req2.Header.Set("Content-Type", "application/json")
+	srv.ServeHTTP(rec2, req2)
+	assert.NotEqual(t, http.StatusRequestEntityTooLarge, rec2.Code)
 }
 
 func Test_NotFoundHandler(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add a global 10 MiB request body size limit using Echo's BodyLimit middleware, which wraps `Request.Body` with `http.MaxBytesReader` and returns 413 when exceeded.
- Prevents the `AuditBody` middleware's `BodyDumpWithConfig` from buffering arbitrarily large request payloads in memory, eliminating the OOM crash vector for authenticated mutating endpoints.
- Add a regression test that verifies oversized POST requests are rejected with 413 and normal-sized requests pass through.

## Test plan

- [x] New `Test_BodyLimit` verifies 413 for 11 MiB POST and pass-through for normal body
- [x] Existing `Test_Audit`, `Test_InitAPIServer`, `Test_NotFoundHandler` pass unchanged
- [ ] CI pipeline validation