### PR TITLE
feat: Allow power control to NSM and PSM without registration

### DIFF
--- a/nvswitch-manager/docs/API_REFERENCE.md
+++ b/nvswitch-manager/docs/API_REFERENCE.md
@@ -489,24 +489,68 @@ grpcurl -plaintext -d '{
 
 ---
 
-### PowerCycle
+### PowerControl
 
-Issues a Redfish chassis power cycle for each specified NV-Switch tray.
+Performs a power action (e.g., PowerCycle, ForceOff, On) on one or more NV-Switch trays. Supports both registered switches (by UUID) and unregistered devices (by inline connection details via `PowerTarget`).
 
 ```protobuf
-rpc PowerCycle(NVSwitchRequest) returns (PowerControlResponse)
+rpc PowerControl(PowerControlRequest) returns (PowerControlResponse)
+```
+
+#### Request
+
+```protobuf
+message PowerControlRequest {
+    repeated string uuids = 1;          // Registered switches by UUID
+    PowerAction action = 2;
+    repeated PowerTarget targets = 3;   // Unregistered devices with inline credentials
+}
+
+message PowerTarget {
+    string bmc_ip = 1;
+    Credentials bmc_credentials = 2;
+    int32 bmc_port = 3;                 // 0 = default (443)
+}
+```
+
+#### Response
+
+```protobuf
+message PowerControlResponse {
+    repeated NVSwitchResponse responses = 1;
+}
+
+message NVSwitchResponse {
+    string uuid = 1;       // Set for registered switches; empty for direct targets
+    StatusCode status = 2;
+    string error = 3;
+    string bmc_ip = 4;     // Set for direct PowerTarget responses; empty for registered switches
+}
 ```
 
 #### Behavior
 
 - Returns per-switch status; partial failures are possible
+- For registered switches, `uuid` identifies the device in the response
+- For direct `PowerTarget` requests, `bmc_ip` identifies the device and `uuid` is empty
 
 #### Example
 
 ```bash
+# Registered switch by UUID
 grpcurl -plaintext -d '{
-  "uuids": ["uuid-1"]
-}' localhost:50051 v1.NVSwitchManager/PowerCycle
+  "uuids": ["uuid-1"],
+  "action": "POWER_ACTION_POWER_CYCLE"
+}' localhost:50051 v1.NVSwitchManager/PowerControl
+
+# Unregistered device via PowerTarget
+grpcurl -plaintext -d '{
+  "action": "POWER_ACTION_FORCE_OFF",
+  "targets": [{
+    "bmc_ip": "10.0.1.100",
+    "bmc_credentials": {"username": "admin", "password": "secret"}
+  }]
+}' localhost:50051 v1.NVSwitchManager/PowerControl
 ```
 
 ---

--- a/nvswitch-manager/internal/proto/v1/nvswitch-manager.pb.go
+++ b/nvswitch-manager/internal/proto/v1/nvswitch-manager.pb.go
@@ -1161,18 +1161,82 @@ func (x *NVSwitchResponse) GetError() string {
 	return ""
 }
 
+// PowerTarget allows power control against a device without prior registration.
+// Only IP and credentials are required; the registry and credential manager are bypassed.
+type PowerTarget struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	BmcIp          string                 `protobuf:"bytes,1,opt,name=bmc_ip,json=bmcIp,proto3" json:"bmc_ip,omitempty"`
+	BmcCredentials *Credentials           `protobuf:"bytes,2,opt,name=bmc_credentials,json=bmcCredentials,proto3" json:"bmc_credentials,omitempty"`
+	BmcPort        int32                  `protobuf:"varint,3,opt,name=bmc_port,json=bmcPort,proto3" json:"bmc_port,omitempty"` // 0 = default (443)
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *PowerTarget) Reset() {
+	*x = PowerTarget{}
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PowerTarget) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PowerTarget) ProtoMessage() {}
+
+func (x *PowerTarget) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PowerTarget.ProtoReflect.Descriptor instead.
+func (*PowerTarget) Descriptor() ([]byte, []int) {
+	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *PowerTarget) GetBmcIp() string {
+	if x != nil {
+		return x.BmcIp
+	}
+	return ""
+}
+
+func (x *PowerTarget) GetBmcCredentials() *Credentials {
+	if x != nil {
+		return x.BmcCredentials
+	}
+	return nil
+}
+
+func (x *PowerTarget) GetBmcPort() int32 {
+	if x != nil {
+		return x.BmcPort
+	}
+	return 0
+}
+
 // PowerControlRequest specifies the switches and the power action to perform.
+// Registered switches are identified by UUID; unregistered devices use PowerTarget.
 type PowerControlRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Uuids         []string               `protobuf:"bytes,1,rep,name=uuids,proto3" json:"uuids,omitempty"`
 	Action        PowerAction            `protobuf:"varint,2,opt,name=action,proto3,enum=v1.PowerAction" json:"action,omitempty"`
+	Targets       []*PowerTarget         `protobuf:"bytes,3,rep,name=targets,proto3" json:"targets,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *PowerControlRequest) Reset() {
 	*x = PowerControlRequest{}
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[12]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1184,7 +1248,7 @@ func (x *PowerControlRequest) String() string {
 func (*PowerControlRequest) ProtoMessage() {}
 
 func (x *PowerControlRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[12]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1197,7 +1261,7 @@ func (x *PowerControlRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PowerControlRequest.ProtoReflect.Descriptor instead.
 func (*PowerControlRequest) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{12}
+	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *PowerControlRequest) GetUuids() []string {
@@ -1214,6 +1278,13 @@ func (x *PowerControlRequest) GetAction() PowerAction {
 	return PowerAction_POWER_ACTION_UNKNOWN
 }
 
+func (x *PowerControlRequest) GetTargets() []*PowerTarget {
+	if x != nil {
+		return x.Targets
+	}
+	return nil
+}
+
 type PowerControlResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Responses     []*NVSwitchResponse    `protobuf:"bytes,1,rep,name=responses,proto3" json:"responses,omitempty"`
@@ -1223,7 +1294,7 @@ type PowerControlResponse struct {
 
 func (x *PowerControlResponse) Reset() {
 	*x = PowerControlResponse{}
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[13]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1235,7 +1306,7 @@ func (x *PowerControlResponse) String() string {
 func (*PowerControlResponse) ProtoMessage() {}
 
 func (x *PowerControlResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[13]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1248,7 +1319,7 @@ func (x *PowerControlResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PowerControlResponse.ProtoReflect.Descriptor instead.
 func (*PowerControlResponse) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{13}
+	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *PowerControlResponse) GetResponses() []*NVSwitchResponse {
@@ -1267,7 +1338,7 @@ type GetNVSwitchesResponse struct {
 
 func (x *GetNVSwitchesResponse) Reset() {
 	*x = GetNVSwitchesResponse{}
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[14]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1279,7 +1350,7 @@ func (x *GetNVSwitchesResponse) String() string {
 func (*GetNVSwitchesResponse) ProtoMessage() {}
 
 func (x *GetNVSwitchesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[14]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1292,7 +1363,7 @@ func (x *GetNVSwitchesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNVSwitchesResponse.ProtoReflect.Descriptor instead.
 func (*GetNVSwitchesResponse) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{14}
+	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *GetNVSwitchesResponse) GetNvswitches() []*NVSwitchTray {
@@ -1314,7 +1385,7 @@ type FirmwareBundle struct {
 
 func (x *FirmwareBundle) Reset() {
 	*x = FirmwareBundle{}
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[15]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1326,7 +1397,7 @@ func (x *FirmwareBundle) String() string {
 func (*FirmwareBundle) ProtoMessage() {}
 
 func (x *FirmwareBundle) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[15]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1339,7 +1410,7 @@ func (x *FirmwareBundle) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FirmwareBundle.ProtoReflect.Descriptor instead.
 func (*FirmwareBundle) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{15}
+	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *FirmwareBundle) GetVersion() string {
@@ -1375,7 +1446,7 @@ type ComponentInfo struct {
 
 func (x *ComponentInfo) Reset() {
 	*x = ComponentInfo{}
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[16]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1387,7 +1458,7 @@ func (x *ComponentInfo) String() string {
 func (*ComponentInfo) ProtoMessage() {}
 
 func (x *ComponentInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[16]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1400,7 +1471,7 @@ func (x *ComponentInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ComponentInfo.ProtoReflect.Descriptor instead.
 func (*ComponentInfo) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{16}
+	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ComponentInfo) GetName() string {
@@ -1434,7 +1505,7 @@ type ListBundlesResponse struct {
 
 func (x *ListBundlesResponse) Reset() {
 	*x = ListBundlesResponse{}
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[17]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1446,7 +1517,7 @@ func (x *ListBundlesResponse) String() string {
 func (*ListBundlesResponse) ProtoMessage() {}
 
 func (x *ListBundlesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[17]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1459,7 +1530,7 @@ func (x *ListBundlesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBundlesResponse.ProtoReflect.Descriptor instead.
 func (*ListBundlesResponse) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{17}
+	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ListBundlesResponse) GetBundles() []*FirmwareBundle {
@@ -1482,7 +1553,7 @@ type QueueUpdateRequest struct {
 
 func (x *QueueUpdateRequest) Reset() {
 	*x = QueueUpdateRequest{}
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[18]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1494,7 +1565,7 @@ func (x *QueueUpdateRequest) String() string {
 func (*QueueUpdateRequest) ProtoMessage() {}
 
 func (x *QueueUpdateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[18]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1507,7 +1578,7 @@ func (x *QueueUpdateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueueUpdateRequest.ProtoReflect.Descriptor instead.
 func (*QueueUpdateRequest) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{18}
+	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *QueueUpdateRequest) GetSwitchUuid() string {
@@ -1541,7 +1612,7 @@ type QueueUpdateResponse struct {
 
 func (x *QueueUpdateResponse) Reset() {
 	*x = QueueUpdateResponse{}
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[19]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1553,7 +1624,7 @@ func (x *QueueUpdateResponse) String() string {
 func (*QueueUpdateResponse) ProtoMessage() {}
 
 func (x *QueueUpdateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[19]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1566,7 +1637,7 @@ func (x *QueueUpdateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueueUpdateResponse.ProtoReflect.Descriptor instead.
 func (*QueueUpdateResponse) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{19}
+	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *QueueUpdateResponse) GetUpdates() []*FirmwareUpdateInfo {
@@ -1588,7 +1659,7 @@ type QueueUpdatesRequest struct {
 
 func (x *QueueUpdatesRequest) Reset() {
 	*x = QueueUpdatesRequest{}
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[20]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1600,7 +1671,7 @@ func (x *QueueUpdatesRequest) String() string {
 func (*QueueUpdatesRequest) ProtoMessage() {}
 
 func (x *QueueUpdatesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[20]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1613,7 +1684,7 @@ func (x *QueueUpdatesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueueUpdatesRequest.ProtoReflect.Descriptor instead.
 func (*QueueUpdatesRequest) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{20}
+	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *QueueUpdatesRequest) GetSwitchUuids() []string {
@@ -1647,7 +1718,7 @@ type QueueUpdatesResponse struct {
 
 func (x *QueueUpdatesResponse) Reset() {
 	*x = QueueUpdatesResponse{}
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[21]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1659,7 +1730,7 @@ func (x *QueueUpdatesResponse) String() string {
 func (*QueueUpdatesResponse) ProtoMessage() {}
 
 func (x *QueueUpdatesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[21]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1672,7 +1743,7 @@ func (x *QueueUpdatesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueueUpdatesResponse.ProtoReflect.Descriptor instead.
 func (*QueueUpdatesResponse) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{21}
+	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *QueueUpdatesResponse) GetResults() []*QueueUpdateResult {
@@ -1695,7 +1766,7 @@ type QueueUpdateResult struct {
 
 func (x *QueueUpdateResult) Reset() {
 	*x = QueueUpdateResult{}
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[22]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1707,7 +1778,7 @@ func (x *QueueUpdateResult) String() string {
 func (*QueueUpdateResult) ProtoMessage() {}
 
 func (x *QueueUpdateResult) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[22]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1720,7 +1791,7 @@ func (x *QueueUpdateResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueueUpdateResult.ProtoReflect.Descriptor instead.
 func (*QueueUpdateResult) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{22}
+	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *QueueUpdateResult) GetSwitchUuid() string {
@@ -1761,7 +1832,7 @@ type GetUpdateRequest struct {
 
 func (x *GetUpdateRequest) Reset() {
 	*x = GetUpdateRequest{}
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[23]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1773,7 +1844,7 @@ func (x *GetUpdateRequest) String() string {
 func (*GetUpdateRequest) ProtoMessage() {}
 
 func (x *GetUpdateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[23]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1786,7 +1857,7 @@ func (x *GetUpdateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUpdateRequest.ProtoReflect.Descriptor instead.
 func (*GetUpdateRequest) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{23}
+	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *GetUpdateRequest) GetUpdateId() string {
@@ -1806,7 +1877,7 @@ type GetUpdateResponse struct {
 
 func (x *GetUpdateResponse) Reset() {
 	*x = GetUpdateResponse{}
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[24]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1818,7 +1889,7 @@ func (x *GetUpdateResponse) String() string {
 func (*GetUpdateResponse) ProtoMessage() {}
 
 func (x *GetUpdateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[24]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1831,7 +1902,7 @@ func (x *GetUpdateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUpdateResponse.ProtoReflect.Descriptor instead.
 func (*GetUpdateResponse) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{24}
+	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *GetUpdateResponse) GetUpdate() *FirmwareUpdateInfo {
@@ -1851,7 +1922,7 @@ type GetUpdatesForSwitchRequest struct {
 
 func (x *GetUpdatesForSwitchRequest) Reset() {
 	*x = GetUpdatesForSwitchRequest{}
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[25]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1863,7 +1934,7 @@ func (x *GetUpdatesForSwitchRequest) String() string {
 func (*GetUpdatesForSwitchRequest) ProtoMessage() {}
 
 func (x *GetUpdatesForSwitchRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[25]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1876,7 +1947,7 @@ func (x *GetUpdatesForSwitchRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUpdatesForSwitchRequest.ProtoReflect.Descriptor instead.
 func (*GetUpdatesForSwitchRequest) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{25}
+	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *GetUpdatesForSwitchRequest) GetSwitchUuid() string {
@@ -1896,7 +1967,7 @@ type GetUpdatesForSwitchResponse struct {
 
 func (x *GetUpdatesForSwitchResponse) Reset() {
 	*x = GetUpdatesForSwitchResponse{}
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[26]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1908,7 +1979,7 @@ func (x *GetUpdatesForSwitchResponse) String() string {
 func (*GetUpdatesForSwitchResponse) ProtoMessage() {}
 
 func (x *GetUpdatesForSwitchResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[26]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1921,7 +1992,7 @@ func (x *GetUpdatesForSwitchResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUpdatesForSwitchResponse.ProtoReflect.Descriptor instead.
 func (*GetUpdatesForSwitchResponse) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{26}
+	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *GetUpdatesForSwitchResponse) GetUpdates() []*FirmwareUpdateInfo {
@@ -1941,7 +2012,7 @@ type GetAllUpdatesResponse struct {
 
 func (x *GetAllUpdatesResponse) Reset() {
 	*x = GetAllUpdatesResponse{}
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[27]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1953,7 +2024,7 @@ func (x *GetAllUpdatesResponse) String() string {
 func (*GetAllUpdatesResponse) ProtoMessage() {}
 
 func (x *GetAllUpdatesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[27]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1966,7 +2037,7 @@ func (x *GetAllUpdatesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAllUpdatesResponse.ProtoReflect.Descriptor instead.
 func (*GetAllUpdatesResponse) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{27}
+	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *GetAllUpdatesResponse) GetUpdates() []*FirmwareUpdateInfo {
@@ -1986,7 +2057,7 @@ type CancelUpdateRequest struct {
 
 func (x *CancelUpdateRequest) Reset() {
 	*x = CancelUpdateRequest{}
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[28]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1998,7 +2069,7 @@ func (x *CancelUpdateRequest) String() string {
 func (*CancelUpdateRequest) ProtoMessage() {}
 
 func (x *CancelUpdateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[28]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2011,7 +2082,7 @@ func (x *CancelUpdateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelUpdateRequest.ProtoReflect.Descriptor instead.
 func (*CancelUpdateRequest) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{28}
+	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *CancelUpdateRequest) GetUpdateId() string {
@@ -2032,7 +2103,7 @@ type CancelUpdateResponse struct {
 
 func (x *CancelUpdateResponse) Reset() {
 	*x = CancelUpdateResponse{}
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[29]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2044,7 +2115,7 @@ func (x *CancelUpdateResponse) String() string {
 func (*CancelUpdateResponse) ProtoMessage() {}
 
 func (x *CancelUpdateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[29]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2057,7 +2128,7 @@ func (x *CancelUpdateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelUpdateResponse.ProtoReflect.Descriptor instead.
 func (*CancelUpdateResponse) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{29}
+	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *CancelUpdateResponse) GetSuccess() bool {
@@ -2099,7 +2170,7 @@ type FirmwareUpdateInfo struct {
 
 func (x *FirmwareUpdateInfo) Reset() {
 	*x = FirmwareUpdateInfo{}
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[30]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2111,7 +2182,7 @@ func (x *FirmwareUpdateInfo) String() string {
 func (*FirmwareUpdateInfo) ProtoMessage() {}
 
 func (x *FirmwareUpdateInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[30]
+	mi := &file_internal_proto_v1_nvswitch_manager_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2124,7 +2195,7 @@ func (x *FirmwareUpdateInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FirmwareUpdateInfo.ProtoReflect.Descriptor instead.
 func (*FirmwareUpdateInfo) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{30}
+	return file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *FirmwareUpdateInfo) GetId() string {
@@ -2300,10 +2371,15 @@ const file_internal_proto_v1_nvswitch_manager_proto_rawDesc = "" +
 	"\x10NVSwitchResponse\x12\x12\n" +
 	"\x04uuid\x18\x01 \x01(\tR\x04uuid\x12&\n" +
 	"\x06status\x18\x02 \x01(\x0e2\x0e.v1.StatusCodeR\x06status\x12\x14\n" +
-	"\x05error\x18\x03 \x01(\tR\x05error\"T\n" +
+	"\x05error\x18\x03 \x01(\tR\x05error\"y\n" +
+	"\vPowerTarget\x12\x15\n" +
+	"\x06bmc_ip\x18\x01 \x01(\tR\x05bmcIp\x128\n" +
+	"\x0fbmc_credentials\x18\x02 \x01(\v2\x0f.v1.CredentialsR\x0ebmcCredentials\x12\x19\n" +
+	"\bbmc_port\x18\x03 \x01(\x05R\abmcPort\"\x7f\n" +
 	"\x13PowerControlRequest\x12\x14\n" +
 	"\x05uuids\x18\x01 \x03(\tR\x05uuids\x12'\n" +
-	"\x06action\x18\x02 \x01(\x0e2\x0f.v1.PowerActionR\x06action\"J\n" +
+	"\x06action\x18\x02 \x01(\x0e2\x0f.v1.PowerActionR\x06action\x12)\n" +
+	"\atargets\x18\x03 \x03(\v2\x0f.v1.PowerTargetR\atargets\"J\n" +
 	"\x14PowerControlResponse\x122\n" +
 	"\tresponses\x18\x01 \x03(\v2\x14.v1.NVSwitchResponseR\tresponses\"I\n" +
 	"\x15GetNVSwitchesResponse\x120\n" +
@@ -2451,7 +2527,7 @@ func file_internal_proto_v1_nvswitch_manager_proto_rawDescGZIP() []byte {
 }
 
 var file_internal_proto_v1_nvswitch_manager_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
-var file_internal_proto_v1_nvswitch_manager_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
+var file_internal_proto_v1_nvswitch_manager_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
 var file_internal_proto_v1_nvswitch_manager_proto_goTypes = []any{
 	(Vendor)(0),                         // 0: v1.Vendor
 	(StatusCode)(0),                     // 1: v1.StatusCode
@@ -2471,27 +2547,28 @@ var file_internal_proto_v1_nvswitch_manager_proto_goTypes = []any{
 	(*RegisterNVSwitchesResponse)(nil),  // 15: v1.RegisterNVSwitchesResponse
 	(*NVSwitchRequest)(nil),             // 16: v1.NVSwitchRequest
 	(*NVSwitchResponse)(nil),            // 17: v1.NVSwitchResponse
-	(*PowerControlRequest)(nil),         // 18: v1.PowerControlRequest
-	(*PowerControlResponse)(nil),        // 19: v1.PowerControlResponse
-	(*GetNVSwitchesResponse)(nil),       // 20: v1.GetNVSwitchesResponse
-	(*FirmwareBundle)(nil),              // 21: v1.FirmwareBundle
-	(*ComponentInfo)(nil),               // 22: v1.ComponentInfo
-	(*ListBundlesResponse)(nil),         // 23: v1.ListBundlesResponse
-	(*QueueUpdateRequest)(nil),          // 24: v1.QueueUpdateRequest
-	(*QueueUpdateResponse)(nil),         // 25: v1.QueueUpdateResponse
-	(*QueueUpdatesRequest)(nil),         // 26: v1.QueueUpdatesRequest
-	(*QueueUpdatesResponse)(nil),        // 27: v1.QueueUpdatesResponse
-	(*QueueUpdateResult)(nil),           // 28: v1.QueueUpdateResult
-	(*GetUpdateRequest)(nil),            // 29: v1.GetUpdateRequest
-	(*GetUpdateResponse)(nil),           // 30: v1.GetUpdateResponse
-	(*GetUpdatesForSwitchRequest)(nil),  // 31: v1.GetUpdatesForSwitchRequest
-	(*GetUpdatesForSwitchResponse)(nil), // 32: v1.GetUpdatesForSwitchResponse
-	(*GetAllUpdatesResponse)(nil),       // 33: v1.GetAllUpdatesResponse
-	(*CancelUpdateRequest)(nil),         // 34: v1.CancelUpdateRequest
-	(*CancelUpdateResponse)(nil),        // 35: v1.CancelUpdateResponse
-	(*FirmwareUpdateInfo)(nil),          // 36: v1.FirmwareUpdateInfo
-	(*timestamppb.Timestamp)(nil),       // 37: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),               // 38: google.protobuf.Empty
+	(*PowerTarget)(nil),                 // 18: v1.PowerTarget
+	(*PowerControlRequest)(nil),         // 19: v1.PowerControlRequest
+	(*PowerControlResponse)(nil),        // 20: v1.PowerControlResponse
+	(*GetNVSwitchesResponse)(nil),       // 21: v1.GetNVSwitchesResponse
+	(*FirmwareBundle)(nil),              // 22: v1.FirmwareBundle
+	(*ComponentInfo)(nil),               // 23: v1.ComponentInfo
+	(*ListBundlesResponse)(nil),         // 24: v1.ListBundlesResponse
+	(*QueueUpdateRequest)(nil),          // 25: v1.QueueUpdateRequest
+	(*QueueUpdateResponse)(nil),         // 26: v1.QueueUpdateResponse
+	(*QueueUpdatesRequest)(nil),         // 27: v1.QueueUpdatesRequest
+	(*QueueUpdatesResponse)(nil),        // 28: v1.QueueUpdatesResponse
+	(*QueueUpdateResult)(nil),           // 29: v1.QueueUpdateResult
+	(*GetUpdateRequest)(nil),            // 30: v1.GetUpdateRequest
+	(*GetUpdateResponse)(nil),           // 31: v1.GetUpdateResponse
+	(*GetUpdatesForSwitchRequest)(nil),  // 32: v1.GetUpdatesForSwitchRequest
+	(*GetUpdatesForSwitchResponse)(nil), // 33: v1.GetUpdatesForSwitchResponse
+	(*GetAllUpdatesResponse)(nil),       // 34: v1.GetAllUpdatesResponse
+	(*CancelUpdateRequest)(nil),         // 35: v1.CancelUpdateRequest
+	(*CancelUpdateResponse)(nil),        // 36: v1.CancelUpdateResponse
+	(*FirmwareUpdateInfo)(nil),          // 37: v1.FirmwareUpdateInfo
+	(*timestamppb.Timestamp)(nil),       // 38: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),               // 39: google.protobuf.Empty
 }
 var file_internal_proto_v1_nvswitch_manager_proto_depIdxs = []int32{
 	6,  // 0: v1.Subsystem.credentials:type_name -> v1.Credentials
@@ -2503,54 +2580,56 @@ var file_internal_proto_v1_nvswitch_manager_proto_depIdxs = []int32{
 	7,  // 6: v1.RegisterNVSwitchRequest.bmc:type_name -> v1.Subsystem
 	7,  // 7: v1.RegisterNVSwitchRequest.nvos:type_name -> v1.Subsystem
 	12, // 8: v1.RegisterNVSwitchesRequest.registration_requests:type_name -> v1.RegisterNVSwitchRequest
-	37, // 9: v1.RegisterNVSwitchResponse.created:type_name -> google.protobuf.Timestamp
+	38, // 9: v1.RegisterNVSwitchResponse.created:type_name -> google.protobuf.Timestamp
 	1,  // 10: v1.RegisterNVSwitchResponse.status:type_name -> v1.StatusCode
 	14, // 11: v1.RegisterNVSwitchesResponse.responses:type_name -> v1.RegisterNVSwitchResponse
 	1,  // 12: v1.NVSwitchResponse.status:type_name -> v1.StatusCode
-	2,  // 13: v1.PowerControlRequest.action:type_name -> v1.PowerAction
-	17, // 14: v1.PowerControlResponse.responses:type_name -> v1.NVSwitchResponse
-	11, // 15: v1.GetNVSwitchesResponse.nvswitches:type_name -> v1.NVSwitchTray
-	22, // 16: v1.FirmwareBundle.components:type_name -> v1.ComponentInfo
-	21, // 17: v1.ListBundlesResponse.bundles:type_name -> v1.FirmwareBundle
-	3,  // 18: v1.QueueUpdateRequest.components:type_name -> v1.NVSwitchComponent
-	36, // 19: v1.QueueUpdateResponse.updates:type_name -> v1.FirmwareUpdateInfo
-	3,  // 20: v1.QueueUpdatesRequest.components:type_name -> v1.NVSwitchComponent
-	28, // 21: v1.QueueUpdatesResponse.results:type_name -> v1.QueueUpdateResult
-	1,  // 22: v1.QueueUpdateResult.status:type_name -> v1.StatusCode
-	36, // 23: v1.QueueUpdateResult.updates:type_name -> v1.FirmwareUpdateInfo
-	36, // 24: v1.GetUpdateResponse.update:type_name -> v1.FirmwareUpdateInfo
-	36, // 25: v1.GetUpdatesForSwitchResponse.updates:type_name -> v1.FirmwareUpdateInfo
-	36, // 26: v1.GetAllUpdatesResponse.updates:type_name -> v1.FirmwareUpdateInfo
-	3,  // 27: v1.FirmwareUpdateInfo.component:type_name -> v1.NVSwitchComponent
-	4,  // 28: v1.FirmwareUpdateInfo.strategy:type_name -> v1.UpdateStrategy
-	5,  // 29: v1.FirmwareUpdateInfo.state:type_name -> v1.UpdateState
-	37, // 30: v1.FirmwareUpdateInfo.created_at:type_name -> google.protobuf.Timestamp
-	37, // 31: v1.FirmwareUpdateInfo.updated_at:type_name -> google.protobuf.Timestamp
-	13, // 32: v1.NVSwitchManager.RegisterNVSwitches:input_type -> v1.RegisterNVSwitchesRequest
-	16, // 33: v1.NVSwitchManager.GetNVSwitches:input_type -> v1.NVSwitchRequest
-	38, // 34: v1.NVSwitchManager.ListBundles:input_type -> google.protobuf.Empty
-	24, // 35: v1.NVSwitchManager.QueueUpdate:input_type -> v1.QueueUpdateRequest
-	26, // 36: v1.NVSwitchManager.QueueUpdates:input_type -> v1.QueueUpdatesRequest
-	29, // 37: v1.NVSwitchManager.GetUpdate:input_type -> v1.GetUpdateRequest
-	31, // 38: v1.NVSwitchManager.GetUpdatesForSwitch:input_type -> v1.GetUpdatesForSwitchRequest
-	38, // 39: v1.NVSwitchManager.GetAllUpdates:input_type -> google.protobuf.Empty
-	34, // 40: v1.NVSwitchManager.CancelUpdate:input_type -> v1.CancelUpdateRequest
-	18, // 41: v1.NVSwitchManager.PowerControl:input_type -> v1.PowerControlRequest
-	15, // 42: v1.NVSwitchManager.RegisterNVSwitches:output_type -> v1.RegisterNVSwitchesResponse
-	20, // 43: v1.NVSwitchManager.GetNVSwitches:output_type -> v1.GetNVSwitchesResponse
-	23, // 44: v1.NVSwitchManager.ListBundles:output_type -> v1.ListBundlesResponse
-	25, // 45: v1.NVSwitchManager.QueueUpdate:output_type -> v1.QueueUpdateResponse
-	27, // 46: v1.NVSwitchManager.QueueUpdates:output_type -> v1.QueueUpdatesResponse
-	30, // 47: v1.NVSwitchManager.GetUpdate:output_type -> v1.GetUpdateResponse
-	32, // 48: v1.NVSwitchManager.GetUpdatesForSwitch:output_type -> v1.GetUpdatesForSwitchResponse
-	33, // 49: v1.NVSwitchManager.GetAllUpdates:output_type -> v1.GetAllUpdatesResponse
-	35, // 50: v1.NVSwitchManager.CancelUpdate:output_type -> v1.CancelUpdateResponse
-	19, // 51: v1.NVSwitchManager.PowerControl:output_type -> v1.PowerControlResponse
-	42, // [42:52] is the sub-list for method output_type
-	32, // [32:42] is the sub-list for method input_type
-	32, // [32:32] is the sub-list for extension type_name
-	32, // [32:32] is the sub-list for extension extendee
-	0,  // [0:32] is the sub-list for field type_name
+	6,  // 13: v1.PowerTarget.bmc_credentials:type_name -> v1.Credentials
+	2,  // 14: v1.PowerControlRequest.action:type_name -> v1.PowerAction
+	18, // 15: v1.PowerControlRequest.targets:type_name -> v1.PowerTarget
+	17, // 16: v1.PowerControlResponse.responses:type_name -> v1.NVSwitchResponse
+	11, // 17: v1.GetNVSwitchesResponse.nvswitches:type_name -> v1.NVSwitchTray
+	23, // 18: v1.FirmwareBundle.components:type_name -> v1.ComponentInfo
+	22, // 19: v1.ListBundlesResponse.bundles:type_name -> v1.FirmwareBundle
+	3,  // 20: v1.QueueUpdateRequest.components:type_name -> v1.NVSwitchComponent
+	37, // 21: v1.QueueUpdateResponse.updates:type_name -> v1.FirmwareUpdateInfo
+	3,  // 22: v1.QueueUpdatesRequest.components:type_name -> v1.NVSwitchComponent
+	29, // 23: v1.QueueUpdatesResponse.results:type_name -> v1.QueueUpdateResult
+	1,  // 24: v1.QueueUpdateResult.status:type_name -> v1.StatusCode
+	37, // 25: v1.QueueUpdateResult.updates:type_name -> v1.FirmwareUpdateInfo
+	37, // 26: v1.GetUpdateResponse.update:type_name -> v1.FirmwareUpdateInfo
+	37, // 27: v1.GetUpdatesForSwitchResponse.updates:type_name -> v1.FirmwareUpdateInfo
+	37, // 28: v1.GetAllUpdatesResponse.updates:type_name -> v1.FirmwareUpdateInfo
+	3,  // 29: v1.FirmwareUpdateInfo.component:type_name -> v1.NVSwitchComponent
+	4,  // 30: v1.FirmwareUpdateInfo.strategy:type_name -> v1.UpdateStrategy
+	5,  // 31: v1.FirmwareUpdateInfo.state:type_name -> v1.UpdateState
+	38, // 32: v1.FirmwareUpdateInfo.created_at:type_name -> google.protobuf.Timestamp
+	38, // 33: v1.FirmwareUpdateInfo.updated_at:type_name -> google.protobuf.Timestamp
+	13, // 34: v1.NVSwitchManager.RegisterNVSwitches:input_type -> v1.RegisterNVSwitchesRequest
+	16, // 35: v1.NVSwitchManager.GetNVSwitches:input_type -> v1.NVSwitchRequest
+	39, // 36: v1.NVSwitchManager.ListBundles:input_type -> google.protobuf.Empty
+	25, // 37: v1.NVSwitchManager.QueueUpdate:input_type -> v1.QueueUpdateRequest
+	27, // 38: v1.NVSwitchManager.QueueUpdates:input_type -> v1.QueueUpdatesRequest
+	30, // 39: v1.NVSwitchManager.GetUpdate:input_type -> v1.GetUpdateRequest
+	32, // 40: v1.NVSwitchManager.GetUpdatesForSwitch:input_type -> v1.GetUpdatesForSwitchRequest
+	39, // 41: v1.NVSwitchManager.GetAllUpdates:input_type -> google.protobuf.Empty
+	35, // 42: v1.NVSwitchManager.CancelUpdate:input_type -> v1.CancelUpdateRequest
+	19, // 43: v1.NVSwitchManager.PowerControl:input_type -> v1.PowerControlRequest
+	15, // 44: v1.NVSwitchManager.RegisterNVSwitches:output_type -> v1.RegisterNVSwitchesResponse
+	21, // 45: v1.NVSwitchManager.GetNVSwitches:output_type -> v1.GetNVSwitchesResponse
+	24, // 46: v1.NVSwitchManager.ListBundles:output_type -> v1.ListBundlesResponse
+	26, // 47: v1.NVSwitchManager.QueueUpdate:output_type -> v1.QueueUpdateResponse
+	28, // 48: v1.NVSwitchManager.QueueUpdates:output_type -> v1.QueueUpdatesResponse
+	31, // 49: v1.NVSwitchManager.GetUpdate:output_type -> v1.GetUpdateResponse
+	33, // 50: v1.NVSwitchManager.GetUpdatesForSwitch:output_type -> v1.GetUpdatesForSwitchResponse
+	34, // 51: v1.NVSwitchManager.GetAllUpdates:output_type -> v1.GetAllUpdatesResponse
+	36, // 52: v1.NVSwitchManager.CancelUpdate:output_type -> v1.CancelUpdateResponse
+	20, // 53: v1.NVSwitchManager.PowerControl:output_type -> v1.PowerControlResponse
+	44, // [44:54] is the sub-list for method output_type
+	34, // [34:44] is the sub-list for method input_type
+	34, // [34:34] is the sub-list for extension type_name
+	34, // [34:34] is the sub-list for extension extendee
+	0,  // [0:34] is the sub-list for field type_name
 }
 
 func init() { file_internal_proto_v1_nvswitch_manager_proto_init() }
@@ -2564,7 +2643,7 @@ func file_internal_proto_v1_nvswitch_manager_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internal_proto_v1_nvswitch_manager_proto_rawDesc), len(file_internal_proto_v1_nvswitch_manager_proto_rawDesc)),
 			NumEnums:      6,
-			NumMessages:   31,
+			NumMessages:   32,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/nvswitch-manager/internal/proto/v1/nvswitch-manager.pb.go
+++ b/nvswitch-manager/internal/proto/v1/nvswitch-manager.pb.go
@@ -1106,6 +1106,7 @@ type NVSwitchResponse struct {
 	Uuid          string                 `protobuf:"bytes,1,opt,name=uuid,proto3" json:"uuid,omitempty"`
 	Status        StatusCode             `protobuf:"varint,2,opt,name=status,proto3,enum=v1.StatusCode" json:"status,omitempty"`
 	Error         string                 `protobuf:"bytes,3,opt,name=error,proto3" json:"error,omitempty"`
+	BmcIp         string                 `protobuf:"bytes,4,opt,name=bmc_ip,json=bmcIp,proto3" json:"bmc_ip,omitempty"` // Set for direct PowerTarget responses; empty for registered switches
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1157,6 +1158,13 @@ func (x *NVSwitchResponse) GetStatus() StatusCode {
 func (x *NVSwitchResponse) GetError() string {
 	if x != nil {
 		return x.Error
+	}
+	return ""
+}
+
+func (x *NVSwitchResponse) GetBmcIp() string {
+	if x != nil {
+		return x.BmcIp
 	}
 	return ""
 }
@@ -2367,11 +2375,12 @@ const file_internal_proto_v1_nvswitch_manager_proto_rawDesc = "" +
 	"\x1aRegisterNVSwitchesResponse\x12:\n" +
 	"\tresponses\x18\x01 \x03(\v2\x1c.v1.RegisterNVSwitchResponseR\tresponses\"'\n" +
 	"\x0fNVSwitchRequest\x12\x14\n" +
-	"\x05uuids\x18\x01 \x03(\tR\x05uuids\"d\n" +
+	"\x05uuids\x18\x01 \x03(\tR\x05uuids\"{\n" +
 	"\x10NVSwitchResponse\x12\x12\n" +
 	"\x04uuid\x18\x01 \x01(\tR\x04uuid\x12&\n" +
 	"\x06status\x18\x02 \x01(\x0e2\x0e.v1.StatusCodeR\x06status\x12\x14\n" +
-	"\x05error\x18\x03 \x01(\tR\x05error\"y\n" +
+	"\x05error\x18\x03 \x01(\tR\x05error\x12\x15\n" +
+	"\x06bmc_ip\x18\x04 \x01(\tR\x05bmcIp\"y\n" +
 	"\vPowerTarget\x12\x15\n" +
 	"\x06bmc_ip\x18\x01 \x01(\tR\x05bmcIp\x128\n" +
 	"\x0fbmc_credentials\x18\x02 \x01(\v2\x0f.v1.CredentialsR\x0ebmcCredentials\x12\x19\n" +

--- a/nvswitch-manager/internal/proto/v1/nvswitch-manager.proto
+++ b/nvswitch-manager/internal/proto/v1/nvswitch-manager.proto
@@ -152,6 +152,7 @@ message NVSwitchResponse {
     string uuid = 1;
     StatusCode status = 2;
     string error = 3;
+    string bmc_ip = 4;  // Set for direct PowerTarget responses; empty for registered switches
 }
 
 // PowerAction enumerates the Redfish ComputerSystem.Reset actions supported by NV-Switch trays.

--- a/nvswitch-manager/internal/proto/v1/nvswitch-manager.proto
+++ b/nvswitch-manager/internal/proto/v1/nvswitch-manager.proto
@@ -166,10 +166,20 @@ enum PowerAction {
     POWER_ACTION_FORCE_RESTART = 7;
 }
 
+// PowerTarget allows power control against a device without prior registration.
+// Only IP and credentials are required; the registry and credential manager are bypassed.
+message PowerTarget {
+    string bmc_ip = 1;
+    Credentials bmc_credentials = 2;
+    int32 bmc_port = 3; // 0 = default (443)
+}
+
 // PowerControlRequest specifies the switches and the power action to perform.
+// Registered switches are identified by UUID; unregistered devices use PowerTarget.
 message PowerControlRequest {
     repeated string uuids = 1;
     PowerAction action = 2;
+    repeated PowerTarget targets = 3;
 }
 
 message PowerControlResponse {

--- a/nvswitch-manager/internal/service/server_impl.go
+++ b/nvswitch-manager/internal/service/server_impl.go
@@ -290,6 +290,14 @@ func resetTarget(ctx context.Context, target *pb.PowerTarget, resetType redfish.
 		}
 	}
 
+	if target.BmcCredentials.Username == "" || target.BmcCredentials.Password == "" {
+		return &pb.NVSwitchResponse{
+			Uuid:   target.BmcIp,
+			Status: pb.StatusCode_INVALID_ARGUMENT,
+			Error:  "bmc_credentials username and password must not be empty",
+		}
+	}
+
 	cred := credential.New(target.BmcCredentials.Username, target.BmcCredentials.Password)
 	tray := &nvswitch.NVSwitchTray{
 		BMC: &bmc.BMC{
@@ -307,7 +315,6 @@ func resetTarget(ctx context.Context, target *pb.PowerTarget, resetType redfish.
 		}
 	}
 
-	log.Infof("%s initiated for target %s", resetType, target.BmcIp)
 	return &pb.NVSwitchResponse{
 		Uuid:   target.BmcIp,
 		Status: pb.StatusCode_SUCCESS,

--- a/nvswitch-manager/internal/service/server_impl.go
+++ b/nvswitch-manager/internal/service/server_impl.go
@@ -276,7 +276,7 @@ func resetTarget(ctx context.Context, target *pb.PowerTarget, resetType redfish.
 	ip := net.ParseIP(target.BmcIp)
 	if ip == nil {
 		return &pb.NVSwitchResponse{
-			Uuid:   target.BmcIp,
+			BmcIp:  target.BmcIp,
 			Status: pb.StatusCode_INVALID_ARGUMENT,
 			Error:  fmt.Sprintf("invalid BMC IP: %s", target.BmcIp),
 		}
@@ -284,7 +284,7 @@ func resetTarget(ctx context.Context, target *pb.PowerTarget, resetType redfish.
 
 	if target.BmcCredentials == nil {
 		return &pb.NVSwitchResponse{
-			Uuid:   target.BmcIp,
+			BmcIp:  target.BmcIp,
 			Status: pb.StatusCode_INVALID_ARGUMENT,
 			Error:  "bmc_credentials are required for power targets",
 		}
@@ -292,7 +292,7 @@ func resetTarget(ctx context.Context, target *pb.PowerTarget, resetType redfish.
 
 	if target.BmcCredentials.Username == "" || target.BmcCredentials.Password == "" {
 		return &pb.NVSwitchResponse{
-			Uuid:   target.BmcIp,
+			BmcIp:  target.BmcIp,
 			Status: pb.StatusCode_INVALID_ARGUMENT,
 			Error:  "bmc_credentials username and password must not be empty",
 		}
@@ -309,14 +309,14 @@ func resetTarget(ctx context.Context, target *pb.PowerTarget, resetType redfish.
 
 	if err := firmwaremanager.ResetTray(ctx, tray, resetType); err != nil {
 		return &pb.NVSwitchResponse{
-			Uuid:   target.BmcIp,
+			BmcIp:  target.BmcIp,
 			Status: pb.StatusCode_INTERNAL_ERROR,
 			Error:  fmt.Sprintf("%s failed: %s", resetType, err.Error()),
 		}
 	}
 
 	return &pb.NVSwitchResponse{
-		Uuid:   target.BmcIp,
+		BmcIp:  target.BmcIp,
 		Status: pb.StatusCode_SUCCESS,
 	}
 }

--- a/nvswitch-manager/internal/service/server_impl.go
+++ b/nvswitch-manager/internal/service/server_impl.go
@@ -20,6 +20,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"net"
 	"time"
 
 	"github.com/google/uuid"
@@ -220,8 +221,9 @@ func (s *NVSwitchManagerServerImpl) PowerControl(ctx context.Context, req *pb.Po
 		}, nil
 	}
 
-	responses := make([]*pb.NVSwitchResponse, 0, len(req.Uuids))
+	responses := make([]*pb.NVSwitchResponse, 0, len(req.Uuids)+len(req.Targets))
 
+	// Registered path: resolve UUIDs via registry + credential manager
 	for _, uuidStr := range req.Uuids {
 		uuid, err := protobuf.ParseUUID(uuidStr)
 		if err != nil {
@@ -259,9 +261,57 @@ func (s *NVSwitchManagerServerImpl) PowerControl(ctx context.Context, req *pb.Po
 		})
 	}
 
+	// Direct path: use inline connection details, bypass registry and credential manager
+	for _, target := range req.Targets {
+		responses = append(responses, resetTarget(ctx, target, resetType))
+	}
+
 	return &pb.PowerControlResponse{
 		Responses: responses,
 	}, nil
+}
+
+// resetTarget performs a power action against an unregistered device using inline connection details.
+func resetTarget(ctx context.Context, target *pb.PowerTarget, resetType redfish.ResetType) *pb.NVSwitchResponse {
+	ip := net.ParseIP(target.BmcIp)
+	if ip == nil {
+		return &pb.NVSwitchResponse{
+			Uuid:   target.BmcIp,
+			Status: pb.StatusCode_INVALID_ARGUMENT,
+			Error:  fmt.Sprintf("invalid BMC IP: %s", target.BmcIp),
+		}
+	}
+
+	if target.BmcCredentials == nil {
+		return &pb.NVSwitchResponse{
+			Uuid:   target.BmcIp,
+			Status: pb.StatusCode_INVALID_ARGUMENT,
+			Error:  "bmc_credentials are required for power targets",
+		}
+	}
+
+	cred := credential.New(target.BmcCredentials.Username, target.BmcCredentials.Password)
+	tray := &nvswitch.NVSwitchTray{
+		BMC: &bmc.BMC{
+			IP:         ip,
+			Port:       int(target.BmcPort),
+			Credential: cred,
+		},
+	}
+
+	if err := firmwaremanager.ResetTray(ctx, tray, resetType); err != nil {
+		return &pb.NVSwitchResponse{
+			Uuid:   target.BmcIp,
+			Status: pb.StatusCode_INTERNAL_ERROR,
+			Error:  fmt.Sprintf("%s failed: %s", resetType, err.Error()),
+		}
+	}
+
+	log.Infof("%s initiated for target %s", resetType, target.BmcIp)
+	return &pb.NVSwitchResponse{
+		Uuid:   target.BmcIp,
+		Status: pb.StatusCode_SUCCESS,
+	}
 }
 
 // ============================================================================

--- a/nvswitch-manager/internal/service/server_impl_test.go
+++ b/nvswitch-manager/internal/service/server_impl_test.go
@@ -73,9 +73,9 @@ func TestResetTarget_EmptyCredentials(t *testing.T) {
 		username string
 		password string
 	}{
-		"empty username":      {username: "", password: "bmcSecret"},
-		"empty password":      {username: "bmcAdmin", password: ""},
-		"both empty":          {username: "", password: ""},
+		"empty username": {username: "", password: "bmcSecret"},
+		"empty password": {username: "bmcAdmin", password: ""},
+		"both empty":     {username: "", password: ""},
 	}
 
 	for name, tc := range tests {

--- a/nvswitch-manager/internal/service/server_impl_test.go
+++ b/nvswitch-manager/internal/service/server_impl_test.go
@@ -1,0 +1,97 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/NVIDIA/ncx-infra-controller-rest/nvswitch-manager/internal/proto/v1"
+	"github.com/NVIDIA/ncx-infra-controller-rest/nvswitch-manager/pkg/redfish"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResetTarget_InvalidIP(t *testing.T) {
+	tests := map[string]struct {
+		ip string
+	}{
+		"empty":   {ip: ""},
+		"garbage": {ip: "bmc-bad-addr"},
+		"partial": {ip: "172.16.0"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			target := &pb.PowerTarget{
+				BmcIp: tc.ip,
+				BmcCredentials: &pb.Credentials{
+					Username: "bmcAdmin",
+					Password: "bmcSecret",
+				},
+			}
+
+			resp := resetTarget(context.Background(), target, redfish.ResetOn)
+
+			assert.Equal(t, pb.StatusCode_INVALID_ARGUMENT, resp.Status)
+			assert.Equal(t, tc.ip, resp.Uuid)
+			assert.Contains(t, resp.Error, "invalid BMC IP")
+		})
+	}
+}
+
+func TestResetTarget_NilCredentials(t *testing.T) {
+	target := &pb.PowerTarget{
+		BmcIp:          "172.16.0.10",
+		BmcCredentials: nil,
+	}
+
+	resp := resetTarget(context.Background(), target, redfish.ResetOn)
+
+	assert.Equal(t, pb.StatusCode_INVALID_ARGUMENT, resp.Status)
+	assert.Equal(t, "172.16.0.10", resp.Uuid)
+	assert.Contains(t, resp.Error, "bmc_credentials are required")
+}
+
+func TestResetTarget_EmptyCredentials(t *testing.T) {
+	tests := map[string]struct {
+		username string
+		password string
+	}{
+		"empty username":      {username: "", password: "bmcSecret"},
+		"empty password":      {username: "bmcAdmin", password: ""},
+		"both empty":          {username: "", password: ""},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			target := &pb.PowerTarget{
+				BmcIp: "172.16.0.10",
+				BmcCredentials: &pb.Credentials{
+					Username: tc.username,
+					Password: tc.password,
+				},
+			}
+
+			resp := resetTarget(context.Background(), target, redfish.ResetOn)
+
+			assert.Equal(t, pb.StatusCode_INVALID_ARGUMENT, resp.Status)
+			assert.Contains(t, resp.Error, "must not be empty")
+		})
+	}
+}

--- a/nvswitch-manager/internal/service/server_impl_test.go
+++ b/nvswitch-manager/internal/service/server_impl_test.go
@@ -49,7 +49,7 @@ func TestResetTarget_InvalidIP(t *testing.T) {
 			resp := resetTarget(context.Background(), target, redfish.ResetOn)
 
 			assert.Equal(t, pb.StatusCode_INVALID_ARGUMENT, resp.Status)
-			assert.Equal(t, tc.ip, resp.Uuid)
+			assert.Equal(t, tc.ip, resp.BmcIp)
 			assert.Contains(t, resp.Error, "invalid BMC IP")
 		})
 	}
@@ -64,7 +64,7 @@ func TestResetTarget_NilCredentials(t *testing.T) {
 	resp := resetTarget(context.Background(), target, redfish.ResetOn)
 
 	assert.Equal(t, pb.StatusCode_INVALID_ARGUMENT, resp.Status)
-	assert.Equal(t, "172.16.0.10", resp.Uuid)
+	assert.Equal(t, "172.16.0.10", resp.BmcIp)
 	assert.Contains(t, resp.Error, "bmc_credentials are required")
 }
 

--- a/powershelf-manager/docs/API_REFERENCE.md
+++ b/powershelf-manager/docs/API_REFERENCE.md
@@ -551,17 +551,24 @@ grpcurl -plaintext -d '{"dry_run": false}' localhost:50051 v1.PowershelfManager/
 
 ### PowerOff
 
-Issues a Redfish chassis power-off action for each specified powershelf.
+Issues a Redfish chassis power-off action for each specified powershelf. Supports both registered devices (by MAC) and unregistered devices (by inline connection details via `PowerTarget`).
 
 ```protobuf
-rpc PowerOff(PowershelfRequest) returns (PowerControlResponse)
+rpc PowerOff(PowerRequest) returns (PowerControlResponse)
 ```
 
 #### Request
 
 ```protobuf
-message PowershelfRequest {
-    repeated string pmc_macs = 1;  // Required. At least one MAC
+message PowerRequest {
+    repeated string pmc_macs = 1;       // Registered devices by MAC
+    repeated PowerTarget targets = 2;   // Unregistered devices with inline credentials
+}
+
+message PowerTarget {
+    string pmc_ip = 1;
+    Credentials pmc_credentials = 2;
+    PMCVendor pmc_vendor = 3;
 }
 ```
 
@@ -573,9 +580,10 @@ message PowerControlResponse {
 }
 
 message PowershelfResponse {
-    string pmc_mac_address = 1;
+    string pmc_mac_address = 1;  // Set for registered devices; empty for direct targets
     StatusCode status = 2;
     string error = 3;
+    string pmc_ip = 4;           // Set for direct PowerTarget responses; empty for registered devices
 }
 ```
 
@@ -583,13 +591,25 @@ message PowershelfResponse {
 
 - Executes `Chassis.Reset` with `ResetType: ForceOff`
 - Idempotent: powering off an already-off chassis succeeds
-- Returns per-PMC status; partial failures are possible
+- Returns per-target status; partial failures are possible
+- For registered devices, `pmc_mac_address` identifies the device in the response
+- For direct `PowerTarget` requests, `pmc_ip` identifies the device and `pmc_mac_address` is empty
 
 #### Example
 
 ```bash
+# Registered device by MAC
 grpcurl -plaintext -d '{
   "pmc_macs": ["00:11:22:33:44:55"]
+}' localhost:50051 v1.PowershelfManager/PowerOff
+
+# Unregistered device via PowerTarget
+grpcurl -plaintext -d '{
+  "targets": [{
+    "pmc_ip": "10.0.1.100",
+    "pmc_credentials": {"username": "admin", "password": "secret"},
+    "pmc_vendor": "PMC_TYPE_LITEON"
+  }]
 }' localhost:50051 v1.PowershelfManager/PowerOff
 ```
 
@@ -597,23 +617,34 @@ grpcurl -plaintext -d '{
 
 ### PowerOn
 
-Issues a Redfish chassis power-on action for each specified powershelf.
+Issues a Redfish chassis power-on action for each specified powershelf. Supports both registered devices (by MAC) and unregistered devices (by inline connection details via `PowerTarget`).
 
 ```protobuf
-rpc PowerOn(PowershelfRequest) returns (PowerControlResponse)
+rpc PowerOn(PowerRequest) returns (PowerControlResponse)
 ```
 
 #### Behavior
 
 - Executes `Chassis.Reset` with `ResetType: On`
 - Idempotent: powering on an already-on chassis succeeds
-- Returns per-PMC status; partial failures are possible
+- Returns per-target status; partial failures are possible
+- Response format is the same as `PowerOff`: `pmc_mac_address` for registered devices, `pmc_ip` for direct targets
 
 #### Example
 
 ```bash
+# Registered device by MAC
 grpcurl -plaintext -d '{
   "pmc_macs": ["00:11:22:33:44:55"]
+}' localhost:50051 v1.PowershelfManager/PowerOn
+
+# Unregistered device via PowerTarget
+grpcurl -plaintext -d '{
+  "targets": [{
+    "pmc_ip": "10.0.1.100",
+    "pmc_credentials": {"username": "admin", "password": "secret"},
+    "pmc_vendor": "PMC_TYPE_LITEON"
+  }]
 }' localhost:50051 v1.PowershelfManager/PowerOn
 ```
 

--- a/powershelf-manager/internal/proto/v1/powershelf-manager.pb.go
+++ b/powershelf-manager/internal/proto/v1/powershelf-manager.pb.go
@@ -1073,7 +1073,6 @@ func (x *RegisterPowershelvesResponse) GetResponses() []*RegisterPowershelfRespo
 type PowershelfRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	PmcMacs       []string               `protobuf:"bytes,1,rep,name=pmc_macs,json=pmcMacs,proto3" json:"pmc_macs,omitempty"`
-	Targets       []*PowerTarget         `protobuf:"bytes,2,rep,name=targets,proto3" json:"targets,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1115,7 +1114,55 @@ func (x *PowershelfRequest) GetPmcMacs() []string {
 	return nil
 }
 
-func (x *PowershelfRequest) GetTargets() []*PowerTarget {
+// PowerRequest is used by PowerOn/PowerOff RPCs. Registered devices are
+// identified by MAC; unregistered devices use PowerTarget with inline
+// connection details.
+type PowerRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	PmcMacs       []string               `protobuf:"bytes,1,rep,name=pmc_macs,json=pmcMacs,proto3" json:"pmc_macs,omitempty"`
+	Targets       []*PowerTarget         `protobuf:"bytes,2,rep,name=targets,proto3" json:"targets,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PowerRequest) Reset() {
+	*x = PowerRequest{}
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PowerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PowerRequest) ProtoMessage() {}
+
+func (x *PowerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PowerRequest.ProtoReflect.Descriptor instead.
+func (*PowerRequest) Descriptor() ([]byte, []int) {
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *PowerRequest) GetPmcMacs() []string {
+	if x != nil {
+		return x.PmcMacs
+	}
+	return nil
+}
+
+func (x *PowerRequest) GetTargets() []*PowerTarget {
 	if x != nil {
 		return x.Targets
 	}
@@ -1133,7 +1180,7 @@ type PowershelfResponse struct {
 
 func (x *PowershelfResponse) Reset() {
 	*x = PowershelfResponse{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[13]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1145,7 +1192,7 @@ func (x *PowershelfResponse) String() string {
 func (*PowershelfResponse) ProtoMessage() {}
 
 func (x *PowershelfResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[13]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1158,7 +1205,7 @@ func (x *PowershelfResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PowershelfResponse.ProtoReflect.Descriptor instead.
 func (*PowershelfResponse) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{13}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *PowershelfResponse) GetPmcMacAddress() string {
@@ -1191,7 +1238,7 @@ type PowerControlResponse struct {
 
 func (x *PowerControlResponse) Reset() {
 	*x = PowerControlResponse{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[14]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1203,7 +1250,7 @@ func (x *PowerControlResponse) String() string {
 func (*PowerControlResponse) ProtoMessage() {}
 
 func (x *PowerControlResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[14]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1216,7 +1263,7 @@ func (x *PowerControlResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PowerControlResponse.ProtoReflect.Descriptor instead.
 func (*PowerControlResponse) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{14}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *PowerControlResponse) GetResponses() []*PowershelfResponse {
@@ -1229,17 +1276,17 @@ func (x *PowerControlResponse) GetResponses() []*PowershelfResponse {
 // PowerTarget allows power control against a device without prior registration.
 // Only IP and credentials are required; the registry and credential manager are bypassed.
 type PowerTarget struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	PmcIp         string                 `protobuf:"bytes,1,opt,name=pmc_ip,json=pmcIp,proto3" json:"pmc_ip,omitempty"`
-	Credentials   *Credentials           `protobuf:"bytes,2,opt,name=credentials,proto3" json:"credentials,omitempty"`
-	Vendor        PMCVendor              `protobuf:"varint,3,opt,name=vendor,proto3,enum=v1.PMCVendor" json:"vendor,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	PmcIp          string                 `protobuf:"bytes,1,opt,name=pmc_ip,json=pmcIp,proto3" json:"pmc_ip,omitempty"`
+	PmcCredentials *Credentials           `protobuf:"bytes,2,opt,name=pmc_credentials,json=pmcCredentials,proto3" json:"pmc_credentials,omitempty"`
+	PmcVendor      PMCVendor              `protobuf:"varint,3,opt,name=pmc_vendor,json=pmcVendor,proto3,enum=v1.PMCVendor" json:"pmc_vendor,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *PowerTarget) Reset() {
 	*x = PowerTarget{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[15]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1251,7 +1298,7 @@ func (x *PowerTarget) String() string {
 func (*PowerTarget) ProtoMessage() {}
 
 func (x *PowerTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[15]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1264,7 +1311,7 @@ func (x *PowerTarget) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PowerTarget.ProtoReflect.Descriptor instead.
 func (*PowerTarget) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{15}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *PowerTarget) GetPmcIp() string {
@@ -1274,16 +1321,16 @@ func (x *PowerTarget) GetPmcIp() string {
 	return ""
 }
 
-func (x *PowerTarget) GetCredentials() *Credentials {
+func (x *PowerTarget) GetPmcCredentials() *Credentials {
 	if x != nil {
-		return x.Credentials
+		return x.PmcCredentials
 	}
 	return nil
 }
 
-func (x *PowerTarget) GetVendor() PMCVendor {
+func (x *PowerTarget) GetPmcVendor() PMCVendor {
 	if x != nil {
-		return x.Vendor
+		return x.PmcVendor
 	}
 	return PMCVendor_PMC_TYPE_UNKNOWN
 }
@@ -1297,7 +1344,7 @@ type GetPowershelvesResponse struct {
 
 func (x *GetPowershelvesResponse) Reset() {
 	*x = GetPowershelvesResponse{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[16]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1309,7 +1356,7 @@ func (x *GetPowershelvesResponse) String() string {
 func (*GetPowershelvesResponse) ProtoMessage() {}
 
 func (x *GetPowershelvesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[16]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1322,7 +1369,7 @@ func (x *GetPowershelvesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetPowershelvesResponse.ProtoReflect.Descriptor instead.
 func (*GetPowershelvesResponse) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{16}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *GetPowershelvesResponse) GetPowershelves() []*PowerShelf {
@@ -1342,7 +1389,7 @@ type UpdateComponentFirmwareRequest struct {
 
 func (x *UpdateComponentFirmwareRequest) Reset() {
 	*x = UpdateComponentFirmwareRequest{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[17]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1354,7 +1401,7 @@ func (x *UpdateComponentFirmwareRequest) String() string {
 func (*UpdateComponentFirmwareRequest) ProtoMessage() {}
 
 func (x *UpdateComponentFirmwareRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[17]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1367,7 +1414,7 @@ func (x *UpdateComponentFirmwareRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateComponentFirmwareRequest.ProtoReflect.Descriptor instead.
 func (*UpdateComponentFirmwareRequest) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{17}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *UpdateComponentFirmwareRequest) GetComponent() PowershelfComponent {
@@ -1394,7 +1441,7 @@ type UpdatePowershelfFirmwareRequest struct {
 
 func (x *UpdatePowershelfFirmwareRequest) Reset() {
 	*x = UpdatePowershelfFirmwareRequest{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[18]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1406,7 +1453,7 @@ func (x *UpdatePowershelfFirmwareRequest) String() string {
 func (*UpdatePowershelfFirmwareRequest) ProtoMessage() {}
 
 func (x *UpdatePowershelfFirmwareRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[18]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1419,7 +1466,7 @@ func (x *UpdatePowershelfFirmwareRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdatePowershelfFirmwareRequest.ProtoReflect.Descriptor instead.
 func (*UpdatePowershelfFirmwareRequest) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{18}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *UpdatePowershelfFirmwareRequest) GetPmcMacAddress() string {
@@ -1445,7 +1492,7 @@ type UpdateFirmwareRequest struct {
 
 func (x *UpdateFirmwareRequest) Reset() {
 	*x = UpdateFirmwareRequest{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[19]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1457,7 +1504,7 @@ func (x *UpdateFirmwareRequest) String() string {
 func (*UpdateFirmwareRequest) ProtoMessage() {}
 
 func (x *UpdateFirmwareRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[19]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1470,7 +1517,7 @@ func (x *UpdateFirmwareRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateFirmwareRequest.ProtoReflect.Descriptor instead.
 func (*UpdateFirmwareRequest) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{19}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *UpdateFirmwareRequest) GetUpgrades() []*UpdatePowershelfFirmwareRequest {
@@ -1491,7 +1538,7 @@ type UpdateComponentFirmwareResponse struct {
 
 func (x *UpdateComponentFirmwareResponse) Reset() {
 	*x = UpdateComponentFirmwareResponse{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[20]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1503,7 +1550,7 @@ func (x *UpdateComponentFirmwareResponse) String() string {
 func (*UpdateComponentFirmwareResponse) ProtoMessage() {}
 
 func (x *UpdateComponentFirmwareResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[20]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1516,7 +1563,7 @@ func (x *UpdateComponentFirmwareResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateComponentFirmwareResponse.ProtoReflect.Descriptor instead.
 func (*UpdateComponentFirmwareResponse) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{20}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *UpdateComponentFirmwareResponse) GetComponent() PowershelfComponent {
@@ -1550,7 +1597,7 @@ type UpdatePowershelfFirmwareResponse struct {
 
 func (x *UpdatePowershelfFirmwareResponse) Reset() {
 	*x = UpdatePowershelfFirmwareResponse{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[21]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1562,7 +1609,7 @@ func (x *UpdatePowershelfFirmwareResponse) String() string {
 func (*UpdatePowershelfFirmwareResponse) ProtoMessage() {}
 
 func (x *UpdatePowershelfFirmwareResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[21]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1575,7 +1622,7 @@ func (x *UpdatePowershelfFirmwareResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdatePowershelfFirmwareResponse.ProtoReflect.Descriptor instead.
 func (*UpdatePowershelfFirmwareResponse) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{21}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *UpdatePowershelfFirmwareResponse) GetPmcMacAddress() string {
@@ -1601,7 +1648,7 @@ type UpdateFirmwareResponse struct {
 
 func (x *UpdateFirmwareResponse) Reset() {
 	*x = UpdateFirmwareResponse{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[22]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1613,7 +1660,7 @@ func (x *UpdateFirmwareResponse) String() string {
 func (*UpdateFirmwareResponse) ProtoMessage() {}
 
 func (x *UpdateFirmwareResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[22]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1626,7 +1673,7 @@ func (x *UpdateFirmwareResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateFirmwareResponse.ProtoReflect.Descriptor instead.
 func (*UpdateFirmwareResponse) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{22}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *UpdateFirmwareResponse) GetResponses() []*UpdatePowershelfFirmwareResponse {
@@ -1645,7 +1692,7 @@ type CanUpdateFirmwareResponse struct {
 
 func (x *CanUpdateFirmwareResponse) Reset() {
 	*x = CanUpdateFirmwareResponse{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[23]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1657,7 +1704,7 @@ func (x *CanUpdateFirmwareResponse) String() string {
 func (*CanUpdateFirmwareResponse) ProtoMessage() {}
 
 func (x *CanUpdateFirmwareResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[23]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1670,7 +1717,7 @@ func (x *CanUpdateFirmwareResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CanUpdateFirmwareResponse.ProtoReflect.Descriptor instead.
 func (*CanUpdateFirmwareResponse) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{23}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *CanUpdateFirmwareResponse) GetCanUpdate() bool {
@@ -1689,7 +1736,7 @@ type FirmwareVersion struct {
 
 func (x *FirmwareVersion) Reset() {
 	*x = FirmwareVersion{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[24]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1701,7 +1748,7 @@ func (x *FirmwareVersion) String() string {
 func (*FirmwareVersion) ProtoMessage() {}
 
 func (x *FirmwareVersion) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[24]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1714,7 +1761,7 @@ func (x *FirmwareVersion) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FirmwareVersion.ProtoReflect.Descriptor instead.
 func (*FirmwareVersion) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{24}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *FirmwareVersion) GetVersion() string {
@@ -1734,7 +1781,7 @@ type ComponentFirmwareUpgrades struct {
 
 func (x *ComponentFirmwareUpgrades) Reset() {
 	*x = ComponentFirmwareUpgrades{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[25]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1746,7 +1793,7 @@ func (x *ComponentFirmwareUpgrades) String() string {
 func (*ComponentFirmwareUpgrades) ProtoMessage() {}
 
 func (x *ComponentFirmwareUpgrades) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[25]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1759,7 +1806,7 @@ func (x *ComponentFirmwareUpgrades) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ComponentFirmwareUpgrades.ProtoReflect.Descriptor instead.
 func (*ComponentFirmwareUpgrades) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{25}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *ComponentFirmwareUpgrades) GetComponent() PowershelfComponent {
@@ -1786,7 +1833,7 @@ type AvailableFirmware struct {
 
 func (x *AvailableFirmware) Reset() {
 	*x = AvailableFirmware{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[26]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1798,7 +1845,7 @@ func (x *AvailableFirmware) String() string {
 func (*AvailableFirmware) ProtoMessage() {}
 
 func (x *AvailableFirmware) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[26]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1811,7 +1858,7 @@ func (x *AvailableFirmware) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AvailableFirmware.ProtoReflect.Descriptor instead.
 func (*AvailableFirmware) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{26}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *AvailableFirmware) GetPmcMacAddress() string {
@@ -1837,7 +1884,7 @@ type ListAvailableFirmwareResponse struct {
 
 func (x *ListAvailableFirmwareResponse) Reset() {
 	*x = ListAvailableFirmwareResponse{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[27]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1849,7 +1896,7 @@ func (x *ListAvailableFirmwareResponse) String() string {
 func (*ListAvailableFirmwareResponse) ProtoMessage() {}
 
 func (x *ListAvailableFirmwareResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[27]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1862,7 +1909,7 @@ func (x *ListAvailableFirmwareResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAvailableFirmwareResponse.ProtoReflect.Descriptor instead.
 func (*ListAvailableFirmwareResponse) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{27}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ListAvailableFirmwareResponse) GetUpgrades() []*AvailableFirmware {
@@ -1881,7 +1928,7 @@ type SetDryRunRequest struct {
 
 func (x *SetDryRunRequest) Reset() {
 	*x = SetDryRunRequest{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[28]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1893,7 +1940,7 @@ func (x *SetDryRunRequest) String() string {
 func (*SetDryRunRequest) ProtoMessage() {}
 
 func (x *SetDryRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[28]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1906,7 +1953,7 @@ func (x *SetDryRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetDryRunRequest.ProtoReflect.Descriptor instead.
 func (*SetDryRunRequest) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{28}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *SetDryRunRequest) GetDryRun() bool {
@@ -1926,7 +1973,7 @@ type GetFirmwareUpdateStatusRequest struct {
 
 func (x *GetFirmwareUpdateStatusRequest) Reset() {
 	*x = GetFirmwareUpdateStatusRequest{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[29]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1938,7 +1985,7 @@ func (x *GetFirmwareUpdateStatusRequest) String() string {
 func (*GetFirmwareUpdateStatusRequest) ProtoMessage() {}
 
 func (x *GetFirmwareUpdateStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[29]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1951,7 +1998,7 @@ func (x *GetFirmwareUpdateStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFirmwareUpdateStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetFirmwareUpdateStatusRequest) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{29}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *GetFirmwareUpdateStatusRequest) GetQueries() []*FirmwareUpdateQuery {
@@ -1972,7 +2019,7 @@ type FirmwareUpdateQuery struct {
 
 func (x *FirmwareUpdateQuery) Reset() {
 	*x = FirmwareUpdateQuery{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[30]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1984,7 +2031,7 @@ func (x *FirmwareUpdateQuery) String() string {
 func (*FirmwareUpdateQuery) ProtoMessage() {}
 
 func (x *FirmwareUpdateQuery) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[30]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1997,7 +2044,7 @@ func (x *FirmwareUpdateQuery) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FirmwareUpdateQuery.ProtoReflect.Descriptor instead.
 func (*FirmwareUpdateQuery) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{30}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *FirmwareUpdateQuery) GetPmcMacAddress() string {
@@ -2024,7 +2071,7 @@ type GetFirmwareUpdateStatusResponse struct {
 
 func (x *GetFirmwareUpdateStatusResponse) Reset() {
 	*x = GetFirmwareUpdateStatusResponse{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[31]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2036,7 +2083,7 @@ func (x *GetFirmwareUpdateStatusResponse) String() string {
 func (*GetFirmwareUpdateStatusResponse) ProtoMessage() {}
 
 func (x *GetFirmwareUpdateStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[31]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2049,7 +2096,7 @@ func (x *GetFirmwareUpdateStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFirmwareUpdateStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetFirmwareUpdateStatusResponse) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{31}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *GetFirmwareUpdateStatusResponse) GetStatuses() []*FirmwareUpdateStatus {
@@ -2073,7 +2120,7 @@ type FirmwareUpdateStatus struct {
 
 func (x *FirmwareUpdateStatus) Reset() {
 	*x = FirmwareUpdateStatus{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[32]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2085,7 +2132,7 @@ func (x *FirmwareUpdateStatus) String() string {
 func (*FirmwareUpdateStatus) ProtoMessage() {}
 
 func (x *FirmwareUpdateStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[32]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2098,7 +2145,7 @@ func (x *FirmwareUpdateStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FirmwareUpdateStatus.ProtoReflect.Descriptor instead.
 func (*FirmwareUpdateStatus) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{32}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *FirmwareUpdateStatus) GetPmcMacAddress() string {
@@ -2213,8 +2260,10 @@ const file_internal_proto_v1_powershelf_manager_proto_rawDesc = "" +
 	"\x06status\x18\x04 \x01(\x0e2\x0e.v1.StatusCodeR\x06status\x12\x14\n" +
 	"\x05error\x18\x05 \x01(\tR\x05error\"\\\n" +
 	"\x1cRegisterPowershelvesResponse\x12<\n" +
-	"\tresponses\x18\x01 \x03(\v2\x1e.v1.RegisterPowershelfResponseR\tresponses\"Y\n" +
+	"\tresponses\x18\x01 \x03(\v2\x1e.v1.RegisterPowershelfResponseR\tresponses\".\n" +
 	"\x11PowershelfRequest\x12\x19\n" +
+	"\bpmc_macs\x18\x01 \x03(\tR\apmcMacs\"T\n" +
+	"\fPowerRequest\x12\x19\n" +
 	"\bpmc_macs\x18\x01 \x03(\tR\apmcMacs\x12)\n" +
 	"\atargets\x18\x02 \x03(\v2\x0f.v1.PowerTargetR\atargets\"z\n" +
 	"\x12PowershelfResponse\x12&\n" +
@@ -2222,11 +2271,12 @@ const file_internal_proto_v1_powershelf_manager_proto_rawDesc = "" +
 	"\x06status\x18\x02 \x01(\x0e2\x0e.v1.StatusCodeR\x06status\x12\x14\n" +
 	"\x05error\x18\x03 \x01(\tR\x05error\"L\n" +
 	"\x14PowerControlResponse\x124\n" +
-	"\tresponses\x18\x01 \x03(\v2\x16.v1.PowershelfResponseR\tresponses\"~\n" +
+	"\tresponses\x18\x01 \x03(\v2\x16.v1.PowershelfResponseR\tresponses\"\x8c\x01\n" +
 	"\vPowerTarget\x12\x15\n" +
-	"\x06pmc_ip\x18\x01 \x01(\tR\x05pmcIp\x121\n" +
-	"\vcredentials\x18\x02 \x01(\v2\x0f.v1.CredentialsR\vcredentials\x12%\n" +
-	"\x06vendor\x18\x03 \x01(\x0e2\r.v1.PMCVendorR\x06vendor\"M\n" +
+	"\x06pmc_ip\x18\x01 \x01(\tR\x05pmcIp\x128\n" +
+	"\x0fpmc_credentials\x18\x02 \x01(\v2\x0f.v1.CredentialsR\x0epmcCredentials\x12,\n" +
+	"\n" +
+	"pmc_vendor\x18\x03 \x01(\x0e2\r.v1.PMCVendorR\tpmcVendor\"M\n" +
 	"\x17GetPowershelvesResponse\x122\n" +
 	"\fpowershelves\x18\x01 \x03(\v2\x0e.v1.PowerShelfR\fpowershelves\"\x8a\x01\n" +
 	"\x1eUpdateComponentFirmwareRequest\x125\n" +
@@ -2295,16 +2345,16 @@ const file_internal_proto_v1_powershelf_manager_proto_rawDesc = "" +
 	"\x1cFIRMWARE_UPDATE_STATE_QUEUED\x10\x01\x12#\n" +
 	"\x1fFIRMWARE_UPDATE_STATE_VERIFYING\x10\x02\x12#\n" +
 	"\x1fFIRMWARE_UPDATE_STATE_COMPLETED\x10\x03\x12 \n" +
-	"\x1cFIRMWARE_UPDATE_STATE_FAILED\x10\x042\xe9\x04\n" +
+	"\x1cFIRMWARE_UPDATE_STATE_FAILED\x10\x042\xdf\x04\n" +
 	"\x11PowershelfManager\x12Y\n" +
 	"\x14RegisterPowershelves\x12\x1f.v1.RegisterPowershelvesRequest\x1a .v1.RegisterPowershelvesResponse\x12E\n" +
 	"\x0fGetPowershelves\x12\x15.v1.PowershelfRequest\x1a\x1b.v1.GetPowershelvesResponse\x12G\n" +
 	"\x0eUpdateFirmware\x12\x19.v1.UpdateFirmwareRequest\x1a\x1a.v1.UpdateFirmwareResponse\x12b\n" +
 	"\x17GetFirmwareUpdateStatus\x12\".v1.GetFirmwareUpdateStatusRequest\x1a#.v1.GetFirmwareUpdateStatusResponse\x12Q\n" +
 	"\x15ListAvailableFirmware\x12\x15.v1.PowershelfRequest\x1a!.v1.ListAvailableFirmwareResponse\x129\n" +
-	"\tSetDryRun\x12\x14.v1.SetDryRunRequest\x1a\x16.google.protobuf.Empty\x12;\n" +
-	"\bPowerOff\x12\x15.v1.PowershelfRequest\x1a\x18.v1.PowerControlResponse\x12:\n" +
-	"\aPowerOn\x12\x15.v1.PowershelfRequest\x1a\x18.v1.PowerControlResponseB\n" +
+	"\tSetDryRun\x12\x14.v1.SetDryRunRequest\x1a\x16.google.protobuf.Empty\x126\n" +
+	"\bPowerOff\x12\x10.v1.PowerRequest\x1a\x18.v1.PowerControlResponse\x125\n" +
+	"\aPowerOn\x12\x10.v1.PowerRequest\x1a\x18.v1.PowerControlResponseB\n" +
 	"Z\bproto/v1b\x06proto3"
 
 var (
@@ -2320,7 +2370,7 @@ func file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP() []byte {
 }
 
 var file_internal_proto_v1_powershelf_manager_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_internal_proto_v1_powershelf_manager_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
+var file_internal_proto_v1_powershelf_manager_proto_msgTypes = make([]protoimpl.MessageInfo, 34)
 var file_internal_proto_v1_powershelf_manager_proto_goTypes = []any{
 	(PMCVendor)(0),                           // 0: v1.PMCVendor
 	(StatusCode)(0),                          // 1: v1.StatusCode
@@ -2339,28 +2389,29 @@ var file_internal_proto_v1_powershelf_manager_proto_goTypes = []any{
 	(*RegisterPowershelfResponse)(nil),       // 14: v1.RegisterPowershelfResponse
 	(*RegisterPowershelvesResponse)(nil),     // 15: v1.RegisterPowershelvesResponse
 	(*PowershelfRequest)(nil),                // 16: v1.PowershelfRequest
-	(*PowershelfResponse)(nil),               // 17: v1.PowershelfResponse
-	(*PowerControlResponse)(nil),             // 18: v1.PowerControlResponse
-	(*PowerTarget)(nil),                      // 19: v1.PowerTarget
-	(*GetPowershelvesResponse)(nil),          // 20: v1.GetPowershelvesResponse
-	(*UpdateComponentFirmwareRequest)(nil),   // 21: v1.UpdateComponentFirmwareRequest
-	(*UpdatePowershelfFirmwareRequest)(nil),  // 22: v1.UpdatePowershelfFirmwareRequest
-	(*UpdateFirmwareRequest)(nil),            // 23: v1.UpdateFirmwareRequest
-	(*UpdateComponentFirmwareResponse)(nil),  // 24: v1.UpdateComponentFirmwareResponse
-	(*UpdatePowershelfFirmwareResponse)(nil), // 25: v1.UpdatePowershelfFirmwareResponse
-	(*UpdateFirmwareResponse)(nil),           // 26: v1.UpdateFirmwareResponse
-	(*CanUpdateFirmwareResponse)(nil),        // 27: v1.CanUpdateFirmwareResponse
-	(*FirmwareVersion)(nil),                  // 28: v1.FirmwareVersion
-	(*ComponentFirmwareUpgrades)(nil),        // 29: v1.ComponentFirmwareUpgrades
-	(*AvailableFirmware)(nil),                // 30: v1.AvailableFirmware
-	(*ListAvailableFirmwareResponse)(nil),    // 31: v1.ListAvailableFirmwareResponse
-	(*SetDryRunRequest)(nil),                 // 32: v1.SetDryRunRequest
-	(*GetFirmwareUpdateStatusRequest)(nil),   // 33: v1.GetFirmwareUpdateStatusRequest
-	(*FirmwareUpdateQuery)(nil),              // 34: v1.FirmwareUpdateQuery
-	(*GetFirmwareUpdateStatusResponse)(nil),  // 35: v1.GetFirmwareUpdateStatusResponse
-	(*FirmwareUpdateStatus)(nil),             // 36: v1.FirmwareUpdateStatus
-	(*timestamppb.Timestamp)(nil),            // 37: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),                    // 38: google.protobuf.Empty
+	(*PowerRequest)(nil),                     // 17: v1.PowerRequest
+	(*PowershelfResponse)(nil),               // 18: v1.PowershelfResponse
+	(*PowerControlResponse)(nil),             // 19: v1.PowerControlResponse
+	(*PowerTarget)(nil),                      // 20: v1.PowerTarget
+	(*GetPowershelvesResponse)(nil),          // 21: v1.GetPowershelvesResponse
+	(*UpdateComponentFirmwareRequest)(nil),   // 22: v1.UpdateComponentFirmwareRequest
+	(*UpdatePowershelfFirmwareRequest)(nil),  // 23: v1.UpdatePowershelfFirmwareRequest
+	(*UpdateFirmwareRequest)(nil),            // 24: v1.UpdateFirmwareRequest
+	(*UpdateComponentFirmwareResponse)(nil),  // 25: v1.UpdateComponentFirmwareResponse
+	(*UpdatePowershelfFirmwareResponse)(nil), // 26: v1.UpdatePowershelfFirmwareResponse
+	(*UpdateFirmwareResponse)(nil),           // 27: v1.UpdateFirmwareResponse
+	(*CanUpdateFirmwareResponse)(nil),        // 28: v1.CanUpdateFirmwareResponse
+	(*FirmwareVersion)(nil),                  // 29: v1.FirmwareVersion
+	(*ComponentFirmwareUpgrades)(nil),        // 30: v1.ComponentFirmwareUpgrades
+	(*AvailableFirmware)(nil),                // 31: v1.AvailableFirmware
+	(*ListAvailableFirmwareResponse)(nil),    // 32: v1.ListAvailableFirmwareResponse
+	(*SetDryRunRequest)(nil),                 // 33: v1.SetDryRunRequest
+	(*GetFirmwareUpdateStatusRequest)(nil),   // 34: v1.GetFirmwareUpdateStatusRequest
+	(*FirmwareUpdateQuery)(nil),              // 35: v1.FirmwareUpdateQuery
+	(*GetFirmwareUpdateStatusResponse)(nil),  // 36: v1.GetFirmwareUpdateStatusResponse
+	(*FirmwareUpdateStatus)(nil),             // 37: v1.FirmwareUpdateStatus
+	(*timestamppb.Timestamp)(nil),            // 38: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),                    // 39: google.protobuf.Empty
 }
 var file_internal_proto_v1_powershelf_manager_proto_depIdxs = []int32{
 	0,  // 0: v1.PowerManagementController.vendor:type_name -> v1.PMCVendor
@@ -2376,49 +2427,49 @@ var file_internal_proto_v1_powershelf_manager_proto_depIdxs = []int32{
 	0,  // 10: v1.RegisterPowershelfRequest.pmc_vendor:type_name -> v1.PMCVendor
 	4,  // 11: v1.RegisterPowershelfRequest.pmc_credentials:type_name -> v1.Credentials
 	12, // 12: v1.RegisterPowershelvesRequest.registration_requests:type_name -> v1.RegisterPowershelfRequest
-	37, // 13: v1.RegisterPowershelfResponse.created:type_name -> google.protobuf.Timestamp
+	38, // 13: v1.RegisterPowershelfResponse.created:type_name -> google.protobuf.Timestamp
 	1,  // 14: v1.RegisterPowershelfResponse.status:type_name -> v1.StatusCode
 	14, // 15: v1.RegisterPowershelvesResponse.responses:type_name -> v1.RegisterPowershelfResponse
-	19, // 16: v1.PowershelfRequest.targets:type_name -> v1.PowerTarget
+	20, // 16: v1.PowerRequest.targets:type_name -> v1.PowerTarget
 	1,  // 17: v1.PowershelfResponse.status:type_name -> v1.StatusCode
-	17, // 18: v1.PowerControlResponse.responses:type_name -> v1.PowershelfResponse
-	4,  // 19: v1.PowerTarget.credentials:type_name -> v1.Credentials
-	0,  // 20: v1.PowerTarget.vendor:type_name -> v1.PMCVendor
+	18, // 18: v1.PowerControlResponse.responses:type_name -> v1.PowershelfResponse
+	4,  // 19: v1.PowerTarget.pmc_credentials:type_name -> v1.Credentials
+	0,  // 20: v1.PowerTarget.pmc_vendor:type_name -> v1.PMCVendor
 	11, // 21: v1.GetPowershelvesResponse.powershelves:type_name -> v1.PowerShelf
 	2,  // 22: v1.UpdateComponentFirmwareRequest.component:type_name -> v1.PowershelfComponent
-	28, // 23: v1.UpdateComponentFirmwareRequest.upgradeTo:type_name -> v1.FirmwareVersion
-	21, // 24: v1.UpdatePowershelfFirmwareRequest.components:type_name -> v1.UpdateComponentFirmwareRequest
-	22, // 25: v1.UpdateFirmwareRequest.upgrades:type_name -> v1.UpdatePowershelfFirmwareRequest
+	29, // 23: v1.UpdateComponentFirmwareRequest.upgradeTo:type_name -> v1.FirmwareVersion
+	22, // 24: v1.UpdatePowershelfFirmwareRequest.components:type_name -> v1.UpdateComponentFirmwareRequest
+	23, // 25: v1.UpdateFirmwareRequest.upgrades:type_name -> v1.UpdatePowershelfFirmwareRequest
 	2,  // 26: v1.UpdateComponentFirmwareResponse.component:type_name -> v1.PowershelfComponent
 	1,  // 27: v1.UpdateComponentFirmwareResponse.status:type_name -> v1.StatusCode
-	24, // 28: v1.UpdatePowershelfFirmwareResponse.components:type_name -> v1.UpdateComponentFirmwareResponse
-	25, // 29: v1.UpdateFirmwareResponse.responses:type_name -> v1.UpdatePowershelfFirmwareResponse
+	25, // 28: v1.UpdatePowershelfFirmwareResponse.components:type_name -> v1.UpdateComponentFirmwareResponse
+	26, // 29: v1.UpdateFirmwareResponse.responses:type_name -> v1.UpdatePowershelfFirmwareResponse
 	2,  // 30: v1.ComponentFirmwareUpgrades.component:type_name -> v1.PowershelfComponent
-	28, // 31: v1.ComponentFirmwareUpgrades.upgrades:type_name -> v1.FirmwareVersion
-	29, // 32: v1.AvailableFirmware.upgrades:type_name -> v1.ComponentFirmwareUpgrades
-	30, // 33: v1.ListAvailableFirmwareResponse.upgrades:type_name -> v1.AvailableFirmware
-	34, // 34: v1.GetFirmwareUpdateStatusRequest.queries:type_name -> v1.FirmwareUpdateQuery
+	29, // 31: v1.ComponentFirmwareUpgrades.upgrades:type_name -> v1.FirmwareVersion
+	30, // 32: v1.AvailableFirmware.upgrades:type_name -> v1.ComponentFirmwareUpgrades
+	31, // 33: v1.ListAvailableFirmwareResponse.upgrades:type_name -> v1.AvailableFirmware
+	35, // 34: v1.GetFirmwareUpdateStatusRequest.queries:type_name -> v1.FirmwareUpdateQuery
 	2,  // 35: v1.FirmwareUpdateQuery.component:type_name -> v1.PowershelfComponent
-	36, // 36: v1.GetFirmwareUpdateStatusResponse.statuses:type_name -> v1.FirmwareUpdateStatus
+	37, // 36: v1.GetFirmwareUpdateStatusResponse.statuses:type_name -> v1.FirmwareUpdateStatus
 	2,  // 37: v1.FirmwareUpdateStatus.component:type_name -> v1.PowershelfComponent
 	3,  // 38: v1.FirmwareUpdateStatus.state:type_name -> v1.FirmwareUpdateState
 	1,  // 39: v1.FirmwareUpdateStatus.status:type_name -> v1.StatusCode
 	13, // 40: v1.PowershelfManager.RegisterPowershelves:input_type -> v1.RegisterPowershelvesRequest
 	16, // 41: v1.PowershelfManager.GetPowershelves:input_type -> v1.PowershelfRequest
-	23, // 42: v1.PowershelfManager.UpdateFirmware:input_type -> v1.UpdateFirmwareRequest
-	33, // 43: v1.PowershelfManager.GetFirmwareUpdateStatus:input_type -> v1.GetFirmwareUpdateStatusRequest
+	24, // 42: v1.PowershelfManager.UpdateFirmware:input_type -> v1.UpdateFirmwareRequest
+	34, // 43: v1.PowershelfManager.GetFirmwareUpdateStatus:input_type -> v1.GetFirmwareUpdateStatusRequest
 	16, // 44: v1.PowershelfManager.ListAvailableFirmware:input_type -> v1.PowershelfRequest
-	32, // 45: v1.PowershelfManager.SetDryRun:input_type -> v1.SetDryRunRequest
-	16, // 46: v1.PowershelfManager.PowerOff:input_type -> v1.PowershelfRequest
-	16, // 47: v1.PowershelfManager.PowerOn:input_type -> v1.PowershelfRequest
+	33, // 45: v1.PowershelfManager.SetDryRun:input_type -> v1.SetDryRunRequest
+	17, // 46: v1.PowershelfManager.PowerOff:input_type -> v1.PowerRequest
+	17, // 47: v1.PowershelfManager.PowerOn:input_type -> v1.PowerRequest
 	15, // 48: v1.PowershelfManager.RegisterPowershelves:output_type -> v1.RegisterPowershelvesResponse
-	20, // 49: v1.PowershelfManager.GetPowershelves:output_type -> v1.GetPowershelvesResponse
-	26, // 50: v1.PowershelfManager.UpdateFirmware:output_type -> v1.UpdateFirmwareResponse
-	35, // 51: v1.PowershelfManager.GetFirmwareUpdateStatus:output_type -> v1.GetFirmwareUpdateStatusResponse
-	31, // 52: v1.PowershelfManager.ListAvailableFirmware:output_type -> v1.ListAvailableFirmwareResponse
-	38, // 53: v1.PowershelfManager.SetDryRun:output_type -> google.protobuf.Empty
-	18, // 54: v1.PowershelfManager.PowerOff:output_type -> v1.PowerControlResponse
-	18, // 55: v1.PowershelfManager.PowerOn:output_type -> v1.PowerControlResponse
+	21, // 49: v1.PowershelfManager.GetPowershelves:output_type -> v1.GetPowershelvesResponse
+	27, // 50: v1.PowershelfManager.UpdateFirmware:output_type -> v1.UpdateFirmwareResponse
+	36, // 51: v1.PowershelfManager.GetFirmwareUpdateStatus:output_type -> v1.GetFirmwareUpdateStatusResponse
+	32, // 52: v1.PowershelfManager.ListAvailableFirmware:output_type -> v1.ListAvailableFirmwareResponse
+	39, // 53: v1.PowershelfManager.SetDryRun:output_type -> google.protobuf.Empty
+	19, // 54: v1.PowershelfManager.PowerOff:output_type -> v1.PowerControlResponse
+	19, // 55: v1.PowershelfManager.PowerOn:output_type -> v1.PowerControlResponse
 	48, // [48:56] is the sub-list for method output_type
 	40, // [40:48] is the sub-list for method input_type
 	40, // [40:40] is the sub-list for extension type_name
@@ -2437,7 +2488,7 @@ func file_internal_proto_v1_powershelf_manager_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internal_proto_v1_powershelf_manager_proto_rawDesc), len(file_internal_proto_v1_powershelf_manager_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   33,
+			NumMessages:   34,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/powershelf-manager/internal/proto/v1/powershelf-manager.pb.go
+++ b/powershelf-manager/internal/proto/v1/powershelf-manager.pb.go
@@ -1174,6 +1174,7 @@ type PowershelfResponse struct {
 	PmcMacAddress string                 `protobuf:"bytes,1,opt,name=pmc_mac_address,json=pmcMacAddress,proto3" json:"pmc_mac_address,omitempty"`
 	Status        StatusCode             `protobuf:"varint,2,opt,name=status,proto3,enum=v1.StatusCode" json:"status,omitempty"`
 	Error         string                 `protobuf:"bytes,3,opt,name=error,proto3" json:"error,omitempty"`
+	PmcIp         string                 `protobuf:"bytes,4,opt,name=pmc_ip,json=pmcIp,proto3" json:"pmc_ip,omitempty"` // Set for direct PowerTarget responses; empty for registered shelves
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1225,6 +1226,13 @@ func (x *PowershelfResponse) GetStatus() StatusCode {
 func (x *PowershelfResponse) GetError() string {
 	if x != nil {
 		return x.Error
+	}
+	return ""
+}
+
+func (x *PowershelfResponse) GetPmcIp() string {
+	if x != nil {
+		return x.PmcIp
 	}
 	return ""
 }
@@ -2265,11 +2273,12 @@ const file_internal_proto_v1_powershelf_manager_proto_rawDesc = "" +
 	"\bpmc_macs\x18\x01 \x03(\tR\apmcMacs\"T\n" +
 	"\fPowerRequest\x12\x19\n" +
 	"\bpmc_macs\x18\x01 \x03(\tR\apmcMacs\x12)\n" +
-	"\atargets\x18\x02 \x03(\v2\x0f.v1.PowerTargetR\atargets\"z\n" +
+	"\atargets\x18\x02 \x03(\v2\x0f.v1.PowerTargetR\atargets\"\x91\x01\n" +
 	"\x12PowershelfResponse\x12&\n" +
 	"\x0fpmc_mac_address\x18\x01 \x01(\tR\rpmcMacAddress\x12&\n" +
 	"\x06status\x18\x02 \x01(\x0e2\x0e.v1.StatusCodeR\x06status\x12\x14\n" +
-	"\x05error\x18\x03 \x01(\tR\x05error\"L\n" +
+	"\x05error\x18\x03 \x01(\tR\x05error\x12\x15\n" +
+	"\x06pmc_ip\x18\x04 \x01(\tR\x05pmcIp\"L\n" +
 	"\x14PowerControlResponse\x124\n" +
 	"\tresponses\x18\x01 \x03(\v2\x16.v1.PowershelfResponseR\tresponses\"\x8c\x01\n" +
 	"\vPowerTarget\x12\x15\n" +

--- a/powershelf-manager/internal/proto/v1/powershelf-manager.pb.go
+++ b/powershelf-manager/internal/proto/v1/powershelf-manager.pb.go
@@ -1073,6 +1073,7 @@ func (x *RegisterPowershelvesResponse) GetResponses() []*RegisterPowershelfRespo
 type PowershelfRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	PmcMacs       []string               `protobuf:"bytes,1,rep,name=pmc_macs,json=pmcMacs,proto3" json:"pmc_macs,omitempty"`
+	Targets       []*PowerTarget         `protobuf:"bytes,2,rep,name=targets,proto3" json:"targets,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1110,6 +1111,13 @@ func (*PowershelfRequest) Descriptor() ([]byte, []int) {
 func (x *PowershelfRequest) GetPmcMacs() []string {
 	if x != nil {
 		return x.PmcMacs
+	}
+	return nil
+}
+
+func (x *PowershelfRequest) GetTargets() []*PowerTarget {
+	if x != nil {
+		return x.Targets
 	}
 	return nil
 }
@@ -1218,6 +1226,68 @@ func (x *PowerControlResponse) GetResponses() []*PowershelfResponse {
 	return nil
 }
 
+// PowerTarget allows power control against a device without prior registration.
+// Only IP and credentials are required; the registry and credential manager are bypassed.
+type PowerTarget struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	PmcIp         string                 `protobuf:"bytes,1,opt,name=pmc_ip,json=pmcIp,proto3" json:"pmc_ip,omitempty"`
+	Credentials   *Credentials           `protobuf:"bytes,2,opt,name=credentials,proto3" json:"credentials,omitempty"`
+	Vendor        PMCVendor              `protobuf:"varint,3,opt,name=vendor,proto3,enum=v1.PMCVendor" json:"vendor,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PowerTarget) Reset() {
+	*x = PowerTarget{}
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PowerTarget) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PowerTarget) ProtoMessage() {}
+
+func (x *PowerTarget) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PowerTarget.ProtoReflect.Descriptor instead.
+func (*PowerTarget) Descriptor() ([]byte, []int) {
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *PowerTarget) GetPmcIp() string {
+	if x != nil {
+		return x.PmcIp
+	}
+	return ""
+}
+
+func (x *PowerTarget) GetCredentials() *Credentials {
+	if x != nil {
+		return x.Credentials
+	}
+	return nil
+}
+
+func (x *PowerTarget) GetVendor() PMCVendor {
+	if x != nil {
+		return x.Vendor
+	}
+	return PMCVendor_PMC_TYPE_UNKNOWN
+}
+
 type GetPowershelvesResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Powershelves  []*PowerShelf          `protobuf:"bytes,1,rep,name=powershelves,proto3" json:"powershelves,omitempty"`
@@ -1227,7 +1297,7 @@ type GetPowershelvesResponse struct {
 
 func (x *GetPowershelvesResponse) Reset() {
 	*x = GetPowershelvesResponse{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[15]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1239,7 +1309,7 @@ func (x *GetPowershelvesResponse) String() string {
 func (*GetPowershelvesResponse) ProtoMessage() {}
 
 func (x *GetPowershelvesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[15]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1252,7 +1322,7 @@ func (x *GetPowershelvesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetPowershelvesResponse.ProtoReflect.Descriptor instead.
 func (*GetPowershelvesResponse) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{15}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *GetPowershelvesResponse) GetPowershelves() []*PowerShelf {
@@ -1272,7 +1342,7 @@ type UpdateComponentFirmwareRequest struct {
 
 func (x *UpdateComponentFirmwareRequest) Reset() {
 	*x = UpdateComponentFirmwareRequest{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[16]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1284,7 +1354,7 @@ func (x *UpdateComponentFirmwareRequest) String() string {
 func (*UpdateComponentFirmwareRequest) ProtoMessage() {}
 
 func (x *UpdateComponentFirmwareRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[16]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1297,7 +1367,7 @@ func (x *UpdateComponentFirmwareRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateComponentFirmwareRequest.ProtoReflect.Descriptor instead.
 func (*UpdateComponentFirmwareRequest) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{16}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *UpdateComponentFirmwareRequest) GetComponent() PowershelfComponent {
@@ -1324,7 +1394,7 @@ type UpdatePowershelfFirmwareRequest struct {
 
 func (x *UpdatePowershelfFirmwareRequest) Reset() {
 	*x = UpdatePowershelfFirmwareRequest{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[17]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1336,7 +1406,7 @@ func (x *UpdatePowershelfFirmwareRequest) String() string {
 func (*UpdatePowershelfFirmwareRequest) ProtoMessage() {}
 
 func (x *UpdatePowershelfFirmwareRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[17]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1349,7 +1419,7 @@ func (x *UpdatePowershelfFirmwareRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdatePowershelfFirmwareRequest.ProtoReflect.Descriptor instead.
 func (*UpdatePowershelfFirmwareRequest) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{17}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *UpdatePowershelfFirmwareRequest) GetPmcMacAddress() string {
@@ -1375,7 +1445,7 @@ type UpdateFirmwareRequest struct {
 
 func (x *UpdateFirmwareRequest) Reset() {
 	*x = UpdateFirmwareRequest{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[18]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1387,7 +1457,7 @@ func (x *UpdateFirmwareRequest) String() string {
 func (*UpdateFirmwareRequest) ProtoMessage() {}
 
 func (x *UpdateFirmwareRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[18]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1400,7 +1470,7 @@ func (x *UpdateFirmwareRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateFirmwareRequest.ProtoReflect.Descriptor instead.
 func (*UpdateFirmwareRequest) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{18}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *UpdateFirmwareRequest) GetUpgrades() []*UpdatePowershelfFirmwareRequest {
@@ -1421,7 +1491,7 @@ type UpdateComponentFirmwareResponse struct {
 
 func (x *UpdateComponentFirmwareResponse) Reset() {
 	*x = UpdateComponentFirmwareResponse{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[19]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1433,7 +1503,7 @@ func (x *UpdateComponentFirmwareResponse) String() string {
 func (*UpdateComponentFirmwareResponse) ProtoMessage() {}
 
 func (x *UpdateComponentFirmwareResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[19]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1446,7 +1516,7 @@ func (x *UpdateComponentFirmwareResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateComponentFirmwareResponse.ProtoReflect.Descriptor instead.
 func (*UpdateComponentFirmwareResponse) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{19}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *UpdateComponentFirmwareResponse) GetComponent() PowershelfComponent {
@@ -1480,7 +1550,7 @@ type UpdatePowershelfFirmwareResponse struct {
 
 func (x *UpdatePowershelfFirmwareResponse) Reset() {
 	*x = UpdatePowershelfFirmwareResponse{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[20]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1492,7 +1562,7 @@ func (x *UpdatePowershelfFirmwareResponse) String() string {
 func (*UpdatePowershelfFirmwareResponse) ProtoMessage() {}
 
 func (x *UpdatePowershelfFirmwareResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[20]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1505,7 +1575,7 @@ func (x *UpdatePowershelfFirmwareResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdatePowershelfFirmwareResponse.ProtoReflect.Descriptor instead.
 func (*UpdatePowershelfFirmwareResponse) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{20}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *UpdatePowershelfFirmwareResponse) GetPmcMacAddress() string {
@@ -1531,7 +1601,7 @@ type UpdateFirmwareResponse struct {
 
 func (x *UpdateFirmwareResponse) Reset() {
 	*x = UpdateFirmwareResponse{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[21]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1543,7 +1613,7 @@ func (x *UpdateFirmwareResponse) String() string {
 func (*UpdateFirmwareResponse) ProtoMessage() {}
 
 func (x *UpdateFirmwareResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[21]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1556,7 +1626,7 @@ func (x *UpdateFirmwareResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateFirmwareResponse.ProtoReflect.Descriptor instead.
 func (*UpdateFirmwareResponse) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{21}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *UpdateFirmwareResponse) GetResponses() []*UpdatePowershelfFirmwareResponse {
@@ -1575,7 +1645,7 @@ type CanUpdateFirmwareResponse struct {
 
 func (x *CanUpdateFirmwareResponse) Reset() {
 	*x = CanUpdateFirmwareResponse{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[22]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1587,7 +1657,7 @@ func (x *CanUpdateFirmwareResponse) String() string {
 func (*CanUpdateFirmwareResponse) ProtoMessage() {}
 
 func (x *CanUpdateFirmwareResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[22]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1600,7 +1670,7 @@ func (x *CanUpdateFirmwareResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CanUpdateFirmwareResponse.ProtoReflect.Descriptor instead.
 func (*CanUpdateFirmwareResponse) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{22}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *CanUpdateFirmwareResponse) GetCanUpdate() bool {
@@ -1619,7 +1689,7 @@ type FirmwareVersion struct {
 
 func (x *FirmwareVersion) Reset() {
 	*x = FirmwareVersion{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[23]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1631,7 +1701,7 @@ func (x *FirmwareVersion) String() string {
 func (*FirmwareVersion) ProtoMessage() {}
 
 func (x *FirmwareVersion) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[23]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1644,7 +1714,7 @@ func (x *FirmwareVersion) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FirmwareVersion.ProtoReflect.Descriptor instead.
 func (*FirmwareVersion) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{23}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *FirmwareVersion) GetVersion() string {
@@ -1664,7 +1734,7 @@ type ComponentFirmwareUpgrades struct {
 
 func (x *ComponentFirmwareUpgrades) Reset() {
 	*x = ComponentFirmwareUpgrades{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[24]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1676,7 +1746,7 @@ func (x *ComponentFirmwareUpgrades) String() string {
 func (*ComponentFirmwareUpgrades) ProtoMessage() {}
 
 func (x *ComponentFirmwareUpgrades) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[24]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1689,7 +1759,7 @@ func (x *ComponentFirmwareUpgrades) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ComponentFirmwareUpgrades.ProtoReflect.Descriptor instead.
 func (*ComponentFirmwareUpgrades) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{24}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *ComponentFirmwareUpgrades) GetComponent() PowershelfComponent {
@@ -1716,7 +1786,7 @@ type AvailableFirmware struct {
 
 func (x *AvailableFirmware) Reset() {
 	*x = AvailableFirmware{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[25]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1728,7 +1798,7 @@ func (x *AvailableFirmware) String() string {
 func (*AvailableFirmware) ProtoMessage() {}
 
 func (x *AvailableFirmware) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[25]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1741,7 +1811,7 @@ func (x *AvailableFirmware) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AvailableFirmware.ProtoReflect.Descriptor instead.
 func (*AvailableFirmware) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{25}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *AvailableFirmware) GetPmcMacAddress() string {
@@ -1767,7 +1837,7 @@ type ListAvailableFirmwareResponse struct {
 
 func (x *ListAvailableFirmwareResponse) Reset() {
 	*x = ListAvailableFirmwareResponse{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[26]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1779,7 +1849,7 @@ func (x *ListAvailableFirmwareResponse) String() string {
 func (*ListAvailableFirmwareResponse) ProtoMessage() {}
 
 func (x *ListAvailableFirmwareResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[26]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1792,7 +1862,7 @@ func (x *ListAvailableFirmwareResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAvailableFirmwareResponse.ProtoReflect.Descriptor instead.
 func (*ListAvailableFirmwareResponse) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{26}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ListAvailableFirmwareResponse) GetUpgrades() []*AvailableFirmware {
@@ -1811,7 +1881,7 @@ type SetDryRunRequest struct {
 
 func (x *SetDryRunRequest) Reset() {
 	*x = SetDryRunRequest{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[27]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1823,7 +1893,7 @@ func (x *SetDryRunRequest) String() string {
 func (*SetDryRunRequest) ProtoMessage() {}
 
 func (x *SetDryRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[27]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1836,7 +1906,7 @@ func (x *SetDryRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetDryRunRequest.ProtoReflect.Descriptor instead.
 func (*SetDryRunRequest) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{27}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *SetDryRunRequest) GetDryRun() bool {
@@ -1856,7 +1926,7 @@ type GetFirmwareUpdateStatusRequest struct {
 
 func (x *GetFirmwareUpdateStatusRequest) Reset() {
 	*x = GetFirmwareUpdateStatusRequest{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[28]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1868,7 +1938,7 @@ func (x *GetFirmwareUpdateStatusRequest) String() string {
 func (*GetFirmwareUpdateStatusRequest) ProtoMessage() {}
 
 func (x *GetFirmwareUpdateStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[28]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1881,7 +1951,7 @@ func (x *GetFirmwareUpdateStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFirmwareUpdateStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetFirmwareUpdateStatusRequest) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{28}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *GetFirmwareUpdateStatusRequest) GetQueries() []*FirmwareUpdateQuery {
@@ -1902,7 +1972,7 @@ type FirmwareUpdateQuery struct {
 
 func (x *FirmwareUpdateQuery) Reset() {
 	*x = FirmwareUpdateQuery{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[29]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1914,7 +1984,7 @@ func (x *FirmwareUpdateQuery) String() string {
 func (*FirmwareUpdateQuery) ProtoMessage() {}
 
 func (x *FirmwareUpdateQuery) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[29]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1927,7 +1997,7 @@ func (x *FirmwareUpdateQuery) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FirmwareUpdateQuery.ProtoReflect.Descriptor instead.
 func (*FirmwareUpdateQuery) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{29}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *FirmwareUpdateQuery) GetPmcMacAddress() string {
@@ -1954,7 +2024,7 @@ type GetFirmwareUpdateStatusResponse struct {
 
 func (x *GetFirmwareUpdateStatusResponse) Reset() {
 	*x = GetFirmwareUpdateStatusResponse{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[30]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1966,7 +2036,7 @@ func (x *GetFirmwareUpdateStatusResponse) String() string {
 func (*GetFirmwareUpdateStatusResponse) ProtoMessage() {}
 
 func (x *GetFirmwareUpdateStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[30]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1979,7 +2049,7 @@ func (x *GetFirmwareUpdateStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFirmwareUpdateStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetFirmwareUpdateStatusResponse) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{30}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *GetFirmwareUpdateStatusResponse) GetStatuses() []*FirmwareUpdateStatus {
@@ -2003,7 +2073,7 @@ type FirmwareUpdateStatus struct {
 
 func (x *FirmwareUpdateStatus) Reset() {
 	*x = FirmwareUpdateStatus{}
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[31]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2015,7 +2085,7 @@ func (x *FirmwareUpdateStatus) String() string {
 func (*FirmwareUpdateStatus) ProtoMessage() {}
 
 func (x *FirmwareUpdateStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[31]
+	mi := &file_internal_proto_v1_powershelf_manager_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2028,7 +2098,7 @@ func (x *FirmwareUpdateStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FirmwareUpdateStatus.ProtoReflect.Descriptor instead.
 func (*FirmwareUpdateStatus) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{31}
+	return file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *FirmwareUpdateStatus) GetPmcMacAddress() string {
@@ -2143,15 +2213,20 @@ const file_internal_proto_v1_powershelf_manager_proto_rawDesc = "" +
 	"\x06status\x18\x04 \x01(\x0e2\x0e.v1.StatusCodeR\x06status\x12\x14\n" +
 	"\x05error\x18\x05 \x01(\tR\x05error\"\\\n" +
 	"\x1cRegisterPowershelvesResponse\x12<\n" +
-	"\tresponses\x18\x01 \x03(\v2\x1e.v1.RegisterPowershelfResponseR\tresponses\".\n" +
+	"\tresponses\x18\x01 \x03(\v2\x1e.v1.RegisterPowershelfResponseR\tresponses\"Y\n" +
 	"\x11PowershelfRequest\x12\x19\n" +
-	"\bpmc_macs\x18\x01 \x03(\tR\apmcMacs\"z\n" +
+	"\bpmc_macs\x18\x01 \x03(\tR\apmcMacs\x12)\n" +
+	"\atargets\x18\x02 \x03(\v2\x0f.v1.PowerTargetR\atargets\"z\n" +
 	"\x12PowershelfResponse\x12&\n" +
 	"\x0fpmc_mac_address\x18\x01 \x01(\tR\rpmcMacAddress\x12&\n" +
 	"\x06status\x18\x02 \x01(\x0e2\x0e.v1.StatusCodeR\x06status\x12\x14\n" +
 	"\x05error\x18\x03 \x01(\tR\x05error\"L\n" +
 	"\x14PowerControlResponse\x124\n" +
-	"\tresponses\x18\x01 \x03(\v2\x16.v1.PowershelfResponseR\tresponses\"M\n" +
+	"\tresponses\x18\x01 \x03(\v2\x16.v1.PowershelfResponseR\tresponses\"~\n" +
+	"\vPowerTarget\x12\x15\n" +
+	"\x06pmc_ip\x18\x01 \x01(\tR\x05pmcIp\x121\n" +
+	"\vcredentials\x18\x02 \x01(\v2\x0f.v1.CredentialsR\vcredentials\x12%\n" +
+	"\x06vendor\x18\x03 \x01(\x0e2\r.v1.PMCVendorR\x06vendor\"M\n" +
 	"\x17GetPowershelvesResponse\x122\n" +
 	"\fpowershelves\x18\x01 \x03(\v2\x0e.v1.PowerShelfR\fpowershelves\"\x8a\x01\n" +
 	"\x1eUpdateComponentFirmwareRequest\x125\n" +
@@ -2245,7 +2320,7 @@ func file_internal_proto_v1_powershelf_manager_proto_rawDescGZIP() []byte {
 }
 
 var file_internal_proto_v1_powershelf_manager_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_internal_proto_v1_powershelf_manager_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
+var file_internal_proto_v1_powershelf_manager_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
 var file_internal_proto_v1_powershelf_manager_proto_goTypes = []any{
 	(PMCVendor)(0),                           // 0: v1.PMCVendor
 	(StatusCode)(0),                          // 1: v1.StatusCode
@@ -2266,25 +2341,26 @@ var file_internal_proto_v1_powershelf_manager_proto_goTypes = []any{
 	(*PowershelfRequest)(nil),                // 16: v1.PowershelfRequest
 	(*PowershelfResponse)(nil),               // 17: v1.PowershelfResponse
 	(*PowerControlResponse)(nil),             // 18: v1.PowerControlResponse
-	(*GetPowershelvesResponse)(nil),          // 19: v1.GetPowershelvesResponse
-	(*UpdateComponentFirmwareRequest)(nil),   // 20: v1.UpdateComponentFirmwareRequest
-	(*UpdatePowershelfFirmwareRequest)(nil),  // 21: v1.UpdatePowershelfFirmwareRequest
-	(*UpdateFirmwareRequest)(nil),            // 22: v1.UpdateFirmwareRequest
-	(*UpdateComponentFirmwareResponse)(nil),  // 23: v1.UpdateComponentFirmwareResponse
-	(*UpdatePowershelfFirmwareResponse)(nil), // 24: v1.UpdatePowershelfFirmwareResponse
-	(*UpdateFirmwareResponse)(nil),           // 25: v1.UpdateFirmwareResponse
-	(*CanUpdateFirmwareResponse)(nil),        // 26: v1.CanUpdateFirmwareResponse
-	(*FirmwareVersion)(nil),                  // 27: v1.FirmwareVersion
-	(*ComponentFirmwareUpgrades)(nil),        // 28: v1.ComponentFirmwareUpgrades
-	(*AvailableFirmware)(nil),                // 29: v1.AvailableFirmware
-	(*ListAvailableFirmwareResponse)(nil),    // 30: v1.ListAvailableFirmwareResponse
-	(*SetDryRunRequest)(nil),                 // 31: v1.SetDryRunRequest
-	(*GetFirmwareUpdateStatusRequest)(nil),   // 32: v1.GetFirmwareUpdateStatusRequest
-	(*FirmwareUpdateQuery)(nil),              // 33: v1.FirmwareUpdateQuery
-	(*GetFirmwareUpdateStatusResponse)(nil),  // 34: v1.GetFirmwareUpdateStatusResponse
-	(*FirmwareUpdateStatus)(nil),             // 35: v1.FirmwareUpdateStatus
-	(*timestamppb.Timestamp)(nil),            // 36: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),                    // 37: google.protobuf.Empty
+	(*PowerTarget)(nil),                      // 19: v1.PowerTarget
+	(*GetPowershelvesResponse)(nil),          // 20: v1.GetPowershelvesResponse
+	(*UpdateComponentFirmwareRequest)(nil),   // 21: v1.UpdateComponentFirmwareRequest
+	(*UpdatePowershelfFirmwareRequest)(nil),  // 22: v1.UpdatePowershelfFirmwareRequest
+	(*UpdateFirmwareRequest)(nil),            // 23: v1.UpdateFirmwareRequest
+	(*UpdateComponentFirmwareResponse)(nil),  // 24: v1.UpdateComponentFirmwareResponse
+	(*UpdatePowershelfFirmwareResponse)(nil), // 25: v1.UpdatePowershelfFirmwareResponse
+	(*UpdateFirmwareResponse)(nil),           // 26: v1.UpdateFirmwareResponse
+	(*CanUpdateFirmwareResponse)(nil),        // 27: v1.CanUpdateFirmwareResponse
+	(*FirmwareVersion)(nil),                  // 28: v1.FirmwareVersion
+	(*ComponentFirmwareUpgrades)(nil),        // 29: v1.ComponentFirmwareUpgrades
+	(*AvailableFirmware)(nil),                // 30: v1.AvailableFirmware
+	(*ListAvailableFirmwareResponse)(nil),    // 31: v1.ListAvailableFirmwareResponse
+	(*SetDryRunRequest)(nil),                 // 32: v1.SetDryRunRequest
+	(*GetFirmwareUpdateStatusRequest)(nil),   // 33: v1.GetFirmwareUpdateStatusRequest
+	(*FirmwareUpdateQuery)(nil),              // 34: v1.FirmwareUpdateQuery
+	(*GetFirmwareUpdateStatusResponse)(nil),  // 35: v1.GetFirmwareUpdateStatusResponse
+	(*FirmwareUpdateStatus)(nil),             // 36: v1.FirmwareUpdateStatus
+	(*timestamppb.Timestamp)(nil),            // 37: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),                    // 38: google.protobuf.Empty
 }
 var file_internal_proto_v1_powershelf_manager_proto_depIdxs = []int32{
 	0,  // 0: v1.PowerManagementController.vendor:type_name -> v1.PMCVendor
@@ -2300,51 +2376,54 @@ var file_internal_proto_v1_powershelf_manager_proto_depIdxs = []int32{
 	0,  // 10: v1.RegisterPowershelfRequest.pmc_vendor:type_name -> v1.PMCVendor
 	4,  // 11: v1.RegisterPowershelfRequest.pmc_credentials:type_name -> v1.Credentials
 	12, // 12: v1.RegisterPowershelvesRequest.registration_requests:type_name -> v1.RegisterPowershelfRequest
-	36, // 13: v1.RegisterPowershelfResponse.created:type_name -> google.protobuf.Timestamp
+	37, // 13: v1.RegisterPowershelfResponse.created:type_name -> google.protobuf.Timestamp
 	1,  // 14: v1.RegisterPowershelfResponse.status:type_name -> v1.StatusCode
 	14, // 15: v1.RegisterPowershelvesResponse.responses:type_name -> v1.RegisterPowershelfResponse
-	1,  // 16: v1.PowershelfResponse.status:type_name -> v1.StatusCode
-	17, // 17: v1.PowerControlResponse.responses:type_name -> v1.PowershelfResponse
-	11, // 18: v1.GetPowershelvesResponse.powershelves:type_name -> v1.PowerShelf
-	2,  // 19: v1.UpdateComponentFirmwareRequest.component:type_name -> v1.PowershelfComponent
-	27, // 20: v1.UpdateComponentFirmwareRequest.upgradeTo:type_name -> v1.FirmwareVersion
-	20, // 21: v1.UpdatePowershelfFirmwareRequest.components:type_name -> v1.UpdateComponentFirmwareRequest
-	21, // 22: v1.UpdateFirmwareRequest.upgrades:type_name -> v1.UpdatePowershelfFirmwareRequest
-	2,  // 23: v1.UpdateComponentFirmwareResponse.component:type_name -> v1.PowershelfComponent
-	1,  // 24: v1.UpdateComponentFirmwareResponse.status:type_name -> v1.StatusCode
-	23, // 25: v1.UpdatePowershelfFirmwareResponse.components:type_name -> v1.UpdateComponentFirmwareResponse
-	24, // 26: v1.UpdateFirmwareResponse.responses:type_name -> v1.UpdatePowershelfFirmwareResponse
-	2,  // 27: v1.ComponentFirmwareUpgrades.component:type_name -> v1.PowershelfComponent
-	27, // 28: v1.ComponentFirmwareUpgrades.upgrades:type_name -> v1.FirmwareVersion
-	28, // 29: v1.AvailableFirmware.upgrades:type_name -> v1.ComponentFirmwareUpgrades
-	29, // 30: v1.ListAvailableFirmwareResponse.upgrades:type_name -> v1.AvailableFirmware
-	33, // 31: v1.GetFirmwareUpdateStatusRequest.queries:type_name -> v1.FirmwareUpdateQuery
-	2,  // 32: v1.FirmwareUpdateQuery.component:type_name -> v1.PowershelfComponent
-	35, // 33: v1.GetFirmwareUpdateStatusResponse.statuses:type_name -> v1.FirmwareUpdateStatus
-	2,  // 34: v1.FirmwareUpdateStatus.component:type_name -> v1.PowershelfComponent
-	3,  // 35: v1.FirmwareUpdateStatus.state:type_name -> v1.FirmwareUpdateState
-	1,  // 36: v1.FirmwareUpdateStatus.status:type_name -> v1.StatusCode
-	13, // 37: v1.PowershelfManager.RegisterPowershelves:input_type -> v1.RegisterPowershelvesRequest
-	16, // 38: v1.PowershelfManager.GetPowershelves:input_type -> v1.PowershelfRequest
-	22, // 39: v1.PowershelfManager.UpdateFirmware:input_type -> v1.UpdateFirmwareRequest
-	32, // 40: v1.PowershelfManager.GetFirmwareUpdateStatus:input_type -> v1.GetFirmwareUpdateStatusRequest
-	16, // 41: v1.PowershelfManager.ListAvailableFirmware:input_type -> v1.PowershelfRequest
-	31, // 42: v1.PowershelfManager.SetDryRun:input_type -> v1.SetDryRunRequest
-	16, // 43: v1.PowershelfManager.PowerOff:input_type -> v1.PowershelfRequest
-	16, // 44: v1.PowershelfManager.PowerOn:input_type -> v1.PowershelfRequest
-	15, // 45: v1.PowershelfManager.RegisterPowershelves:output_type -> v1.RegisterPowershelvesResponse
-	19, // 46: v1.PowershelfManager.GetPowershelves:output_type -> v1.GetPowershelvesResponse
-	25, // 47: v1.PowershelfManager.UpdateFirmware:output_type -> v1.UpdateFirmwareResponse
-	34, // 48: v1.PowershelfManager.GetFirmwareUpdateStatus:output_type -> v1.GetFirmwareUpdateStatusResponse
-	30, // 49: v1.PowershelfManager.ListAvailableFirmware:output_type -> v1.ListAvailableFirmwareResponse
-	37, // 50: v1.PowershelfManager.SetDryRun:output_type -> google.protobuf.Empty
-	18, // 51: v1.PowershelfManager.PowerOff:output_type -> v1.PowerControlResponse
-	18, // 52: v1.PowershelfManager.PowerOn:output_type -> v1.PowerControlResponse
-	45, // [45:53] is the sub-list for method output_type
-	37, // [37:45] is the sub-list for method input_type
-	37, // [37:37] is the sub-list for extension type_name
-	37, // [37:37] is the sub-list for extension extendee
-	0,  // [0:37] is the sub-list for field type_name
+	19, // 16: v1.PowershelfRequest.targets:type_name -> v1.PowerTarget
+	1,  // 17: v1.PowershelfResponse.status:type_name -> v1.StatusCode
+	17, // 18: v1.PowerControlResponse.responses:type_name -> v1.PowershelfResponse
+	4,  // 19: v1.PowerTarget.credentials:type_name -> v1.Credentials
+	0,  // 20: v1.PowerTarget.vendor:type_name -> v1.PMCVendor
+	11, // 21: v1.GetPowershelvesResponse.powershelves:type_name -> v1.PowerShelf
+	2,  // 22: v1.UpdateComponentFirmwareRequest.component:type_name -> v1.PowershelfComponent
+	28, // 23: v1.UpdateComponentFirmwareRequest.upgradeTo:type_name -> v1.FirmwareVersion
+	21, // 24: v1.UpdatePowershelfFirmwareRequest.components:type_name -> v1.UpdateComponentFirmwareRequest
+	22, // 25: v1.UpdateFirmwareRequest.upgrades:type_name -> v1.UpdatePowershelfFirmwareRequest
+	2,  // 26: v1.UpdateComponentFirmwareResponse.component:type_name -> v1.PowershelfComponent
+	1,  // 27: v1.UpdateComponentFirmwareResponse.status:type_name -> v1.StatusCode
+	24, // 28: v1.UpdatePowershelfFirmwareResponse.components:type_name -> v1.UpdateComponentFirmwareResponse
+	25, // 29: v1.UpdateFirmwareResponse.responses:type_name -> v1.UpdatePowershelfFirmwareResponse
+	2,  // 30: v1.ComponentFirmwareUpgrades.component:type_name -> v1.PowershelfComponent
+	28, // 31: v1.ComponentFirmwareUpgrades.upgrades:type_name -> v1.FirmwareVersion
+	29, // 32: v1.AvailableFirmware.upgrades:type_name -> v1.ComponentFirmwareUpgrades
+	30, // 33: v1.ListAvailableFirmwareResponse.upgrades:type_name -> v1.AvailableFirmware
+	34, // 34: v1.GetFirmwareUpdateStatusRequest.queries:type_name -> v1.FirmwareUpdateQuery
+	2,  // 35: v1.FirmwareUpdateQuery.component:type_name -> v1.PowershelfComponent
+	36, // 36: v1.GetFirmwareUpdateStatusResponse.statuses:type_name -> v1.FirmwareUpdateStatus
+	2,  // 37: v1.FirmwareUpdateStatus.component:type_name -> v1.PowershelfComponent
+	3,  // 38: v1.FirmwareUpdateStatus.state:type_name -> v1.FirmwareUpdateState
+	1,  // 39: v1.FirmwareUpdateStatus.status:type_name -> v1.StatusCode
+	13, // 40: v1.PowershelfManager.RegisterPowershelves:input_type -> v1.RegisterPowershelvesRequest
+	16, // 41: v1.PowershelfManager.GetPowershelves:input_type -> v1.PowershelfRequest
+	23, // 42: v1.PowershelfManager.UpdateFirmware:input_type -> v1.UpdateFirmwareRequest
+	33, // 43: v1.PowershelfManager.GetFirmwareUpdateStatus:input_type -> v1.GetFirmwareUpdateStatusRequest
+	16, // 44: v1.PowershelfManager.ListAvailableFirmware:input_type -> v1.PowershelfRequest
+	32, // 45: v1.PowershelfManager.SetDryRun:input_type -> v1.SetDryRunRequest
+	16, // 46: v1.PowershelfManager.PowerOff:input_type -> v1.PowershelfRequest
+	16, // 47: v1.PowershelfManager.PowerOn:input_type -> v1.PowershelfRequest
+	15, // 48: v1.PowershelfManager.RegisterPowershelves:output_type -> v1.RegisterPowershelvesResponse
+	20, // 49: v1.PowershelfManager.GetPowershelves:output_type -> v1.GetPowershelvesResponse
+	26, // 50: v1.PowershelfManager.UpdateFirmware:output_type -> v1.UpdateFirmwareResponse
+	35, // 51: v1.PowershelfManager.GetFirmwareUpdateStatus:output_type -> v1.GetFirmwareUpdateStatusResponse
+	31, // 52: v1.PowershelfManager.ListAvailableFirmware:output_type -> v1.ListAvailableFirmwareResponse
+	38, // 53: v1.PowershelfManager.SetDryRun:output_type -> google.protobuf.Empty
+	18, // 54: v1.PowershelfManager.PowerOff:output_type -> v1.PowerControlResponse
+	18, // 55: v1.PowershelfManager.PowerOn:output_type -> v1.PowerControlResponse
+	48, // [48:56] is the sub-list for method output_type
+	40, // [40:48] is the sub-list for method input_type
+	40, // [40:40] is the sub-list for extension type_name
+	40, // [40:40] is the sub-list for extension extendee
+	0,  // [0:40] is the sub-list for field type_name
 }
 
 func init() { file_internal_proto_v1_powershelf_manager_proto_init() }
@@ -2358,7 +2437,7 @@ func file_internal_proto_v1_powershelf_manager_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internal_proto_v1_powershelf_manager_proto_rawDesc), len(file_internal_proto_v1_powershelf_manager_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   32,
+			NumMessages:   33,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/powershelf-manager/internal/proto/v1/powershelf-manager.proto
+++ b/powershelf-manager/internal/proto/v1/powershelf-manager.proto
@@ -28,9 +28,9 @@ service PowershelfManager {
 
     // Power Control
     // Power OFF the rack
-    rpc PowerOff(PowershelfRequest) returns (PowerControlResponse);
+    rpc PowerOff(PowerRequest) returns (PowerControlResponse);
     // Power ON the rack
-    rpc PowerOn(PowershelfRequest) returns (PowerControlResponse);
+    rpc PowerOn(PowerRequest) returns (PowerControlResponse);
 }
 
 
@@ -142,6 +142,13 @@ message RegisterPowershelvesResponse {
 
 message PowershelfRequest {
     repeated string pmc_macs = 1;
+}
+
+// PowerRequest is used by PowerOn/PowerOff RPCs. Registered devices are
+// identified by MAC; unregistered devices use PowerTarget with inline
+// connection details.
+message PowerRequest {
+    repeated string pmc_macs = 1;
     repeated PowerTarget targets = 2;
 }
 
@@ -159,8 +166,8 @@ message PowerControlResponse {
 // Only IP and credentials are required; the registry and credential manager are bypassed.
 message PowerTarget {
     string pmc_ip = 1;
-    Credentials credentials = 2;
-    PMCVendor vendor = 3;
+    Credentials pmc_credentials = 2;
+    PMCVendor pmc_vendor = 3;
 }
 
 message GetPowershelvesResponse {

--- a/powershelf-manager/internal/proto/v1/powershelf-manager.proto
+++ b/powershelf-manager/internal/proto/v1/powershelf-manager.proto
@@ -156,6 +156,7 @@ message PowershelfResponse {
     string pmc_mac_address = 1;
     StatusCode status = 2;
     string error = 3;
+    string pmc_ip = 4;  // Set for direct PowerTarget responses; empty for registered shelves
 }
 
 message PowerControlResponse {

--- a/powershelf-manager/internal/proto/v1/powershelf-manager.proto
+++ b/powershelf-manager/internal/proto/v1/powershelf-manager.proto
@@ -142,6 +142,7 @@ message RegisterPowershelvesResponse {
 
 message PowershelfRequest {
     repeated string pmc_macs = 1;
+    repeated PowerTarget targets = 2;
 }
 
 message PowershelfResponse {
@@ -152,6 +153,14 @@ message PowershelfResponse {
 
 message PowerControlResponse {
     repeated PowershelfResponse responses = 1;
+}
+
+// PowerTarget allows power control against a device without prior registration.
+// Only IP and credentials are required; the registry and credential manager are bypassed.
+message PowerTarget {
+    string pmc_ip = 1;
+    Credentials credentials = 2;
+    PMCVendor vendor = 3;
 }
 
 message GetPowershelvesResponse {

--- a/powershelf-manager/internal/proto/v1/powershelf-manager_grpc.pb.go
+++ b/powershelf-manager/internal/proto/v1/powershelf-manager_grpc.pb.go
@@ -53,9 +53,9 @@ type PowershelfManagerClient interface {
 	SetDryRun(ctx context.Context, in *SetDryRunRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// Power Control
 	// Power OFF the rack
-	PowerOff(ctx context.Context, in *PowershelfRequest, opts ...grpc.CallOption) (*PowerControlResponse, error)
+	PowerOff(ctx context.Context, in *PowerRequest, opts ...grpc.CallOption) (*PowerControlResponse, error)
 	// Power ON the rack
-	PowerOn(ctx context.Context, in *PowershelfRequest, opts ...grpc.CallOption) (*PowerControlResponse, error)
+	PowerOn(ctx context.Context, in *PowerRequest, opts ...grpc.CallOption) (*PowerControlResponse, error)
 }
 
 type powershelfManagerClient struct {
@@ -126,7 +126,7 @@ func (c *powershelfManagerClient) SetDryRun(ctx context.Context, in *SetDryRunRe
 	return out, nil
 }
 
-func (c *powershelfManagerClient) PowerOff(ctx context.Context, in *PowershelfRequest, opts ...grpc.CallOption) (*PowerControlResponse, error) {
+func (c *powershelfManagerClient) PowerOff(ctx context.Context, in *PowerRequest, opts ...grpc.CallOption) (*PowerControlResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(PowerControlResponse)
 	err := c.cc.Invoke(ctx, PowershelfManager_PowerOff_FullMethodName, in, out, cOpts...)
@@ -136,7 +136,7 @@ func (c *powershelfManagerClient) PowerOff(ctx context.Context, in *PowershelfRe
 	return out, nil
 }
 
-func (c *powershelfManagerClient) PowerOn(ctx context.Context, in *PowershelfRequest, opts ...grpc.CallOption) (*PowerControlResponse, error) {
+func (c *powershelfManagerClient) PowerOn(ctx context.Context, in *PowerRequest, opts ...grpc.CallOption) (*PowerControlResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(PowerControlResponse)
 	err := c.cc.Invoke(ctx, PowershelfManager_PowerOn_FullMethodName, in, out, cOpts...)
@@ -169,9 +169,9 @@ type PowershelfManagerServer interface {
 	SetDryRun(context.Context, *SetDryRunRequest) (*emptypb.Empty, error)
 	// Power Control
 	// Power OFF the rack
-	PowerOff(context.Context, *PowershelfRequest) (*PowerControlResponse, error)
+	PowerOff(context.Context, *PowerRequest) (*PowerControlResponse, error)
 	// Power ON the rack
-	PowerOn(context.Context, *PowershelfRequest) (*PowerControlResponse, error)
+	PowerOn(context.Context, *PowerRequest) (*PowerControlResponse, error)
 	mustEmbedUnimplementedPowershelfManagerServer()
 }
 
@@ -200,10 +200,10 @@ func (UnimplementedPowershelfManagerServer) ListAvailableFirmware(context.Contex
 func (UnimplementedPowershelfManagerServer) SetDryRun(context.Context, *SetDryRunRequest) (*emptypb.Empty, error) {
 	return nil, status.Error(codes.Unimplemented, "method SetDryRun not implemented")
 }
-func (UnimplementedPowershelfManagerServer) PowerOff(context.Context, *PowershelfRequest) (*PowerControlResponse, error) {
+func (UnimplementedPowershelfManagerServer) PowerOff(context.Context, *PowerRequest) (*PowerControlResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method PowerOff not implemented")
 }
-func (UnimplementedPowershelfManagerServer) PowerOn(context.Context, *PowershelfRequest) (*PowerControlResponse, error) {
+func (UnimplementedPowershelfManagerServer) PowerOn(context.Context, *PowerRequest) (*PowerControlResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method PowerOn not implemented")
 }
 func (UnimplementedPowershelfManagerServer) mustEmbedUnimplementedPowershelfManagerServer() {}
@@ -336,7 +336,7 @@ func _PowershelfManager_SetDryRun_Handler(srv interface{}, ctx context.Context, 
 }
 
 func _PowershelfManager_PowerOff_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(PowershelfRequest)
+	in := new(PowerRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -348,13 +348,13 @@ func _PowershelfManager_PowerOff_Handler(srv interface{}, ctx context.Context, d
 		FullMethod: PowershelfManager_PowerOff_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(PowershelfManagerServer).PowerOff(ctx, req.(*PowershelfRequest))
+		return srv.(PowershelfManagerServer).PowerOff(ctx, req.(*PowerRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _PowershelfManager_PowerOn_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(PowershelfRequest)
+	in := new(PowerRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -366,7 +366,7 @@ func _PowershelfManager_PowerOn_Handler(srv interface{}, ctx context.Context, de
 		FullMethod: PowershelfManager_PowerOn_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(PowershelfManagerServer).PowerOn(ctx, req.(*PowershelfRequest))
+		return srv.(PowershelfManagerServer).PowerOn(ctx, req.(*PowerRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }

--- a/powershelf-manager/internal/service/server_impl.go
+++ b/powershelf-manager/internal/service/server_impl.go
@@ -349,7 +349,7 @@ func (s *PowershelfManagerServerImpl) powerOn(ctx context.Context, pmc_mac strin
 	}
 }
 
-func (s *PowershelfManagerServerImpl) PowerOff(ctx context.Context, req *pb.PowershelfRequest) (*pb.PowerControlResponse, error) {
+func (s *PowershelfManagerServerImpl) PowerOff(ctx context.Context, req *pb.PowerRequest) (*pb.PowerControlResponse, error) {
 	responses := make([]*pb.PowershelfResponse, 0, len(req.PmcMacs)+len(req.Targets))
 	for _, mac := range req.PmcMacs {
 		responses = append(responses, s.powerOff(ctx, mac))
@@ -363,7 +363,7 @@ func (s *PowershelfManagerServerImpl) PowerOff(ctx context.Context, req *pb.Powe
 	}, nil
 }
 
-func (s *PowershelfManagerServerImpl) PowerOn(ctx context.Context, req *pb.PowershelfRequest) (*pb.PowerControlResponse, error) {
+func (s *PowershelfManagerServerImpl) PowerOn(ctx context.Context, req *pb.PowerRequest) (*pb.PowerControlResponse, error) {
 	responses := make([]*pb.PowershelfResponse, 0, len(req.PmcMacs)+len(req.Targets))
 	for _, mac := range req.PmcMacs {
 		responses = append(responses, s.powerOn(ctx, mac))
@@ -388,7 +388,7 @@ func (s *PowershelfManagerServerImpl) powerTarget(ctx context.Context, target *p
 		}
 	}
 
-	if target.Credentials == nil {
+	if target.PmcCredentials == nil {
 		return &pb.PowershelfResponse{
 			PmcMacAddress: target.PmcIp,
 			Status:        pb.StatusCode_INVALID_ARGUMENT,
@@ -396,10 +396,18 @@ func (s *PowershelfManagerServerImpl) powerTarget(ctx context.Context, target *p
 		}
 	}
 
-	cred := credential.New(target.Credentials.Username, target.Credentials.Password)
+	if target.PmcCredentials.Username == "" || target.PmcCredentials.Password == "" {
+		return &pb.PowershelfResponse{
+			PmcMacAddress: target.PmcIp,
+			Status:        pb.StatusCode_INVALID_ARGUMENT,
+			Error:         "credentials username and password must not be empty",
+		}
+	}
+
+	cred := credential.New(target.PmcCredentials.Username, target.PmcCredentials.Password)
 	p := &pmc.PMC{
 		IP:         ip,
-		Vendor:     vendor.CodeToVendor(protobuf.PMCVendorFrom(target.Vendor)),
+		Vendor:     vendor.CodeToVendor(protobuf.PMCVendorFrom(target.PmcVendor)),
 		Credential: &cred,
 	}
 

--- a/powershelf-manager/internal/service/server_impl.go
+++ b/powershelf-manager/internal/service/server_impl.go
@@ -382,25 +382,25 @@ func (s *PowershelfManagerServerImpl) powerTarget(ctx context.Context, target *p
 	ip := net.ParseIP(target.PmcIp)
 	if ip == nil {
 		return &pb.PowershelfResponse{
-			PmcMacAddress: target.PmcIp,
-			Status:        pb.StatusCode_INVALID_ARGUMENT,
-			Error:         fmt.Sprintf("invalid PMC IP: %s", target.PmcIp),
+			PmcIp:  target.PmcIp,
+			Status: pb.StatusCode_INVALID_ARGUMENT,
+			Error:  fmt.Sprintf("invalid PMC IP: %s", target.PmcIp),
 		}
 	}
 
 	if target.PmcCredentials == nil {
 		return &pb.PowershelfResponse{
-			PmcMacAddress: target.PmcIp,
-			Status:        pb.StatusCode_INVALID_ARGUMENT,
-			Error:         "credentials are required for power targets",
+			PmcIp:  target.PmcIp,
+			Status: pb.StatusCode_INVALID_ARGUMENT,
+			Error:  "credentials are required for power targets",
 		}
 	}
 
 	if target.PmcCredentials.Username == "" || target.PmcCredentials.Password == "" {
 		return &pb.PowershelfResponse{
-			PmcMacAddress: target.PmcIp,
-			Status:        pb.StatusCode_INVALID_ARGUMENT,
-			Error:         "credentials username and password must not be empty",
+			PmcIp:  target.PmcIp,
+			Status: pb.StatusCode_INVALID_ARGUMENT,
+			Error:  "credentials username and password must not be empty",
 		}
 	}
 
@@ -413,15 +413,15 @@ func (s *PowershelfManagerServerImpl) powerTarget(ctx context.Context, target *p
 
 	if err := s.psm.PowerControlDirect(ctx, p, on); err != nil {
 		return &pb.PowershelfResponse{
-			PmcMacAddress: target.PmcIp,
-			Status:        pb.StatusCode_INTERNAL_ERROR,
-			Error:         err.Error(),
+			PmcIp:  target.PmcIp,
+			Status: pb.StatusCode_INTERNAL_ERROR,
+			Error:  err.Error(),
 		}
 	}
 
 	return &pb.PowershelfResponse{
-		PmcMacAddress: target.PmcIp,
-		Status:        pb.StatusCode_SUCCESS,
+		PmcIp:  target.PmcIp,
+		Status: pb.StatusCode_SUCCESS,
 	}
 }
 

--- a/powershelf-manager/internal/service/server_impl.go
+++ b/powershelf-manager/internal/service/server_impl.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/NVIDIA/ncx-infra-controller-rest/common/pkg/credential"
 	pb "github.com/NVIDIA/ncx-infra-controller-rest/powershelf-manager/internal/proto/v1"
+	"github.com/NVIDIA/ncx-infra-controller-rest/powershelf-manager/pkg/common/vendor"
 	"github.com/NVIDIA/ncx-infra-controller-rest/powershelf-manager/pkg/converter/protobuf"
 	"github.com/NVIDIA/ncx-infra-controller-rest/powershelf-manager/pkg/objects/pmc"
 	"github.com/NVIDIA/ncx-infra-controller-rest/powershelf-manager/pkg/powershelfmanager"
@@ -349,10 +350,12 @@ func (s *PowershelfManagerServerImpl) powerOn(ctx context.Context, pmc_mac strin
 }
 
 func (s *PowershelfManagerServerImpl) PowerOff(ctx context.Context, req *pb.PowershelfRequest) (*pb.PowerControlResponse, error) {
-	responses := make([]*pb.PowershelfResponse, 0, len(req.PmcMacs))
+	responses := make([]*pb.PowershelfResponse, 0, len(req.PmcMacs)+len(req.Targets))
 	for _, mac := range req.PmcMacs {
-		response := s.powerOff(ctx, mac)
-		responses = append(responses, response)
+		responses = append(responses, s.powerOff(ctx, mac))
+	}
+	for _, target := range req.Targets {
+		responses = append(responses, s.powerTarget(ctx, target, false))
 	}
 
 	return &pb.PowerControlResponse{
@@ -361,10 +364,12 @@ func (s *PowershelfManagerServerImpl) PowerOff(ctx context.Context, req *pb.Powe
 }
 
 func (s *PowershelfManagerServerImpl) PowerOn(ctx context.Context, req *pb.PowershelfRequest) (*pb.PowerControlResponse, error) {
-	responses := make([]*pb.PowershelfResponse, 0, len(req.PmcMacs))
+	responses := make([]*pb.PowershelfResponse, 0, len(req.PmcMacs)+len(req.Targets))
 	for _, mac := range req.PmcMacs {
-		response := s.powerOn(ctx, mac)
-		responses = append(responses, response)
+		responses = append(responses, s.powerOn(ctx, mac))
+	}
+	for _, target := range req.Targets {
+		responses = append(responses, s.powerTarget(ctx, target, true))
 	}
 
 	return &pb.PowerControlResponse{
@@ -372,7 +377,46 @@ func (s *PowershelfManagerServerImpl) PowerOn(ctx context.Context, req *pb.Power
 	}, nil
 }
 
-// registerPowershelf registers a powershelf by its PMC MAC/IP/Vendor and persists its credentials. Returns creation timestamp on success.
+// powerTarget performs a power action against an unregistered device using inline connection details.
+func (s *PowershelfManagerServerImpl) powerTarget(ctx context.Context, target *pb.PowerTarget, on bool) *pb.PowershelfResponse {
+	ip := net.ParseIP(target.PmcIp)
+	if ip == nil {
+		return &pb.PowershelfResponse{
+			PmcMacAddress: target.PmcIp,
+			Status:        pb.StatusCode_INVALID_ARGUMENT,
+			Error:         fmt.Sprintf("invalid PMC IP: %s", target.PmcIp),
+		}
+	}
+
+	if target.Credentials == nil {
+		return &pb.PowershelfResponse{
+			PmcMacAddress: target.PmcIp,
+			Status:        pb.StatusCode_INVALID_ARGUMENT,
+			Error:         "credentials are required for power targets",
+		}
+	}
+
+	cred := credential.New(target.Credentials.Username, target.Credentials.Password)
+	p := &pmc.PMC{
+		IP:         ip,
+		Vendor:     vendor.CodeToVendor(protobuf.PMCVendorFrom(target.Vendor)),
+		Credential: &cred,
+	}
+
+	if err := s.psm.PowerControlDirect(ctx, p, on); err != nil {
+		return &pb.PowershelfResponse{
+			PmcMacAddress: target.PmcIp,
+			Status:        pb.StatusCode_INTERNAL_ERROR,
+			Error:         err.Error(),
+		}
+	}
+
+	return &pb.PowershelfResponse{
+		PmcMacAddress: target.PmcIp,
+		Status:        pb.StatusCode_SUCCESS,
+	}
+}
+
 func (s *PowershelfManagerServerImpl) SetDryRun(
 	ctx context.Context,
 	req *pb.SetDryRunRequest,

--- a/powershelf-manager/internal/service/server_impl_test.go
+++ b/powershelf-manager/internal/service/server_impl_test.go
@@ -53,7 +53,7 @@ func TestPowerTarget_InvalidIP(t *testing.T) {
 			resp := s.powerTarget(context.Background(), target, true)
 
 			assert.Equal(t, pb.StatusCode_INVALID_ARGUMENT, resp.Status)
-			assert.Equal(t, tc.ip, resp.PmcMacAddress)
+			assert.Equal(t, tc.ip, resp.PmcIp)
 			assert.Contains(t, resp.Error, "invalid PMC IP")
 		})
 	}
@@ -69,7 +69,7 @@ func TestPowerTarget_NilCredentials(t *testing.T) {
 	resp := s.powerTarget(context.Background(), target, true)
 
 	assert.Equal(t, pb.StatusCode_INVALID_ARGUMENT, resp.Status)
-	assert.Equal(t, "10.20.30.40", resp.PmcMacAddress)
+	assert.Equal(t, "10.20.30.40", resp.PmcIp)
 	assert.Contains(t, resp.Error, "credentials are required")
 }
 

--- a/powershelf-manager/internal/service/server_impl_test.go
+++ b/powershelf-manager/internal/service/server_impl_test.go
@@ -1,0 +1,104 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package service
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/NVIDIA/ncx-infra-controller-rest/powershelf-manager/internal/proto/v1"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestServer() *PowershelfManagerServerImpl {
+	return &PowershelfManagerServerImpl{}
+}
+
+func TestPowerTarget_InvalidIP(t *testing.T) {
+	tests := map[string]struct {
+		ip string
+	}{
+		"empty":   {ip: ""},
+		"garbage": {ip: "pmc-bad-addr"},
+		"partial": {ip: "10.20.30"},
+	}
+
+	s := newTestServer()
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			target := &pb.PowerTarget{
+				PmcIp: tc.ip,
+				PmcCredentials: &pb.Credentials{
+					Username: "pmcUser",
+					Password: "pmcPass",
+				},
+			}
+
+			resp := s.powerTarget(context.Background(), target, true)
+
+			assert.Equal(t, pb.StatusCode_INVALID_ARGUMENT, resp.Status)
+			assert.Equal(t, tc.ip, resp.PmcMacAddress)
+			assert.Contains(t, resp.Error, "invalid PMC IP")
+		})
+	}
+}
+
+func TestPowerTarget_NilCredentials(t *testing.T) {
+	s := newTestServer()
+	target := &pb.PowerTarget{
+		PmcIp:          "10.20.30.40",
+		PmcCredentials: nil,
+	}
+
+	resp := s.powerTarget(context.Background(), target, true)
+
+	assert.Equal(t, pb.StatusCode_INVALID_ARGUMENT, resp.Status)
+	assert.Equal(t, "10.20.30.40", resp.PmcMacAddress)
+	assert.Contains(t, resp.Error, "credentials are required")
+}
+
+func TestPowerTarget_EmptyCredentials(t *testing.T) {
+	tests := map[string]struct {
+		username string
+		password string
+	}{
+		"empty username": {username: "", password: "pmcPass"},
+		"empty password": {username: "pmcUser", password: ""},
+		"both empty":     {username: "", password: ""},
+	}
+
+	s := newTestServer()
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			target := &pb.PowerTarget{
+				PmcIp: "10.20.30.40",
+				PmcCredentials: &pb.Credentials{
+					Username: tc.username,
+					Password: tc.password,
+				},
+			}
+
+			resp := s.powerTarget(context.Background(), target, true)
+
+			assert.Equal(t, pb.StatusCode_INVALID_ARGUMENT, resp.Status)
+			assert.Contains(t, resp.Error, "must not be empty")
+		})
+	}
+}

--- a/powershelf-manager/pkg/pmcmanager/pmcmanager.go
+++ b/powershelf-manager/pkg/pmcmanager/pmcmanager.go
@@ -20,13 +20,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
 	"github.com/NVIDIA/ncx-infra-controller-rest/powershelf-manager/pkg/credentials"
 	"github.com/NVIDIA/ncx-infra-controller-rest/powershelf-manager/pkg/objects/pmc"
 	"github.com/NVIDIA/ncx-infra-controller-rest/powershelf-manager/pkg/objects/powershelf"
 	"github.com/NVIDIA/ncx-infra-controller-rest/powershelf-manager/pkg/pmcregistry"
 	"github.com/NVIDIA/ncx-infra-controller-rest/powershelf-manager/pkg/redfish"
-	"net"
-	"time"
 )
 
 const redfishTimeout = time.Minute * 1
@@ -128,6 +131,21 @@ func (pm *PmcManager) PowerControl(ctx context.Context, mac net.HardwareAddr, on
 	if err != nil {
 		return err
 	}
+	return pm.powerControlPmc(ctx, pmc, on)
+}
+
+// PowerControlDirect performs a power action on a PMC using pre-built connection
+// details, bypassing registry and credential manager lookups.
+func (pm *PmcManager) PowerControlDirect(ctx context.Context, pmc *pmc.PMC, on bool) error {
+	return pm.powerControlPmc(ctx, pmc, on)
+}
+
+func (pm *PmcManager) powerControlPmc(ctx context.Context, pmc *pmc.PMC, on bool) error {
+	action := "off"
+	if on {
+		action = "on"
+	}
+	log.Infof("Power %s initiated for %s", action, pmc.IP)
 
 	tx := func(client *redfish.RedfishClient) error {
 		if on {
@@ -137,7 +155,6 @@ func (pm *PmcManager) PowerControl(ctx context.Context, mac net.HardwareAddr, on
 		}
 		return nil
 	}
-
 	return pm.RedfishTx(ctx, pmc, tx)
 }
 

--- a/powershelf-manager/pkg/pmcmanager/pmcmanager.go
+++ b/powershelf-manager/pkg/pmcmanager/pmcmanager.go
@@ -149,11 +149,11 @@ func (pm *PmcManager) powerControlPmc(ctx context.Context, pmc *pmc.PMC, on bool
 
 	tx := func(client *redfish.RedfishClient) error {
 		if on {
-			client.PowerOn()
-		} else {
-			client.PowerOff()
+			_, err := client.PowerOn()
+			return err
 		}
-		return nil
+		_, err := client.PowerOff()
+		return err
 	}
 	return pm.RedfishTx(ctx, pmc, tx)
 }

--- a/powershelf-manager/pkg/pmcmanager/pmcmanager_test.go
+++ b/powershelf-manager/pkg/pmcmanager/pmcmanager_test.go
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pmcmanager
+
+import (
+	"context"
+	"testing"
+
+	"github.com/NVIDIA/ncx-infra-controller-rest/powershelf-manager/pkg/redfish"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedfishTx_NilPMC(t *testing.T) {
+	pm := &PmcManager{}
+
+	err := pm.RedfishTx(context.Background(), nil, func(_ *redfish.RedfishClient) error {
+		t.Fatal("tx should not be called with nil PMC")
+		return nil
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "null PMC")
+}

--- a/powershelf-manager/pkg/powershelfmanager/powershelfmanager.go
+++ b/powershelf-manager/pkg/powershelfmanager/powershelfmanager.go
@@ -174,3 +174,9 @@ func (pm *PowershelfManager) PowerOn(ctx context.Context, mac net.HardwareAddr) 
 func (pm *PowershelfManager) PowerOff(ctx context.Context, mac net.HardwareAddr) error {
 	return pm.powerControl(ctx, mac, false)
 }
+
+// PowerControlDirect performs a power action using pre-built connection details,
+// bypassing registry and credential manager lookups.
+func (pm *PowershelfManager) PowerControlDirect(ctx context.Context, pmc *pmc.PMC, on bool) error {
+	return pm.PmcManager.PowerControlDirect(ctx, pmc, on)
+}


### PR DESCRIPTION
## Description

feat: Allow power control to NSM and PSM without registration

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [ ] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [x] **Powershelf Manager** - Powershelf Manager updated
- [x] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
