### PR TITLE
fix: Update default fw update sequence for nsm to only upgrade the BMC and BIOS from the bundle

### DIFF
--- a/nvswitch-manager/pkg/firmwaremanager/packages/schema.go
+++ b/nvswitch-manager/pkg/firmwaremanager/packages/schema.go
@@ -118,8 +118,9 @@ func (p *FirmwarePackage) HasComponent(name string) bool {
 }
 
 // DefaultComponentOrder defines the fallback update order when not specified in YAML.
-// Update sequence: BMC → CPLD → BIOS → NVOS
-var DefaultComponentOrder = []string{"bmc", "cpld", "bios", "nvos"}
+// TODO: re-enable all components once we resolve NVOS connectivity issues
+// var DefaultComponentOrder = []string{"bmc", "cpld", "bios", "nvos"}
+var DefaultComponentOrder = []string{"bmc", "bios"}
 
 // GetOrderedComponents returns the components in this package in the correct update order.
 // Uses the package's ComponentOrder if defined, otherwise falls back to DefaultComponentOrder.


### PR DESCRIPTION
## Description

fix: update default fw update sequence for nsm so that it only upgrades the BMC and BIOS sub-components unless explicitly specified by the user

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [x] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [ ] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [x] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
