### PR TITLE
fix: Maintain association record when Instance Type is updated in Machine inventory

### DIFF
--- a/workflow/pkg/activity/machine/machine.go
+++ b/workflow/pkg/activity/machine/machine.go
@@ -217,6 +217,7 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 	}
 
 	miDAO := cdbm.NewMachineInterfaceDAO(mm.dbSession)
+	mitDAO := cdbm.NewMachineInstanceTypeDAO(mm.dbSession)
 	sdDAO := cdbm.NewStatusDetailDAO(mm.dbSession)
 
 	// Iterate through Machines in the inventory and update/create them in DB
@@ -460,30 +461,12 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 				continue
 			}
 
-			clearMaintenanceMessage := existingCloudMachine.MaintenanceMessage != nil && !isInMaintenance
-			clearNetworkHealthMessage := existingCloudMachine.NetworkHealthMessage != nil && !isNetworkDegraded
-			clearInstanceTypeID := existingCloudMachine.InstanceTypeID != nil && controllerInstanceTypeID == nil
+			// Check if there were any changes to the Instance type ID
+			clearInstanceTypeID := controllerInstanceTypeID == nil && existingCloudMachine.InstanceTypeID != nil
+			updateInstanceTypeID := controllerInstanceTypeID != nil && (existingCloudMachine.InstanceTypeID == nil || *controllerInstanceTypeID != *existingCloudMachine.InstanceTypeID)
 
-			if clearMaintenanceMessage || clearNetworkHealthMessage || clearInstanceTypeID {
-				clearInput := cdbm.MachineClearInput{
-					MachineID:            existingCloudMachine.ID,
-					MaintenanceMessage:   clearMaintenanceMessage,
-					NetworkHealthMessage: clearNetworkHealthMessage,
-					InstanceTypeID:       clearInstanceTypeID,
-				}
-				_, serr = mDAO.Clear(ctx, txn, clearInput)
-				if serr != nil {
-					slogger.Error().Err(serr).Msg("failed to clear maintenance or network health message from Machine in DB")
-				}
-			}
-
-			// If clearing the instance type ID, we _also_ need to remove any
-			// MachineInstanceType records
-			if clearInstanceTypeID {
-				// We'll need to remove any MachineInstanceType records.
-				mitDAO := cdbm.NewMachineInstanceTypeDAO(mm.dbSession)
-
-				// Get any we can find, which should really only be one.
+			if clearInstanceTypeID || updateInstanceTypeID {
+				// Fetch existing MachineInstanceType records
 				machineInstanceTypes, _, err := mitDAO.GetAll(ctx, txn, &existingCloudMachine.ID, nil, nil, nil, cdb.GetIntPtr(cdbp.DefaultLimit), nil)
 				if err != nil {
 					slogger.Error().Err(err).Msg("failed to get MachineInstanceTypes")
@@ -491,7 +474,7 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 					continue
 				}
 
-				// Go through and remove them.
+				// Go through and remove them (covers both clear and update cases)
 				for _, mit := range machineInstanceTypes {
 					err = mitDAO.DeleteByID(ctx, txn, mit.ID, false)
 					if err != nil {
@@ -502,6 +485,33 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 				if err != nil {
 					txn.Rollback()
 					continue
+				}
+
+				// Create new MachineInstanceType record since Instance type ID was changed
+				if updateInstanceTypeID {
+					_, serr = mitDAO.CreateFromParams(ctx, txn, existingCloudMachine.ID, *controllerInstanceTypeID)
+					if serr != nil {
+						slogger.Error().Err(serr).Msg("failed to create MachineInstanceType")
+						txn.Rollback()
+						continue
+					}
+				}
+			}
+
+			// Clear maintenance message, network health message, and Instance type ID if needed
+			clearMaintenanceMessage := existingCloudMachine.MaintenanceMessage != nil && !isInMaintenance
+			clearNetworkHealthMessage := existingCloudMachine.NetworkHealthMessage != nil && !isNetworkDegraded
+
+			if clearMaintenanceMessage || clearNetworkHealthMessage {
+				clearInput := cdbm.MachineClearInput{
+					MachineID:            existingCloudMachine.ID,
+					MaintenanceMessage:   clearMaintenanceMessage,
+					NetworkHealthMessage: clearNetworkHealthMessage,
+					InstanceTypeID:       clearInstanceTypeID,
+				}
+				_, serr = mDAO.Clear(ctx, txn, clearInput)
+				if serr != nil {
+					slogger.Error().Err(serr).Msg("failed to clear maintenance or network health message from Machine in DB")
 				}
 			}
 

--- a/workflow/pkg/activity/machine/machine.go
+++ b/workflow/pkg/activity/machine/machine.go
@@ -463,22 +463,21 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 
 			// Check if there were any changes to the Instance type ID
 			clearInstanceTypeID := controllerInstanceTypeID == nil && existingCloudMachine.InstanceTypeID != nil
-			updateInstanceTypeID := controllerInstanceTypeID != nil && (existingCloudMachine.InstanceTypeID == nil || *controllerInstanceTypeID != *existingCloudMachine.InstanceTypeID)
+			updateInstanceTypeID := controllerInstanceTypeID != nil && !util.PtrsEqual(controllerInstanceTypeID, existingCloudMachine.InstanceTypeID)
 
 			if clearInstanceTypeID || updateInstanceTypeID {
-				// Fetch existing MachineInstanceType records
+				// Fetch existing MachineInstanceType records and delete them
 				machineInstanceTypes, _, err := mitDAO.GetAll(ctx, txn, &existingCloudMachine.ID, nil, nil, nil, cdb.GetIntPtr(cdbp.DefaultLimit), nil)
 				if err != nil {
-					slogger.Error().Err(err).Msg("failed to get MachineInstanceTypes")
+					slogger.Error().Err(err).Msg("failed to get MachineInstanceTypes for deletion")
 					txn.Rollback()
 					continue
 				}
-
 				// Go through and remove them (covers both clear and update cases)
 				for _, mit := range machineInstanceTypes {
 					err = mitDAO.DeleteByID(ctx, txn, mit.ID, false)
 					if err != nil {
-						slogger.Error().Err(err).Msg("failed to delete MachineInstanceType")
+						slogger.Error().Err(err).Msg("failed to delete MachineInstanceType for clearing/updating")
 						break
 					}
 				}
@@ -491,7 +490,7 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 				if updateInstanceTypeID {
 					_, serr = mitDAO.CreateFromParams(ctx, txn, existingCloudMachine.ID, *controllerInstanceTypeID)
 					if serr != nil {
-						slogger.Error().Err(serr).Msg("failed to create MachineInstanceType")
+						slogger.Error().Err(serr).Msg("failed to create MachineInstanceType for Instance Type update")
 						txn.Rollback()
 						continue
 					}

--- a/workflow/pkg/activity/machine/machine.go
+++ b/workflow/pkg/activity/machine/machine.go
@@ -502,7 +502,7 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 			clearMaintenanceMessage := existingCloudMachine.MaintenanceMessage != nil && !isInMaintenance
 			clearNetworkHealthMessage := existingCloudMachine.NetworkHealthMessage != nil && !isNetworkDegraded
 
-			if clearMaintenanceMessage || clearNetworkHealthMessage {
+			if clearMaintenanceMessage || clearNetworkHealthMessage || clearInstanceTypeID {
 				clearInput := cdbm.MachineClearInput{
 					MachineID:            existingCloudMachine.ID,
 					MaintenanceMessage:   clearMaintenanceMessage,
@@ -512,6 +512,8 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 				_, serr = mDAO.Clear(ctx, txn, clearInput)
 				if serr != nil {
 					slogger.Error().Err(serr).Msg("failed to clear maintenance or network health message from Machine in DB")
+					txn.Rollback()
+					continue
 				}
 			}
 

--- a/workflow/pkg/activity/machine/machine.go
+++ b/workflow/pkg/activity/machine/machine.go
@@ -467,7 +467,7 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 
 			if clearInstanceTypeID || updateInstanceTypeID {
 				// Fetch existing MachineInstanceType records and delete them
-				machineInstanceTypes, _, err := mitDAO.GetAll(ctx, txn, &existingCloudMachine.ID, nil, nil, nil, cdb.GetIntPtr(cdbp.DefaultLimit), nil)
+				machineInstanceTypes, _, err := mitDAO.GetAll(ctx, txn, &existingCloudMachine.ID, nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
 				if err != nil {
 					slogger.Error().Err(err).Msg("failed to get MachineInstanceTypes for deletion")
 					txn.Rollback()

--- a/workflow/pkg/activity/machine/machine.go
+++ b/workflow/pkg/activity/machine/machine.go
@@ -480,23 +480,31 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 				continue
 			}
 
-			// Check if there were any changes to the Instance type ID
+			// Reconcile MachineInstanceType rows with controller inventory: always load MIT rows
+			// and fix empty/stale state even when Machine.InstanceTypeID already matches.
 			clearInstanceTypeID := controllerInstanceTypeID == nil && existingCloudMachine.InstanceTypeID != nil
-			updateInstanceTypeID := controllerInstanceTypeID != nil && !util.PtrsEqual(controllerInstanceTypeID, existingCloudMachine.InstanceTypeID)
 
-			if clearInstanceTypeID || updateInstanceTypeID {
-				// Fetch existing MachineInstanceType records and delete them
-				machineInstanceTypes, _, err := mitDAO.GetAll(ctx, txn, &existingCloudMachine.ID, nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
-				if err != nil {
-					slogger.Error().Err(err).Msg("failed to get MachineInstanceTypes for deletion")
-					txn.Rollback()
-					continue
+			machineInstanceTypes, _, err := mitDAO.GetAll(ctx, txn, &existingCloudMachine.ID, nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
+			if err != nil {
+				slogger.Error().Err(err).Msg("failed to get MachineInstanceTypes for reconciliation")
+				txn.Rollback()
+				continue
+			}
+
+			needsMitReconcile := false
+			if controllerInstanceTypeID != nil {
+				if len(machineInstanceTypes) != 1 || !util.PtrsEqual(&machineInstanceTypes[0].InstanceTypeID, controllerInstanceTypeID) {
+					needsMitReconcile = true
 				}
-				// Go through and remove them (covers both clear and update cases)
+			} else if len(machineInstanceTypes) > 0 {
+				needsMitReconcile = true
+			}
+
+			if needsMitReconcile {
 				for _, mit := range machineInstanceTypes {
 					err = mitDAO.DeleteByID(ctx, txn, mit.ID, false)
 					if err != nil {
-						slogger.Error().Err(err).Msg("failed to delete MachineInstanceType for clearing/updating")
+						slogger.Error().Err(err).Msg("failed to delete MachineInstanceType during reconciliation")
 						break
 					}
 				}
@@ -505,11 +513,10 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 					continue
 				}
 
-				// Create new MachineInstanceType record since Instance type ID was changed
-				if updateInstanceTypeID {
+				if controllerInstanceTypeID != nil {
 					_, serr = mitDAO.CreateFromParams(ctx, txn, existingCloudMachine.ID, *controllerInstanceTypeID)
 					if serr != nil {
-						slogger.Error().Err(serr).Msg("failed to create MachineInstanceType for Instance Type update")
+						slogger.Error().Err(serr).Msg("failed to create MachineInstanceType during reconciliation")
 						txn.Rollback()
 						continue
 					}

--- a/workflow/pkg/activity/machine/machine.go
+++ b/workflow/pkg/activity/machine/machine.go
@@ -329,6 +329,13 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 
 		if !found {
 			slogger.Info().Msg("adding new Machine in DB")
+
+			txn, err := cdb.BeginTx(ctx, mm.dbSession, &sql.TxOptions{})
+			if err != nil {
+				slogger.Error().Err(err).Msg("failed to start transaction to create Machine in DB")
+				continue
+			}
+
 			createInput := cdbm.MachineCreateInput{
 				MachineID:                controllerMachineID,
 				InfrastructureProviderID: site.InfrastructureProviderID,
@@ -351,11 +358,25 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 				Labels:                   labels,
 				Status:                   machineStatus,
 			}
-			newMachine, serr := mDAO.Create(ctx, nil, createInput)
+
+			newMachine, serr := mDAO.Create(ctx, txn, createInput)
 			if serr != nil {
-				slogger.Error().Err(serr).Msg("failed to create Machine in DB")
+				slogger.Error().Err(serr).Msg("failed to create DB record for new Machine")
+				txn.Rollback()
 				continue
 			}
+
+			if controllerInstanceTypeID != nil {
+				_, serr = mitDAO.CreateFromParams(ctx, txn, newMachine.ID, *controllerInstanceTypeID)
+				if serr != nil {
+					slogger.Error().Err(serr).Msg("failed to create MachineInstanceType DB record for new Machine")
+					txn.Rollback()
+					continue
+				}
+			}
+
+			// Commit now as the base Machine record is created, any failure below can be retried in next inventory
+			txn.Commit()
 
 			// Create status detail
 			_, serr = sdDAO.CreateFromParams(ctx, nil, newMachine.ID, machineStatus, &statusMessage)
@@ -401,9 +422,7 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 
 			machine = newMachine
 		} else {
-			//
-			// Update
-			//
+			// Update existing Machine record
 
 			// There could be a race between inventory and human changes in carbide-rest-api,
 			// so we need to grab a txn and also lock on the machine record.
@@ -516,9 +535,7 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 				}
 			}
 
-			// Commit the txn now that all work is done.
-			// From this point, there shouldn't be any coordination
-			// needed between human users and the inventory process.
+			// Commit the txn now that the base Machine record is updated, any failure below is not critical and can be retried in next inventory
 			txn.Commit()
 
 			// Check if most recent status detail is the same as the current status, otherwise create a new one

--- a/workflow/pkg/activity/machine/machine_test.go
+++ b/workflow/pkg/activity/machine/machine_test.go
@@ -115,6 +115,9 @@ func testMachineSetupSchema(t *testing.T, dbSession *cdb.Session) {
 	// create InstanceType table
 	err = dbSession.DB.ResetModel(context.Background(), (*cdbm.InstanceType)(nil))
 	assert.Nil(t, err)
+	// create MachineInstanceType table
+	err = dbSession.DB.ResetModel(context.Background(), (*cdbm.MachineInstanceType)(nil))
+	assert.Nil(t, err)
 	// create Instance table
 	err = dbSession.DB.ResetModel(context.Background(), (*cdbm.Instance)(nil))
 	assert.Nil(t, err)
@@ -247,6 +250,23 @@ func testMachineBuildMachineInterface(t *testing.T, dbSession *cdb.Session, mID 
 	return mi
 }
 
+func testMachineBuildMachineInstanceType(t *testing.T, dbSession *cdb.Session, machineID string, instanceTypeID uuid.UUID) *cdbm.MachineInstanceType {
+	mitDAO := cdbm.NewMachineInstanceTypeDAO(dbSession)
+
+	mit, err := mitDAO.CreateFromParams(
+		context.Background(),
+		nil,
+		machineID,
+		instanceTypeID,
+	)
+	assert.Nil(t, err)
+	assert.NotNil(t, mit)
+	assert.Equal(t, machineID, mit.MachineID)
+	assert.Equal(t, instanceTypeID, mit.InstanceTypeID)
+
+	return mit
+}
+
 func testMachineBuildStatusDetail(t *testing.T, dbSession *cdb.Session, entityID string, status string, message *string) {
 	sdDAO := cdbm.NewStatusDetailDAO(dbSession)
 	ssd, err := sdDAO.CreateFromParams(context.Background(), nil, entityID, status, message)
@@ -276,6 +296,7 @@ func TestManageMachine_UpdateMachinesInDB(t *testing.T) {
 	site2 := testMachineBuildSite(t, dbSession, ip2, "test-site-2", cdbm.SiteStatusRegistered)
 	site3 := testMachineBuildSite(t, dbSession, ip2, "test-site-3", cdbm.SiteStatusRegistered)
 	site4 := testMachineBuildSite(t, dbSession, ip2, "test-site-4", cdbm.SiteStatusRegistered)
+	user := testMachineBuildUser(t, dbSession, "test-machine-user", []string{ipOrg2}, []string{"admin"})
 
 	m := testMachineBuildMachine(t, dbSession, ip.ID, site.ID, nil, cdb.GetStrPtr("mcType"), false, nil, false, nil, nil)
 	assert.NotNil(t, m)
@@ -301,6 +322,14 @@ func TestManageMachine_UpdateMachinesInDB(t *testing.T) {
 	m14 := testMachineBuildMachine(t, dbSession, ip2.ID, site.ID, nil, nil, false, nil, false, nil, cdb.GetStrPtr(cdbm.MachineStatusReady))
 	m15 := testMachineBuildMachine(t, dbSession, ip2.ID, site.ID, nil, nil, false, nil, false, nil, cdb.GetStrPtr(cdbm.MachineStatusReady))
 
+	instanceTypeOriginal := cdbm.TestBuildInstanceType(t, dbSession, "machine-instance-type-original", ip2, site, user)
+	instanceTypeUpdated := cdbm.TestBuildInstanceType(t, dbSession, "machine-instance-type-updated", ip2, site, user)
+	instanceTypeUnchanged := cdbm.TestBuildInstanceType(t, dbSession, "machine-instance-type-unchanged", ip2, site, user)
+
+	m16 := testMachineBuildMachine(t, dbSession, ip2.ID, site.ID, &instanceTypeOriginal.ID, nil, false, nil, false, nil, cdb.GetStrPtr(cdbm.MachineStatusReady))
+	m17 := testMachineBuildMachine(t, dbSession, ip2.ID, site.ID, &instanceTypeOriginal.ID, nil, false, nil, false, nil, cdb.GetStrPtr(cdbm.MachineStatusReady))
+	m18 := testMachineBuildMachine(t, dbSession, ip2.ID, site.ID, &instanceTypeUnchanged.ID, nil, false, nil, false, nil, cdb.GetStrPtr(cdbm.MachineStatusReady))
+
 	// Add capability entry to test update of existing capabilities
 	mcDAO := cdbm.NewMachineCapabilityDAO(dbSession)
 
@@ -321,6 +350,10 @@ func TestManageMachine_UpdateMachinesInDB(t *testing.T) {
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, mc14)
+
+	m16MachineInstanceType := testMachineBuildMachineInstanceType(t, dbSession, m16.ID, instanceTypeOriginal.ID)
+	testMachineBuildMachineInstanceType(t, dbSession, m17.ID, instanceTypeOriginal.ID)
+	m18MachineInstanceType := testMachineBuildMachineInstanceType(t, dbSession, m18.ID, instanceTypeUnchanged.ID)
 
 	mi1 := testMachineBuildMachineInterface(t, dbSession, m.ID)
 	assert.NotNil(t, mi1)
@@ -723,9 +756,38 @@ func TestManageMachine_UpdateMachinesInDB(t *testing.T) {
 		},
 	}
 
+	machineInfo15 := &cwssaws.MachineInfo{
+		Machine: &cwssaws.Machine{
+			Id:             &cwssaws.MachineId{Id: m16.ControllerMachineID},
+			State:          controllerMachineStatePrefixReady,
+			Interfaces:     []*cwssaws.MachineInterface{},
+			DiscoveryInfo:  nil,
+			InstanceTypeId: cdb.GetStrPtr(instanceTypeUpdated.ID.String()),
+		},
+	}
+
+	machineInfo16 := &cwssaws.MachineInfo{
+		Machine: &cwssaws.Machine{
+			Id:            &cwssaws.MachineId{Id: m17.ControllerMachineID},
+			State:         controllerMachineStatePrefixReady,
+			Interfaces:    []*cwssaws.MachineInterface{},
+			DiscoveryInfo: nil,
+		},
+	}
+
+	machineInfo17 := &cwssaws.MachineInfo{
+		Machine: &cwssaws.Machine{
+			Id:             &cwssaws.MachineId{Id: m18.ControllerMachineID},
+			State:          controllerMachineStatePrefixReady,
+			Interfaces:     []*cwssaws.MachineInterface{},
+			DiscoveryInfo:  nil,
+			InstanceTypeId: cdb.GetStrPtr(instanceTypeUnchanged.ID.String()),
+		},
+	}
+
 	// Build machineInventory which is populated from site agent
 	machineInventory := &cwssaws.MachineInventory{
-		Machines:  []*cwssaws.MachineInfo{machineInfo1, machineInfo2, machineInfo3, machineInfo4, machineInfo5, machineInfo6, machineInfo7, machineInfo8, machineInfo9, machineInfo11, machineInfo12, machineInfo13, machineInfo14},
+		Machines:  []*cwssaws.MachineInfo{machineInfo1, machineInfo2, machineInfo3, machineInfo4, machineInfo5, machineInfo6, machineInfo7, machineInfo8, machineInfo9, machineInfo11, machineInfo12, machineInfo13, machineInfo14, machineInfo15, machineInfo16, machineInfo17},
 		Timestamp: timestamppb.Now(),
 	}
 	assert.NotNil(t, machineInventory)
@@ -777,6 +839,9 @@ func TestManageMachine_UpdateMachinesInDB(t *testing.T) {
 		updatedCapabilitiesMachineID               *string
 		desiredMachineStates                       map[string]string
 		newHostname                                *string
+		updatedMachineInstanceTypeID               *string
+		clearedMachineInstanceTypeID               *string
+		unchangedMachineInstanceTypeID             *string
 		isHealthReported                           *bool
 		isDPUCountReported                         *bool
 		deletedMachineCapabilities                 []*cdbm.MachineCapability
@@ -808,17 +873,20 @@ func TestManageMachine_UpdateMachinesInDB(t *testing.T) {
 				dbSession: dbSession,
 			},
 			args: args{
-				ctx:                           context.Background(),
-				siteID:                        site.ID,
-				machineInventory:              machineInventory,
-				reportedMachine:               m,
-				missingMachine:                m2,
-				newControllerMachineID:        &newControllerMachineID,
-				restoredControllerMachineID:   &m4.ControllerMachineID,
-				maintenanceCompletedMachineID: &m5.ControllerMachineID,
-				maintenanceStartedMachineID:   &m6.ControllerMachineID,
-				updatedCapabilitiesMachineID:  &m14.ControllerMachineID,
-				isDPUCountReported:            cdb.GetBoolPtr(true),
+				ctx:                            context.Background(),
+				siteID:                         site.ID,
+				machineInventory:               machineInventory,
+				reportedMachine:                m,
+				missingMachine:                 m2,
+				newControllerMachineID:         &newControllerMachineID,
+				restoredControllerMachineID:    &m4.ControllerMachineID,
+				maintenanceCompletedMachineID:  &m5.ControllerMachineID,
+				maintenanceStartedMachineID:    &m6.ControllerMachineID,
+				updatedCapabilitiesMachineID:   &m14.ControllerMachineID,
+				updatedMachineInstanceTypeID:   &m16.ControllerMachineID,
+				clearedMachineInstanceTypeID:   &m17.ControllerMachineID,
+				unchangedMachineInstanceTypeID: &m18.ControllerMachineID,
+				isDPUCountReported:             cdb.GetBoolPtr(true),
 				desiredMachineStates: map[string]string{
 					m7.ControllerMachineID:  cdbm.MachineStatusInitializing,
 					m8.ControllerMachineID:  cdbm.MachineStatusError,
@@ -957,6 +1025,7 @@ func TestManageMachine_UpdateMachinesInDB(t *testing.T) {
 
 			mDAO := cdbm.NewMachineDAO(mm.dbSession)
 			miDAO := cdbm.NewMachineInterfaceDAO(mm.dbSession)
+			mitDAO := cdbm.NewMachineInstanceTypeDAO(mm.dbSession)
 
 			// Check if the Machine specified in machineInfo1 was updated in the DB, it should switch to status `Ready`
 			if tt.args.reportedMachine != nil {
@@ -1166,6 +1235,45 @@ func TestManageMachine_UpdateMachinesInDB(t *testing.T) {
 				assert.Equal(t, *um6.MaintenanceMessage, *machineInfo5.Machine.MaintenanceReference)
 				assert.Equal(t, um6.IsNetworkDegraded, false)
 				assert.Nil(t, um6.NetworkHealthMessage)
+			}
+
+			if tt.args.updatedMachineInstanceTypeID != nil {
+				updatedMachine, serr := mDAO.GetByID(tt.args.ctx, nil, *tt.args.updatedMachineInstanceTypeID, nil, false)
+				assert.Nil(t, serr)
+				if assert.NotNil(t, updatedMachine.InstanceTypeID) {
+					assert.Equal(t, instanceTypeUpdated.ID, *updatedMachine.InstanceTypeID)
+				}
+
+				machineInstanceTypes, total, serr := mitDAO.GetAll(tt.args.ctx, nil, tt.args.updatedMachineInstanceTypeID, nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
+				assert.Nil(t, serr)
+				assert.Equal(t, 1, total)
+				assert.Equal(t, instanceTypeUpdated.ID, machineInstanceTypes[0].InstanceTypeID)
+				assert.NotEqual(t, m16MachineInstanceType.ID, machineInstanceTypes[0].ID)
+			}
+
+			if tt.args.clearedMachineInstanceTypeID != nil {
+				clearedMachine, serr := mDAO.GetByID(tt.args.ctx, nil, *tt.args.clearedMachineInstanceTypeID, nil, false)
+				assert.Nil(t, serr)
+				assert.Nil(t, clearedMachine.InstanceTypeID)
+
+				machineInstanceTypes, total, serr := mitDAO.GetAll(tt.args.ctx, nil, tt.args.clearedMachineInstanceTypeID, nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
+				assert.Nil(t, serr)
+				assert.Equal(t, 0, total)
+				assert.Empty(t, machineInstanceTypes)
+			}
+
+			if tt.args.unchangedMachineInstanceTypeID != nil {
+				unchangedMachine, serr := mDAO.GetByID(tt.args.ctx, nil, *tt.args.unchangedMachineInstanceTypeID, nil, false)
+				assert.Nil(t, serr)
+				if assert.NotNil(t, unchangedMachine.InstanceTypeID) {
+					assert.Equal(t, instanceTypeUnchanged.ID, *unchangedMachine.InstanceTypeID)
+				}
+
+				machineInstanceTypes, total, serr := mitDAO.GetAll(tt.args.ctx, nil, tt.args.unchangedMachineInstanceTypeID, nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
+				assert.Nil(t, serr)
+				assert.Equal(t, 1, total)
+				assert.Equal(t, m18MachineInstanceType.ID, machineInstanceTypes[0].ID)
+				assert.Equal(t, instanceTypeUnchanged.ID, machineInstanceTypes[0].InstanceTypeID)
 			}
 
 			if tt.args.updatedCapabilitiesMachineID != nil {

--- a/workflow/pkg/activity/machine/machine_test.go
+++ b/workflow/pkg/activity/machine/machine_test.go
@@ -33,6 +33,7 @@ import (
 	sc "github.com/NVIDIA/ncx-infra-controller-rest/workflow/pkg/client/site"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun/extra/bundebug"
 
 	cdb "github.com/NVIDIA/ncx-infra-controller-rest/db/pkg/db"
@@ -1246,7 +1247,7 @@ func TestManageMachine_UpdateMachinesInDB(t *testing.T) {
 
 				machineInstanceTypes, total, serr := mitDAO.GetAll(tt.args.ctx, nil, tt.args.updatedMachineInstanceTypeID, nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
 				assert.Nil(t, serr)
-				assert.Equal(t, 1, total)
+				require.Equal(t, 1, total)
 				assert.Equal(t, instanceTypeUpdated.ID, machineInstanceTypes[0].InstanceTypeID)
 				assert.NotEqual(t, m16MachineInstanceType.ID, machineInstanceTypes[0].ID)
 			}

--- a/workflow/pkg/activity/machine/machine_test.go
+++ b/workflow/pkg/activity/machine/machine_test.go
@@ -786,9 +786,20 @@ func TestManageMachine_UpdateMachinesInDB(t *testing.T) {
 		},
 	}
 
+	newWithInstanceTypeMachineID := uuid.NewString()
+	machineInfo18 := &cwssaws.MachineInfo{
+		Machine: &cwssaws.Machine{
+			Id:             &cwssaws.MachineId{Id: newWithInstanceTypeMachineID},
+			State:          controllerMachineStatePrefixReady,
+			Interfaces:     []*cwssaws.MachineInterface{},
+			DiscoveryInfo:  nil,
+			InstanceTypeId: cdb.GetStrPtr(instanceTypeOriginal.ID.String()),
+		},
+	}
+
 	// Build machineInventory which is populated from site agent
 	machineInventory := &cwssaws.MachineInventory{
-		Machines:  []*cwssaws.MachineInfo{machineInfo1, machineInfo2, machineInfo3, machineInfo4, machineInfo5, machineInfo6, machineInfo7, machineInfo8, machineInfo9, machineInfo11, machineInfo12, machineInfo13, machineInfo14, machineInfo15, machineInfo16, machineInfo17},
+		Machines:  []*cwssaws.MachineInfo{machineInfo1, machineInfo2, machineInfo3, machineInfo4, machineInfo5, machineInfo6, machineInfo7, machineInfo8, machineInfo9, machineInfo11, machineInfo12, machineInfo13, machineInfo14, machineInfo15, machineInfo16, machineInfo17, machineInfo18},
 		Timestamp: timestamppb.Now(),
 	}
 	assert.NotNil(t, machineInventory)
@@ -840,9 +851,10 @@ func TestManageMachine_UpdateMachinesInDB(t *testing.T) {
 		updatedCapabilitiesMachineID               *string
 		desiredMachineStates                       map[string]string
 		newHostname                                *string
-		updatedMachineInstanceTypeID               *string
-		clearedMachineInstanceTypeID               *string
-		unchangedMachineInstanceTypeID             *string
+		newWithInstanceTypeMachineID               *string
+		updatedInstanceTypeMachineID               *string
+		clearedInstanceTypeMachineID               *string
+		unchangedInstanceTypeMachineID             *string
 		isHealthReported                           *bool
 		isDPUCountReported                         *bool
 		deletedMachineCapabilities                 []*cdbm.MachineCapability
@@ -884,9 +896,10 @@ func TestManageMachine_UpdateMachinesInDB(t *testing.T) {
 				maintenanceCompletedMachineID:  &m5.ControllerMachineID,
 				maintenanceStartedMachineID:    &m6.ControllerMachineID,
 				updatedCapabilitiesMachineID:   &m14.ControllerMachineID,
-				updatedMachineInstanceTypeID:   &m16.ControllerMachineID,
-				clearedMachineInstanceTypeID:   &m17.ControllerMachineID,
-				unchangedMachineInstanceTypeID: &m18.ControllerMachineID,
+				newWithInstanceTypeMachineID:   &newWithInstanceTypeMachineID,
+				updatedInstanceTypeMachineID:   &m16.ControllerMachineID,
+				clearedInstanceTypeMachineID:   &m17.ControllerMachineID,
+				unchangedInstanceTypeMachineID: &m18.ControllerMachineID,
 				isDPUCountReported:             cdb.GetBoolPtr(true),
 				desiredMachineStates: map[string]string{
 					m7.ControllerMachineID:  cdbm.MachineStatusInitializing,
@@ -1238,39 +1251,51 @@ func TestManageMachine_UpdateMachinesInDB(t *testing.T) {
 				assert.Nil(t, um6.NetworkHealthMessage)
 			}
 
-			if tt.args.updatedMachineInstanceTypeID != nil {
-				updatedMachine, serr := mDAO.GetByID(tt.args.ctx, nil, *tt.args.updatedMachineInstanceTypeID, nil, false)
+			if tt.args.newWithInstanceTypeMachineID != nil {
+				newMachine, serr := mDAO.GetByID(tt.args.ctx, nil, *tt.args.newWithInstanceTypeMachineID, nil, false)
+				require.NoError(t, serr)
+				assert.NotNil(t, newMachine.InstanceTypeID)
+				assert.Equal(t, instanceTypeOriginal.ID, *newMachine.InstanceTypeID)
+
+				machineInstanceTypes, total, serr := mitDAO.GetAll(tt.args.ctx, nil, tt.args.newWithInstanceTypeMachineID, nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
+				assert.Nil(t, serr)
+				require.Equal(t, 1, total)
+				assert.Equal(t, instanceTypeOriginal.ID, machineInstanceTypes[0].InstanceTypeID)
+			}
+
+			if tt.args.updatedInstanceTypeMachineID != nil {
+				updatedMachine, serr := mDAO.GetByID(tt.args.ctx, nil, *tt.args.updatedInstanceTypeMachineID, nil, false)
 				assert.Nil(t, serr)
 				if assert.NotNil(t, updatedMachine.InstanceTypeID) {
 					assert.Equal(t, instanceTypeUpdated.ID, *updatedMachine.InstanceTypeID)
 				}
 
-				machineInstanceTypes, total, serr := mitDAO.GetAll(tt.args.ctx, nil, tt.args.updatedMachineInstanceTypeID, nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
+				machineInstanceTypes, total, serr := mitDAO.GetAll(tt.args.ctx, nil, tt.args.updatedInstanceTypeMachineID, nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
 				assert.Nil(t, serr)
 				require.Equal(t, 1, total)
 				assert.Equal(t, instanceTypeUpdated.ID, machineInstanceTypes[0].InstanceTypeID)
 				assert.NotEqual(t, m16MachineInstanceType.ID, machineInstanceTypes[0].ID)
 			}
 
-			if tt.args.clearedMachineInstanceTypeID != nil {
-				clearedMachine, serr := mDAO.GetByID(tt.args.ctx, nil, *tt.args.clearedMachineInstanceTypeID, nil, false)
+			if tt.args.clearedInstanceTypeMachineID != nil {
+				clearedMachine, serr := mDAO.GetByID(tt.args.ctx, nil, *tt.args.clearedInstanceTypeMachineID, nil, false)
 				assert.Nil(t, serr)
 				assert.Nil(t, clearedMachine.InstanceTypeID)
 
-				machineInstanceTypes, total, serr := mitDAO.GetAll(tt.args.ctx, nil, tt.args.clearedMachineInstanceTypeID, nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
+				machineInstanceTypes, total, serr := mitDAO.GetAll(tt.args.ctx, nil, tt.args.clearedInstanceTypeMachineID, nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
 				assert.Nil(t, serr)
 				assert.Equal(t, 0, total)
 				assert.Empty(t, machineInstanceTypes)
 			}
 
-			if tt.args.unchangedMachineInstanceTypeID != nil {
-				unchangedMachine, serr := mDAO.GetByID(tt.args.ctx, nil, *tt.args.unchangedMachineInstanceTypeID, nil, false)
+			if tt.args.unchangedInstanceTypeMachineID != nil {
+				unchangedMachine, serr := mDAO.GetByID(tt.args.ctx, nil, *tt.args.unchangedInstanceTypeMachineID, nil, false)
 				assert.Nil(t, serr)
 				if assert.NotNil(t, unchangedMachine.InstanceTypeID) {
 					assert.Equal(t, instanceTypeUnchanged.ID, *unchangedMachine.InstanceTypeID)
 				}
 
-				machineInstanceTypes, total, serr := mitDAO.GetAll(tt.args.ctx, nil, tt.args.unchangedMachineInstanceTypeID, nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
+				machineInstanceTypes, total, serr := mitDAO.GetAll(tt.args.ctx, nil, tt.args.unchangedInstanceTypeMachineID, nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
 				assert.Nil(t, serr)
 				require.Equal(t, 1, total)
 				assert.Equal(t, m18MachineInstanceType.ID, machineInstanceTypes[0].ID)

--- a/workflow/pkg/activity/machine/machine_test.go
+++ b/workflow/pkg/activity/machine/machine_test.go
@@ -1272,7 +1272,7 @@ func TestManageMachine_UpdateMachinesInDB(t *testing.T) {
 
 				machineInstanceTypes, total, serr := mitDAO.GetAll(tt.args.ctx, nil, tt.args.unchangedMachineInstanceTypeID, nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
 				assert.Nil(t, serr)
-				assert.Equal(t, 1, total)
+				require.Equal(t, 1, total)
 				assert.Equal(t, m18MachineInstanceType.ID, machineInstanceTypes[0].ID)
 				assert.Equal(t, instanceTypeUnchanged.ID, machineInstanceTypes[0].InstanceTypeID)
 			}


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
Currently we're only updating Instance Type attribute for Machine and not the Machine/Instance Type association record. Until Machine/Instance Type association is deprecated, we need to keep it consistent.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Fix** - Bug fixes (fix:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **Workflow** - Workflow service updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->
None

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
None