### PR TITLE
fix: Error when flags are placed after a positional argument in carbidecli

### DIFF
--- a/cli/pkg/commands.go
+++ b/cli/pkg/commands.go
@@ -432,14 +432,30 @@ func detectMisorderedFlags(c *cli.Context, argParams []string, usageText string)
 // detectMisorderedFlagsInArgs is the pure-function core of detectMisorderedFlags,
 // extracted so it can be exercised directly from tests without building a cli.Context.
 func detectMisorderedFlagsInArgs(args, argParams []string, usageText string) error {
-	if len(args) <= len(argParams) {
+	isFlagLike := func(s string) bool {
+		return strings.HasPrefix(s, "-") && len(s) > 1
+	}
+
+	// Default: extras start past all expected positionals. But if a flag-like
+	// token appears inside the positional slots on a multi-positional command
+	// (e.g. `create <instanceTypeId> --data={}`, where urfave would otherwise
+	// pass --data={} through as the second path param), split earlier so the
+	// flag is detected rather than silently consumed into the URL path.
+	split := len(argParams)
+	for i := 1; i < len(args) && i < len(argParams); i++ {
+		if isFlagLike(args[i]) {
+			split = i
+			break
+		}
+	}
+	if len(args) <= split {
 		return nil
 	}
-	extras := args[len(argParams):]
+	extras := args[split:]
 
 	var misplacedFlags, extraPositionals []string
 	for _, a := range extras {
-		if strings.HasPrefix(a, "-") && len(a) > 1 {
+		if isFlagLike(a) {
 			name := a
 			if eq := strings.Index(a, "="); eq >= 0 {
 				name = a[:eq]

--- a/cli/pkg/commands.go
+++ b/cli/pkg/commands.go
@@ -363,6 +363,10 @@ func buildActionCommand(spec *Spec, ro resolvedOp, subResource string) *cli.Comm
 		UsageText: usageText,
 		Flags:     flags,
 		Action: func(c *cli.Context) error {
+			if err := detectMisorderedFlags(c, argParams, usageText); err != nil {
+				return err
+			}
+
 			client, err := clientFromContext(c)
 			if err != nil {
 				return err
@@ -412,6 +416,72 @@ func buildActionCommand(spec *Spec, ro resolvedOp, subResource string) *cli.Comm
 			return FormatOutput(respBody, c.String("output"))
 		},
 	}
+}
+
+// detectMisorderedFlags returns a helpful error when urfave/cli's stdlib flag
+// parser stopped at a positional and left flag-like tokens in c.Args(). Go's
+// flag package stops parsing at the first non-flag argument, so anything the
+// user placed after a positional is silently ignored -- which on update/create
+// operations surfaces as confusing server-side errors like "no updates
+// specified". Catching it client-side turns a silent drop into a clear usage
+// hint.
+func detectMisorderedFlags(c *cli.Context, argParams []string, usageText string) error {
+	return detectMisorderedFlagsInArgs(c.Args().Slice(), argParams, usageText)
+}
+
+// detectMisorderedFlagsInArgs is the pure-function core of detectMisorderedFlags,
+// extracted so it can be exercised directly from tests without building a cli.Context.
+func detectMisorderedFlagsInArgs(args, argParams []string, usageText string) error {
+	if len(args) <= len(argParams) {
+		return nil
+	}
+	extras := args[len(argParams):]
+
+	var misplacedFlags, extraPositionals []string
+	for _, a := range extras {
+		if strings.HasPrefix(a, "-") && len(a) > 1 {
+			name := a
+			if eq := strings.Index(a, "="); eq >= 0 {
+				name = a[:eq]
+			}
+			misplacedFlags = append(misplacedFlags, name)
+		} else {
+			extraPositionals = append(extraPositionals, a)
+		}
+	}
+
+	if len(misplacedFlags) == 0 && len(extraPositionals) == 0 {
+		return nil
+	}
+
+	// Rewrite the usage line so the hint shows exactly where flags belong.
+	hint := usageText
+	if len(argParams) > 0 {
+		tail := ""
+		for _, ap := range argParams {
+			tail += " <" + ap + ">"
+		}
+		if idx := strings.Index(usageText, tail); idx >= 0 {
+			hint = usageText[:idx] + " [flags...]" + tail
+		}
+	}
+
+	var msg strings.Builder
+	if len(misplacedFlags) > 0 {
+		fmt.Fprintf(&msg, "flag(s) %s placed after a positional argument; urfave/cli (stdlib flag) stops parsing flags at the first positional, so these flags are being ignored.\n",
+			strings.Join(misplacedFlags, ", "))
+		fmt.Fprintf(&msg, "Move all flags before positionals, e.g.\n  %s\n", hint)
+	}
+	if len(extraPositionals) > 0 {
+		if msg.Len() > 0 {
+			msg.WriteString("Also: ")
+		}
+		fmt.Fprintf(&msg, "unexpected positional argument(s): %s (expected %d: %s)",
+			strings.Join(extraPositionals, ", "),
+			len(argParams),
+			strings.Join(argParams, ", "))
+	}
+	return fmt.Errorf("%s", strings.TrimRight(msg.String(), "\n"))
 }
 
 func readFlagValue(c *cli.Context, p Parameter) string {

--- a/cli/pkg/commands_test.go
+++ b/cli/pkg/commands_test.go
@@ -393,6 +393,13 @@ func TestDetectMisorderedFlags(t *testing.T) {
 			wantErr:   false,
 		},
 		{
+			name:         "multi-positional command with flag inside a required positional slot",
+			args:         []string{"instanceTypeId-1", "--data={}"},
+			argParams:    []string{"instanceTypeId", "machineAssociationId"},
+			wantErr:      true,
+			wantContains: []string{"--data", "placed after a positional"},
+		},
+		{
 			name:         "multi-positional command with trailing flag",
 			args:         []string{"instanceTypeId-1", "machineAssociationId-1", "--data", "{}"},
 			argParams:    []string{"instanceTypeId", "machineAssociationId"},

--- a/cli/pkg/commands_test.go
+++ b/cli/pkg/commands_test.go
@@ -18,6 +18,7 @@
 package carbidecli
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -303,6 +304,118 @@ func TestIsListAction(t *testing.T) {
 			got := isListAction(tt.action)
 			if got != tt.want {
 				t.Errorf("isListAction(%q) = %v, want %v", tt.action, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectMisorderedFlags(t *testing.T) {
+	usage := "carbidecli machine update <machineId>"
+	tests := []struct {
+		name         string
+		args         []string
+		argParams    []string
+		wantErr      bool
+		wantContains []string
+	}{
+		{
+			name:      "happy path - exactly the positional, no extras",
+			args:      []string{"fm100htq"},
+			argParams: []string{"machineId"},
+			wantErr:   false,
+		},
+		{
+			name:      "happy path - no positionals required and none given",
+			args:      nil,
+			argParams: nil,
+			wantErr:   false,
+		},
+		{
+			name:         "flag after positional - NVBug repro",
+			args:         []string{"fm100htq", "--data", "{}"},
+			argParams:    []string{"machineId"},
+			wantErr:      true,
+			wantContains: []string{"--data", "placed after a positional", "Move all flags before positionals", "[flags...] <machineId>"},
+		},
+		{
+			name:         "flag=value form after positional",
+			args:         []string{"fm100htq", "--data={}"},
+			argParams:    []string{"machineId"},
+			wantErr:      true,
+			wantContains: []string{"--data", "placed after a positional"},
+		},
+		{
+			name:         "short flag after positional",
+			args:         []string{"fm100htq", "-o", "yaml"},
+			argParams:    []string{"machineId"},
+			wantErr:      true,
+			wantContains: []string{"-o"},
+		},
+		{
+			name:         "multiple flags after positional",
+			args:         []string{"fm100htq", "--data", "{}", "--output", "yaml"},
+			argParams:    []string{"machineId"},
+			wantErr:      true,
+			wantContains: []string{"--data", "--output"},
+		},
+		{
+			name:         "per-field flag after positional",
+			args:         []string{"fm100htq", "--instance-type-id", "uuid-here"},
+			argParams:    []string{"machineId"},
+			wantErr:      true,
+			wantContains: []string{"--instance-type-id"},
+		},
+		{
+			name:         "extra positional without leading dash",
+			args:         []string{"fm100htq", "bonusId"},
+			argParams:    []string{"machineId"},
+			wantErr:      true,
+			wantContains: []string{"unexpected positional argument", "bonusId"},
+		},
+		{
+			name:         "extra positional plus misplaced flag",
+			args:         []string{"fm100htq", "bonusId", "--data", "{}"},
+			argParams:    []string{"machineId"},
+			wantErr:      true,
+			wantContains: []string{"--data", "bonusId", "unexpected positional"},
+		},
+		{
+			name:         "lone dash is not treated as a flag",
+			args:         []string{"fm100htq", "-"},
+			argParams:    []string{"machineId"},
+			wantErr:      true,
+			wantContains: []string{"unexpected positional", "-"},
+		},
+		{
+			name:      "multi-positional command with flags in correct order",
+			args:      []string{"instanceTypeId-1", "machineAssociationId-1"},
+			argParams: []string{"instanceTypeId", "machineAssociationId"},
+			wantErr:   false,
+		},
+		{
+			name:         "multi-positional command with trailing flag",
+			args:         []string{"instanceTypeId-1", "machineAssociationId-1", "--data", "{}"},
+			argParams:    []string{"instanceTypeId", "machineAssociationId"},
+			wantErr:      true,
+			wantContains: []string{"--data"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := detectMisorderedFlagsInArgs(tt.args, tt.argParams, usage)
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err != nil {
+				for _, want := range tt.wantContains {
+					if !strings.Contains(err.Error(), want) {
+						t.Errorf("error missing %q:\n%s", want, err.Error())
+					}
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

`carbidecli machine update <machineId> --data '{...}'` silently discards the `--data` body, surfacing as `API error 400: no updates specified`. Same failure applies to `--data-file`, every per-field flag like `--instance-type-id`, and every other operation with a request body (e.g. `instance-type machine-association create`).

Root cause: urfave/cli/v2 uses Go's stdlib flag package, which stops parsing flags at the first non-flag argument. Once the parser sees `<machineId>`, every flag after it lands in `c.Args()` as an extra positional. `c.String("data")` then returns `""`, `buildRequestBody` returns `nil`, and the client sends an empty PATCH.

Proven end-to-end against a live environment with the same machine and body, only arg order differing:
- `machine update <id> --data '{...}'` -> 400 "no updates specified"
- `machine update --data '{...}' <id>` -> 200

## Change

`buildActionCommand` now runs `detectMisorderedFlags` at the top of its Action. If `c.Args()` contains more tokens than the command's path parameters, we classify the extras:
- tokens starting with `-` -> misplaced flag, error naming it and showing the correct invocation
- other tokens -> unexpected positional, error listing expected path params

No flag surface changes, no HTTP/content-type changes, no schema changes.

## Example

```
$ carbidecli machine update FAKEID --data '{"instanceTypeId":"uuid"}'
Error: flag(s) --data placed after a positional argument; urfave/cli (stdlib flag) stops parsing flags at the first positional, so these flags are being ignored.
Move all flags before positionals, e.g.
  carbidecli machine update [flags...] <machineId>
Also: unexpected positional argument(s): {"instanceTypeId":"uuid"} (expected 1: machineId)
```

## Test plan

- [x] Added `TestDetectMisorderedFlags` with 12 cases (happy path, `--flag value`, `--flag=value`, short flags, multiple flags, per-field flags, bonus positionals, multi-positional commands)
- [x] `go test ./cli/...` passes
- [x] `go vet ./cli/...` clean, `gofmt -l` clean
- [x] `make carbide-cli` builds
- [x] Smoke-tested installed binary with `--base-url http://127.0.0.1:1` on misordered, `--flag=value`, per-field, correctly ordered, and sub-resource (`instance-type machine-association create`) invocations -- detector short-circuits every misordered case before any HTTP attempt and passes cleanly on the correctly ordered one