### PR TITLE
chore: Better tune power operation timer config

### DIFF
--- a/rla/examples/operation-rules-example.yaml
+++ b/rla/examples/operation-rules-example.yaml
@@ -66,8 +66,8 @@ rules:
         post_operation:
           # Verify power shelf status
           - name: VerifyPowerStatus
-            timeout: 30s
-            poll_interval: 5s
+            timeout: 90s
+            poll_interval: 10s
             parameters:
               expected_status: "on"
 
@@ -99,8 +99,8 @@ rules:
         post_operation:
           # Verify switch status
           - name: VerifyPowerStatus
-            timeout: 30s
-            poll_interval: 5s
+            timeout: 90s
+            poll_interval: 10s
             parameters:
               expected_status: "on"
 
@@ -125,8 +125,8 @@ rules:
         post_operation:
           # Verify compute node status
           - name: VerifyPowerStatus
-            timeout: 30s
-            poll_interval: 5s
+            timeout: 90s
+            poll_interval: 10s
             parameters:
               expected_status: "on"
 
@@ -150,8 +150,8 @@ rules:
 
         post_operation:
           - name: VerifyPowerStatus
-            timeout: 30s
-            poll_interval: 5s
+            timeout: 90s
+            poll_interval: 10s
             parameters:
               expected_status: "off"
 
@@ -174,8 +174,8 @@ rules:
 
         post_operation:
           - name: VerifyPowerStatus
-            timeout: 30s
-            poll_interval: 5s
+            timeout: 90s
+            poll_interval: 10s
             parameters:
               expected_status: "off"
 
@@ -204,8 +204,8 @@ rules:
 
         post_operation:
           - name: VerifyPowerStatus
-            timeout: 30s
-            poll_interval: 5s
+            timeout: 90s
+            poll_interval: 10s
             parameters:
               expected_status: "off"
 
@@ -457,8 +457,8 @@ rules:
 
         post_operation:
           - name: VerifyPowerStatus
-            timeout: 30s
-            poll_interval: 5s
+            timeout: 90s
+            poll_interval: 10s
             parameters:
               expected_status: "off"
 
@@ -477,8 +477,8 @@ rules:
 
         post_operation:
           - name: VerifyPowerStatus
-            timeout: 30s
-            poll_interval: 5s
+            timeout: 90s
+            poll_interval: 10s
             parameters:
               expected_status: "off"
 
@@ -497,8 +497,8 @@ rules:
 
         post_operation:
           - name: VerifyPowerStatus
-            timeout: 30s
-            poll_interval: 5s
+            timeout: 90s
+            poll_interval: 10s
             parameters:
               expected_status: "off"
 
@@ -524,8 +524,8 @@ rules:
 
         post_operation:
           - name: VerifyPowerStatus
-            timeout: 30s
-            poll_interval: 5s
+            timeout: 90s
+            poll_interval: 10s
             parameters:
               expected_status: "on"
 
@@ -554,8 +554,8 @@ rules:
 
         post_operation:
           - name: VerifyPowerStatus
-            timeout: 30s
-            poll_interval: 5s
+            timeout: 90s
+            poll_interval: 10s
             parameters:
               expected_status: "on"
 
@@ -578,8 +578,8 @@ rules:
 
         post_operation:
           - name: VerifyPowerStatus
-            timeout: 30s
-            poll_interval: 5s
+            timeout: 90s
+            poll_interval: 10s
             parameters:
               expected_status: "on"
 
@@ -902,7 +902,7 @@ rules:
 #   - Use verification in post_operation to confirm success
 #   - Include VerifyPowerStatus after PowerControl
 #   - Add VerifyReachability after powershelf power-on
-#   - Use appropriate timeouts for verification (30s-3m typical)
+#   - Use appropriate timeouts for verification (90s-3m typical)
 #
 # Forceful Operations:
 #   - Skip intermediate verification for speed

--- a/rla/internal/task/operationrules/resolver_defaults.go
+++ b/rla/internal/task/operationrules/resolver_defaults.go
@@ -87,8 +87,8 @@ func buildPowerOnRule() *OperationRule {
 						{
 							// Verify power status after operation
 							Name:         ActionVerifyPowerStatus,
-							Timeout:      15 * time.Second,
-							PollInterval: 5 * time.Second,
+							Timeout:      90 * time.Second,
+							PollInterval: 10 * time.Second,
 							Parameters: map[string]any{
 								ParamExpectedStatus: "on",
 							},
@@ -124,8 +124,8 @@ func buildPowerOnRule() *OperationRule {
 						{
 							// Verify power status
 							Name:         ActionVerifyPowerStatus,
-							Timeout:      15 * time.Second,
-							PollInterval: 5 * time.Second,
+							Timeout:      90 * time.Second,
+							PollInterval: 10 * time.Second,
 							Parameters: map[string]any{
 								ParamExpectedStatus: "on",
 							},
@@ -149,8 +149,8 @@ func buildPowerOnRule() *OperationRule {
 						{
 							// Verify power status
 							Name:         ActionVerifyPowerStatus,
-							Timeout:      15 * time.Second,
-							PollInterval: 5 * time.Second,
+							Timeout:      90 * time.Second,
+							PollInterval: 10 * time.Second,
 							Parameters: map[string]any{
 								ParamExpectedStatus: "on",
 							},
@@ -189,8 +189,8 @@ func buildPowerOffRule() *OperationRule {
 						{
 							// Verify power status after operation
 							Name:         ActionVerifyPowerStatus,
-							Timeout:      15 * time.Second,
-							PollInterval: 5 * time.Second,
+							Timeout:      90 * time.Second,
+							PollInterval: 10 * time.Second,
 							Parameters: map[string]any{
 								ParamExpectedStatus: "off",
 							},
@@ -214,8 +214,8 @@ func buildPowerOffRule() *OperationRule {
 						{
 							// Verify power status after operation
 							Name:         ActionVerifyPowerStatus,
-							Timeout:      15 * time.Second,
-							PollInterval: 5 * time.Second,
+							Timeout:      90 * time.Second,
+							PollInterval: 10 * time.Second,
 							Parameters: map[string]any{
 								ParamExpectedStatus: "off",
 							},
@@ -249,8 +249,8 @@ func buildPowerOffRule() *OperationRule {
 						{
 							// Verify power status after operation
 							Name:         ActionVerifyPowerStatus,
-							Timeout:      15 * time.Second,
-							PollInterval: 5 * time.Second,
+							Timeout:      90 * time.Second,
+							PollInterval: 10 * time.Second,
 							Parameters: map[string]any{
 								ParamExpectedStatus: "off",
 							},
@@ -290,8 +290,8 @@ func buildRestartRule() *OperationRule {
 						{
 							// Verify power status after operation
 							Name:         ActionVerifyPowerStatus,
-							Timeout:      15 * time.Second,
-							PollInterval: 5 * time.Second,
+							Timeout:      90 * time.Second,
+							PollInterval: 10 * time.Second,
 							Parameters: map[string]any{
 								ParamExpectedStatus: "off",
 							},
@@ -315,8 +315,8 @@ func buildRestartRule() *OperationRule {
 						{
 							// Verify power status after operation
 							Name:         ActionVerifyPowerStatus,
-							Timeout:      15 * time.Second,
-							PollInterval: 5 * time.Second,
+							Timeout:      90 * time.Second,
+							PollInterval: 10 * time.Second,
 							Parameters: map[string]any{
 								ParamExpectedStatus: "off",
 							},
@@ -340,8 +340,8 @@ func buildRestartRule() *OperationRule {
 						{
 							// Verify power status after operation
 							Name:         ActionVerifyPowerStatus,
-							Timeout:      15 * time.Second,
-							PollInterval: 5 * time.Second,
+							Timeout:      90 * time.Second,
+							PollInterval: 10 * time.Second,
 							Parameters: map[string]any{
 								ParamExpectedStatus: "off",
 							},
@@ -366,8 +366,8 @@ func buildRestartRule() *OperationRule {
 						{
 							// Verify power status after operation
 							Name:         ActionVerifyPowerStatus,
-							Timeout:      15 * time.Second,
-							PollInterval: 5 * time.Second,
+							Timeout:      90 * time.Second,
+							PollInterval: 10 * time.Second,
 							Parameters: map[string]any{
 								ParamExpectedStatus: "on",
 							},
@@ -404,8 +404,8 @@ func buildRestartRule() *OperationRule {
 						{
 							// Verify power status after operation
 							Name:         ActionVerifyPowerStatus,
-							Timeout:      15 * time.Second,
-							PollInterval: 5 * time.Second,
+							Timeout:      90 * time.Second,
+							PollInterval: 10 * time.Second,
 							Parameters: map[string]any{
 								ParamExpectedStatus: "on",
 							},
@@ -429,8 +429,8 @@ func buildRestartRule() *OperationRule {
 						{
 							// Verify power status after operation
 							Name:         ActionVerifyPowerStatus,
-							Timeout:      15 * time.Second,
-							PollInterval: 5 * time.Second,
+							Timeout:      90 * time.Second,
+							PollInterval: 10 * time.Second,
 							Parameters: map[string]any{
 								ParamExpectedStatus: "on",
 							},


### PR DESCRIPTION
## Description
The default timeout was too short and could cause premature failures. Adjusted it to a more appropriate value based on real environment testing.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [x] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [ ] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [x] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
