### PR TITLE
fix: Fix OpenAPI URL for IP Block, SSH Key/Group & Tenant Account in TUI/CLI

### DIFF
--- a/cli/tui/commands.go
+++ b/cli/tui/commands.go
@@ -1108,7 +1108,7 @@ func cmdSSHKeyGroupCreate(s *Session, _ []string) error {
 
 	LogCmd(s, "ssh-key-group", "create", "--name", name)
 	bodyJSON, _ := json.Marshal(body)
-	resp, _, err := s.Client.Do("POST", apiPath(s, "ssh-key-group"), nil, nil, bodyJSON)
+	resp, _, err := s.Client.Do("POST", apiPath(s, "sshkeygroup"), nil, nil, bodyJSON)
 	if err != nil {
 		return fmt.Errorf("creating SSH key group: %w", err)
 	}
@@ -1167,7 +1167,7 @@ func cmdSSHKeyGroupUpdate(s *Session, args []string) error {
 
 	LogCmd(s, "ssh-key-group", "update", item.ID)
 	bodyJSON, _ := json.Marshal(body)
-	resp, _, err := s.Client.Do("PATCH", apiPath(s, "ssh-key-group/{id}"), map[string]string{"id": item.ID}, nil, bodyJSON)
+	resp, _, err := s.Client.Do("PATCH", apiPath(s, "sshkeygroup/{id}"), map[string]string{"id": item.ID}, nil, bodyJSON)
 	if err != nil {
 		return fmt.Errorf("updating SSH key group: %w", err)
 	}
@@ -1189,7 +1189,7 @@ func cmdSSHKeyGroupDelete(s *Session, args []string) error {
 		return err
 	}
 	LogCmd(s, "ssh-key-group", "delete", item.ID)
-	_, _, err = s.Client.Do("DELETE", apiPath(s, "ssh-key-group/{id}"), map[string]string{"id": item.ID}, nil, nil)
+	_, _, err = s.Client.Do("DELETE", apiPath(s, "sshkeygroup/{id}"), map[string]string{"id": item.ID}, nil, nil)
 	if err != nil {
 		return fmt.Errorf("deleting SSH key group: %w", err)
 	}
@@ -1236,7 +1236,7 @@ func cmdSSHKeyCreate(s *Session, _ []string) error {
 	}
 	LogCmd(s, "ssh-key", "create", "--name", name)
 	bodyJSON, _ := json.Marshal(body)
-	resp, _, err := s.Client.Do("POST", apiPath(s, "ssh-key"), nil, nil, bodyJSON)
+	resp, _, err := s.Client.Do("POST", apiPath(s, "sshkey"), nil, nil, bodyJSON)
 	if err != nil {
 		return fmt.Errorf("creating SSH key: %w", err)
 	}
@@ -1263,7 +1263,7 @@ func cmdSSHKeyUpdate(s *Session, args []string) error {
 	}
 	LogCmd(s, "ssh-key", "update", item.ID, "--name", strings.TrimSpace(name))
 	bodyJSON, _ := json.Marshal(body)
-	resp, _, err := s.Client.Do("PATCH", apiPath(s, "ssh-key/{id}"), map[string]string{"id": item.ID}, nil, bodyJSON)
+	resp, _, err := s.Client.Do("PATCH", apiPath(s, "sshkey/{id}"), map[string]string{"id": item.ID}, nil, bodyJSON)
 	if err != nil {
 		return fmt.Errorf("updating SSH key: %w", err)
 	}
@@ -1286,7 +1286,7 @@ func cmdSSHKeyDelete(s *Session, args []string) error {
 		return err
 	}
 	LogCmd(s, "ssh-key", "delete", item.ID)
-	_, _, err = s.Client.Do("DELETE", apiPath(s, "ssh-key/{id}"), map[string]string{"id": item.ID}, nil, nil)
+	_, _, err = s.Client.Do("DELETE", apiPath(s, "sshkey/{id}"), map[string]string{"id": item.ID}, nil, nil)
 	if err != nil {
 		return fmt.Errorf("deleting SSH key: %w", err)
 	}
@@ -1437,7 +1437,7 @@ func cmdIPBlockCreate(s *Session, _ []string) error {
 		"prefixLength": pl,
 	}
 	bodyJSON, _ := json.Marshal(body)
-	resp, _, err := s.Client.Do("POST", apiPath(s, "ip-block"), nil, nil, bodyJSON)
+	resp, _, err := s.Client.Do("POST", apiPath(s, "ipblock"), nil, nil, bodyJSON)
 	if err != nil {
 		return fmt.Errorf("creating IP block: %w", err)
 	}
@@ -1473,7 +1473,7 @@ func cmdIPBlockUpdate(s *Session, args []string) error {
 	}
 	LogCmd(s, "ip-block", "update", block.ID)
 	bodyJSON, _ := json.Marshal(body)
-	resp, _, err := s.Client.Do("PATCH", apiPath(s, "ip-block/{id}"), map[string]string{"id": block.ID}, nil, bodyJSON)
+	resp, _, err := s.Client.Do("PATCH", apiPath(s, "ipblock/{id}"), map[string]string{"id": block.ID}, nil, bodyJSON)
 	if err != nil {
 		return fmt.Errorf("updating IP block: %w", err)
 	}
@@ -1495,7 +1495,7 @@ func cmdIPBlockDelete(s *Session, args []string) error {
 		return err
 	}
 	LogCmd(s, "ip-block", "delete", block.ID)
-	_, _, err = s.Client.Do("DELETE", apiPath(s, "ip-block/{id}"), map[string]string{"id": block.ID}, nil, nil)
+	_, _, err = s.Client.Do("DELETE", apiPath(s, "ipblock/{id}"), map[string]string{"id": block.ID}, nil, nil)
 	if err != nil {
 		return fmt.Errorf("deleting IP block: %w", err)
 	}
@@ -1789,7 +1789,7 @@ func cmdTenantAccountCreate(s *Session, _ []string) error {
 	}
 	LogCmd(s, "tenant-account", "create", "--tenant-org", strings.TrimSpace(tenantOrg))
 	bodyJSON, _ := json.Marshal(body)
-	resp, _, err := s.Client.Do("POST", apiPath(s, "tenant-account"), nil, nil, bodyJSON)
+	resp, _, err := s.Client.Do("POST", apiPath(s, "tenant/account"), nil, nil, bodyJSON)
 	if err != nil {
 		return fmt.Errorf("creating tenant account: %w", err)
 	}
@@ -1811,7 +1811,7 @@ func cmdTenantAccountUpdate(s *Session, args []string) error {
 	}
 	LogCmd(s, "tenant-account", "update", item.ID)
 	bodyJSON, _ := json.Marshal(map[string]interface{}{})
-	resp, _, err := s.Client.Do("PATCH", apiPath(s, "tenant-account/{id}"), map[string]string{"id": item.ID}, nil, bodyJSON)
+	resp, _, err := s.Client.Do("PATCH", apiPath(s, "tenant/account/{id}"), map[string]string{"id": item.ID}, nil, bodyJSON)
 	if err != nil {
 		return fmt.Errorf("accepting tenant account invitation: %w", err)
 	}
@@ -1832,7 +1832,7 @@ func cmdTenantAccountDelete(s *Session, args []string) error {
 		return err
 	}
 	LogCmd(s, "tenant-account", "delete", item.ID)
-	_, _, err = s.Client.Do("DELETE", apiPath(s, "tenant-account/{id}"), map[string]string{"id": item.ID}, nil, nil)
+	_, _, err = s.Client.Do("DELETE", apiPath(s, "tenant/account/{id}"), map[string]string{"id": item.ID}, nil, nil)
 	if err != nil {
 		return fmt.Errorf("deleting tenant account: %w", err)
 	}
@@ -2087,7 +2087,7 @@ func cmdSSHKeyGroupGet(s *Session, args []string) error {
 		return err
 	}
 	LogCmd(s, "ssh-key-group", "get", item.ID)
-	return getAndPrint(s, apiPath(s, "ssh-key-group/{id}"), item.ID)
+	return getAndPrint(s, apiPath(s, "sshkeygroup/{id}"), item.ID)
 }
 
 func cmdSSHKeyGet(s *Session, args []string) error {
@@ -2096,7 +2096,7 @@ func cmdSSHKeyGet(s *Session, args []string) error {
 		return err
 	}
 	LogCmd(s, "ssh-key", "get", item.ID)
-	return getAndPrint(s, apiPath(s, "ssh-key/{id}"), item.ID)
+	return getAndPrint(s, apiPath(s, "sshkey/{id}"), item.ID)
 }
 
 func cmdAllocationGet(s *Session, args []string) error {
@@ -2133,7 +2133,7 @@ func cmdIPBlockGet(s *Session, args []string) error {
 		return err
 	}
 	LogCmd(s, "ip-block", "get", item.ID)
-	return getAndPrint(s, apiPath(s, "ip-block/{id}"), item.ID)
+	return getAndPrint(s, apiPath(s, "ipblock/{id}"), item.ID)
 }
 
 func cmdNSGGet(s *Session, args []string) error {
@@ -2178,7 +2178,7 @@ func cmdTenantAccountGet(s *Session, args []string) error {
 		return err
 	}
 	LogCmd(s, "tenant-account", "get", item.ID)
-	return getAndPrint(s, apiPath(s, "tenant-account/{id}"), item.ID)
+	return getAndPrint(s, apiPath(s, "tenant/account/{id}"), item.ID)
 }
 
 func cmdExpectedMachineGet(s *Session, args []string) error {

--- a/cli/tui/session.go
+++ b/cli/tui/session.go
@@ -397,7 +397,7 @@ func (s *Session) fetchSSHKeyGroups(_ context.Context) ([]NamedItem, error) {
 	if s.Scope.SiteID != "" {
 		q["siteId"] = s.Scope.SiteID
 	}
-	items, err := s.fetchAll(apiPath(s, "ssh-key-group"), q)
+	items, err := s.fetchAll(apiPath(s, "sshkeygroup"), q)
 	if err != nil {
 		return nil, err
 	}
@@ -432,7 +432,7 @@ func (s *Session) fetchIPBlocks(_ context.Context) ([]NamedItem, error) {
 	if s.Scope.SiteID != "" {
 		q["siteId"] = s.Scope.SiteID
 	}
-	items, err := s.fetchAll(apiPath(s, "ip-block"), q)
+	items, err := s.fetchAll(apiPath(s, "ipblock"), q)
 	if err != nil {
 		return nil, err
 	}
@@ -494,7 +494,7 @@ func (s *Session) fetchAudits(_ context.Context) ([]NamedItem, error) {
 }
 
 func (s *Session) fetchSSHKeys(_ context.Context) ([]NamedItem, error) {
-	items, err := s.fetchAll(apiPath(s, "ssh-key"), nil)
+	items, err := s.fetchAll(apiPath(s, "sshkey"), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -579,7 +579,7 @@ func (s *Session) fetchVPCPrefixes(_ context.Context) ([]NamedItem, error) {
 }
 
 func (s *Session) fetchTenantAccounts(_ context.Context) ([]NamedItem, error) {
-	items, err := s.fetchAll(apiPath(s, "tenant-account"), nil)
+	items, err := s.fetchAll(apiPath(s, "tenant/account"), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description
Fix TUI URL segments that didn't match the OpenAPI spec. The TUI's
hand-written `apiPath()` calls were using hyphenated display names as URL
path segments for four resources, which don't match the actual paths served
by the API — every list/get/create/update/delete on those resources was
silently 404ing from inside `carbidecli tui`:
| Resource       | Sent                                            | Spec actually serves                           |
|----------------|-------------------------------------------------|------------------------------------------------|
| IP block       | `/v2/org/{org}/carbide/ip-block`                | `/v2/org/{org}/carbide/ipblock`                |
| SSH key        | `/v2/org/{org}/carbide/ssh-key`                 | `/v2/org/{org}/carbide/sshkey`                 |
| SSH key group  | `/v2/org/{org}/carbide/ssh-key-group`           | `/v2/org/{org}/carbide/sshkeygroup`            |
| Tenant account | `/v2/org/{org}/carbide/tenant-account`          | `/v2/org/{org}/carbide/tenant/account`         |

20 call-sites fixed across `cli/tui/commands.go` (16) and
`cli/tui/session.go` (4). Only the URL segment passed to `apiPath(s, ...)`
was changed — user-facing TUI command names (`ip-block list`, `ssh-key get`,
`tenant-account update`, etc.) are intentionally preserved to keep muscle
memory intact.
Not a regression — these segments have been wrong since the TUI was first
introduced in `#165` and survived the `apiPath()` helper refactor in `#356`.
Never caught because the non-TUI auto-generated CLI (`carbidecli ip-block
list`) reads paths directly from the embedded spec and resolves correctly.
## Type of Change
- [ ] **Feature** - New feature or functionality (feat:)
- [x] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)
## Services Affected
- [x] **API** - API models or endpoints updated  <!-- CLI client only, no server-side changes -->
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated
_Scope is limited to the carbidecli TUI (`cli/tui/`). No server endpoints,
DB schema, or other services are modified — this is purely a client-side
fix to align with the existing OpenAPI paths._
## Related Issues (Optional)
<!-- Fill in if there's a tracking issue/ticket -->
## Breaking Changes
- [ ] This PR contains breaking changes
## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)