### PR TITLE
fix: Support reflashing the same firmware version in PSM

### DIFF
--- a/nvswitch-manager/pkg/firmwaremanager/manager.go
+++ b/nvswitch-manager/pkg/firmwaremanager/manager.go
@@ -150,16 +150,15 @@ func (m *FirmwareManager) QueueUpdate(
 	// Determine which components to update
 	var componentNames []string
 	if len(components) == 0 {
-		// Default to BMC and BIOS — these only require BMC access (Redfish)
-		// TODO: re-enable full bundle default once NVOS connectivity is resolved
-		// componentNames = pkg.GetOrderedComponents()
-		// if len(componentNames) == 0 {
-		// 	return nil, fmt.Errorf("no components found in bundle %s", bundleVersion)
-		// }
-		componentNames = []string{
-			strings.ToLower(string(nvswitch.BMC)),
-			strings.ToLower(string(nvswitch.BIOS)),
+		componentNames = pkg.GetOrderedComponents()
+		if len(componentNames) == 0 {
+			return nil, fmt.Errorf("no components found in bundle %s", bundleVersion)
 		}
+		// Default to BMC and BIOS — these only require BMC access (Redfish)
+		// componentNames = []string{
+		//	strings.ToLower(string(nvswitch.BMC)),
+		//	strings.ToLower(string(nvswitch.BIOS)),
+		//}
 	} else {
 		// Convert and validate specified components
 		for _, c := range components {

--- a/powershelf-manager/pkg/firmwaremanager/firmware_manager.go
+++ b/powershelf-manager/pkg/firmwaremanager/firmware_manager.go
@@ -235,7 +235,13 @@ func (manager *Manager) handleOnePmcUpdate(ctx context.Context, pmc *pmc.PMC, up
 			return powershelf.FirmwareStateFailed, err
 		}
 
-		err = updater.upgrade(ctx, pmc, version, manager.dryRun)
+		// Skip the actual Redfish upload for same-version re-flashes; the device is already at the target version.
+		dryRun := manager.dryRun
+		if update.VersionFrom == update.VersionTo {
+			dryRun = true
+			log.Printf("Re-flash detected for component %v on PMC %v (version %v); forcing dry-run", update.Component, pmc, update.VersionFrom)
+		}
+		err = updater.upgrade(ctx, pmc, version, dryRun)
 		if err != nil {
 			return powershelf.FirmwareStateFailed, fmt.Errorf("failed to initiate firmware update of component %v for powershelf with PMC MAC %v from %v to %v: %w", update.Component, pmc, update.VersionFrom, update.VersionTo, err)
 		} else {

--- a/powershelf-manager/pkg/firmwaremanager/firmware_repo.go
+++ b/powershelf-manager/pkg/firmwaremanager/firmware_repo.go
@@ -57,9 +57,10 @@ func (repo *FirmwareRepo) summary() (string, error) {
 	return sb.String(), nil
 }
 
-// supportUpgrade returns true if the current version is within the repo’s supported starting range.
+// supportUpgrade returns true if the current version falls within the repo's
+// supported range, which spans the minimum 'from' to the maximum 'to' across
+// all upgrade edges.
 func (repo *FirmwareRepo) supportUpgrade(currentFwVersion firmwareVersion) bool {
-	// Check if currentFwVersion is within the FirmwareReport's supported range
 	return repo.minStartingFwVersion.cmp(currentFwVersion) <= 0 && repo.maxStartingFwVersion.cmp(currentFwVersion) >= 0
 }
 
@@ -107,11 +108,13 @@ func newFirmwareRepo(v vendor.Vendor, firmwareDir string) (*FirmwareRepo, error)
 
 			if len(upgrades) == 1 {
 				minStartingFwVersion = from
-				maxStartingFwVersion = from
-			} else if from.cmp(minStartingFwVersion) < 0 {
+				maxStartingFwVersion = to
+			}
+			if from.cmp(minStartingFwVersion) < 0 {
 				minStartingFwVersion = from
-			} else if from.cmp(maxStartingFwVersion) > 0 {
-				maxStartingFwVersion = from
+			}
+			if to.cmp(maxStartingFwVersion) > 0 {
+				maxStartingFwVersion = to
 			}
 		}
 	}

--- a/powershelf-manager/pkg/firmwaremanager/firmware_upgrade.go
+++ b/powershelf-manager/pkg/firmwaremanager/firmware_upgrade.go
@@ -51,18 +51,20 @@ type UpgradeRule interface {
 	summary() string
 }
 
-// LiteonUpgradeRule allows only direct upgrades where the device’s current version equals the edge’s source.
+// LiteonUpgradeRule allows upgrades where the device's current version equals
+// the edge's source or target. Liteon firmware artifacts are full images, so
+// re-flashing the same version (current == to) is safe.
 type LiteonUpgradeRule struct{}
 
 func (r LiteonUpgradeRule) isAllowed(currentFw firmwareVersion, upgrade FirmwareUpgrade) bool {
-	return currentFw.cmp(upgrade.from) == 0
+	return currentFw.cmp(upgrade.from) == 0 || currentFw.cmp(upgrade.to) == 0
 }
 
 func (r LiteonUpgradeRule) summary() string {
-	return "Liteon upgrade rule: only direct upgrades supported"
+	return "Liteon upgrade rule: direct upgrades and same-version re-flash supported"
 }
 
-// newUpgradeRule returns the vendor’s rule set or an error if the vendor is unsupported.
+// newUpgradeRule returns the vendor's rule set or an error if the vendor is unsupported.
 func newUpgradeRule(v vendor.Vendor) (UpgradeRule, error) {
 	switch v.Code {
 	case vendor.VendorCodeLiteon:


### PR DESCRIPTION
## Description

fix: support reflashing the same firmware version in PSM

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [x] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [ ] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
