### PR TITLE
fix: Update default fw update sequence for nsm to only include BMC and BIOS updates

### DIFF
--- a/nvswitch-manager/pkg/firmwaremanager/manager.go
+++ b/nvswitch-manager/pkg/firmwaremanager/manager.go
@@ -150,10 +150,15 @@ func (m *FirmwareManager) QueueUpdate(
 	// Determine which components to update
 	var componentNames []string
 	if len(components) == 0 {
-		// Empty list = update all components in order
-		componentNames = pkg.GetOrderedComponents()
-		if len(componentNames) == 0 {
-			return nil, fmt.Errorf("no components found in bundle %s", bundleVersion)
+		// Default to BMC and BIOS — these only require BMC access (Redfish)
+		// TODO: re-enable full bundle default once NVOS connectivity is resolved
+		// componentNames = pkg.GetOrderedComponents()
+		// if len(componentNames) == 0 {
+		// 	return nil, fmt.Errorf("no components found in bundle %s", bundleVersion)
+		// }
+		componentNames = []string{
+			strings.ToLower(string(nvswitch.BMC)),
+			strings.ToLower(string(nvswitch.BIOS)),
 		}
 	} else {
 		// Convert and validate specified components


### PR DESCRIPTION
## Description

fix: Update default fw update sequence for nsm to only include BMC and BIOS updates

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [ x] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [ ] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
