### PR TITLE
fix: Move machine ID lock acquisition before record pull

### DIFF
--- a/api/pkg/api/handler/instance.go
+++ b/api/pkg/api/handler/instance.go
@@ -816,6 +816,13 @@ func (cih CreateInstanceHandler) Handle(c echo.Context) error {
 
 		mDAO := cdbm.NewMachineDAO(cih.dbSession)
 
+		// Acquire a lock on the MachineID
+		err = tx.TryAcquireAdvisoryLock(ctx, cdb.GetAdvisoryLockIDFromString(*apiRequest.MachineID), nil)
+		if err != nil {
+			logger.Error().Err(err).Msg("Failed to acquire advisory lock on Machine")
+			return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("Failed to lock Machine: %s for Instance creation. It is likely being considered for another Instance creation request", *apiRequest.MachineID), nil)
+		}
+
 		// Retrieve Machine by ID
 		machine, err = mDAO.GetByID(ctx, nil, *apiRequest.MachineID, nil, false)
 		if err != nil {
@@ -886,13 +893,6 @@ func (cih CreateInstanceHandler) Handle(c echo.Context) error {
 					return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, fmt.Sprintf("Machine: %s has status: %s that does not allow Instance creation", machine.ID, machine.Status), nil)
 				}
 			}
-		}
-
-		// Acquire a lock on the MachineID
-		err = tx.TryAcquireAdvisoryLock(ctx, cdb.GetAdvisoryLockIDFromString(machine.ID), nil)
-		if err != nil {
-			logger.Error().Err(err).Msg("Failed to acquire advisory lock on Machine")
-			return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("Failed to lock Machine: %s for Instance creation. It is likely being considered for another Instance creation request", machine.ID), nil)
 		}
 
 		// Update the machine status to assigned


### PR DESCRIPTION
## Description
We're grabbing a lock on Machine.ID when allocating an instance, but it's happening after the machine record has already been pulled from the DB, and the locking helper being used has retries.  This means a retry could acquire the lock, but the checks that follow could be on stale data.

We either need to use the helper that fails fast, or we need the lock acquisition moved so that the lock happens before the record is pulled.  I did the latter.

Instance batch creation _seems_ to also expect the Try locking helper to fail fast, but the machine records are being re-pulled after lock acquisition there, so it's fine as it is.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [x] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [ ] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
