### PR TITLE
chore: Update Instance creation API test, validate unhealthy Machine flag sent to Core

### DIFF
--- a/api/pkg/api/handler/instance.go
+++ b/api/pkg/api/handler/instance.go
@@ -805,7 +805,7 @@ func (cih CreateInstanceHandler) Handle(c echo.Context) error {
 
 	// ==================== Step 4: Machine Selection  ====================
 
-	// Default to false, will be set to true if allowUnhealthyMachine is set to true in request. This value is used when
+	// Default to false, will be set to true for data sent to Core if allowUnhealthyMachine is set to true in request
 	allowUnhealthyMachine := false
 
 	// Begin validating Machine ID

--- a/api/pkg/api/handler/instance.go
+++ b/api/pkg/api/handler/instance.go
@@ -805,7 +805,8 @@ func (cih CreateInstanceHandler) Handle(c echo.Context) error {
 
 	// ==================== Step 4: Machine Selection  ====================
 
-	var allowUnhealthyMachine bool
+	// Default to false, will be set to true if allowUnhealthyMachine is set to true in request. This value is used when
+	allowUnhealthyMachine := false
 
 	// Begin validating Machine ID
 	if apiRequest.MachineID != nil {
@@ -839,9 +840,8 @@ func (cih CreateInstanceHandler) Handle(c echo.Context) error {
 			return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, fmt.Sprintf("Machine specified in request does not belong to Site: %s", site.Name), nil)
 		}
 
-		// Propagate allowUnhealthyMachine to the site workflow; API still requires the
-		// machine to be Ready before instance creation proceeds.
-		allowUnhealthyMachine = false
+		// Validate Machine availability. Note: allowUnhealthyMachine also bypasses
+		// the Ready status check, not just health - consider renaming the parameter later.
 		if apiRequest.AllowUnhealthyMachine != nil {
 			allowUnhealthyMachine = *apiRequest.AllowUnhealthyMachine
 		}
@@ -1563,8 +1563,9 @@ func (cih CreateInstanceHandler) Handle(c echo.Context) error {
 		},
 		AllowUnhealthyMachine: allowUnhealthyMachine,
 	}
-	if instanceTypeID != nil {
-		createInstanceRequest.InstanceTypeId = cdb.GetStrPtr(instanceTypeID.String())
+
+	if apiRequest.InstanceTypeID != nil {
+		createInstanceRequest.InstanceTypeId = cdb.GetStrPtr(*apiRequest.InstanceTypeID)
 	}
 
 	workflowOptions := temporalClient.StartWorkflowOptions{

--- a/api/pkg/api/handler/instance_test.go
+++ b/api/pkg/api/handler/instance_test.go
@@ -3477,9 +3477,18 @@ func TestCreateInstanceHandler_Handle(t *testing.T) {
 					assert.Empty(t, req.Config.Tenant.TenantKeysetIds)
 				}
 
+				// Check that if user did not send Instance Type ID, it is not sent to Core
+				if tt.args.reqData.InstanceTypeID == nil {
+					assert.Nil(t, req.InstanceTypeId)
+				} else {
+					assert.Equal(t, *tt.args.reqData.InstanceTypeID, *req.InstanceTypeId)
+				}
+
 				// Check that the allow unhealthy machine flag is set correctly
 				if tt.args.reqData.AllowUnhealthyMachine != nil && *tt.args.reqData.AllowUnhealthyMachine {
 					assert.True(t, req.AllowUnhealthyMachine, fmt.Sprintf("%v", req))
+				} else {
+					assert.False(t, req.AllowUnhealthyMachine, fmt.Sprintf("%v", req))
 				}
 			}
 

--- a/api/pkg/api/handler/instance_test.go
+++ b/api/pkg/api/handler/instance_test.go
@@ -3432,12 +3432,18 @@ func TestCreateInstanceHandler_Handle(t *testing.T) {
 				}
 			}
 
-			if len(tsc.Calls) > 0 && len(tt.args.reqData.SSHKeyGroupIDs) > 0 {
-
-				req := tsc.Calls[0].Arguments[3].(*cwssaws.InstanceAllocationRequest)
+			if len(tsc.Calls) > 0 && len(tsc.Calls[len(tsc.Calls)-1].Arguments) > 3 {
+				req := tsc.Calls[len(tsc.Calls)-1].Arguments[3].(*cwssaws.InstanceAllocationRequest)
 
 				// Check that the list of IDs match in size and order.
-				assert.Equal(t, req.Config.Tenant.TenantKeysetIds, tt.args.reqData.SSHKeyGroupIDs)
+				if len(tt.args.reqData.SSHKeyGroupIDs) > 0 {
+					assert.Equal(t, req.Config.Tenant.TenantKeysetIds, tt.args.reqData.SSHKeyGroupIDs)
+				}
+
+				// Check that the allow unhealthy machine flag is set correctly
+				if tt.args.reqData.AllowUnhealthyMachine != nil && *tt.args.reqData.AllowUnhealthyMachine {
+					assert.True(t, req.AllowUnhealthyMachine, fmt.Sprintf("%v", req))
+				}
 			}
 
 			if len(tt.args.reqData.InfiniBandInterfaces) > 0 {

--- a/api/pkg/api/handler/instance_test.go
+++ b/api/pkg/api/handler/instance_test.go
@@ -1422,6 +1422,41 @@ func TestCreateInstanceHandler_Handle(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "test Instance create API endpoint success, allowUnhealthyMachine true, Machine has Error status, but controller is Ready",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        tc,
+				cfg:       cfg,
+			},
+			args: args{
+				reqData: &model.APIInstanceCreateRequest{
+					Name:        "test-instance-error-controller-ready",
+					Description: cdb.GetStrPtr("Error status with Ready controller state"),
+					TenantID:    tn1.ID.String(),
+					VpcID:       vpc1.ID.String(),
+					UserData:    cdb.GetStrPtr(""),
+					IpxeScript:  cdb.GetStrPtr(common.DefaultIpxeScript),
+					Interfaces: []model.APIInterfaceCreateOrUpdateRequest{
+						{
+							SubnetID: cdb.GetStrPtr(subnet1.ID.String()),
+						},
+					},
+					AllowUnhealthyMachine: cdb.GetBoolPtr(true),
+					PhoneHomeEnabled:      cdb.GetBoolPtr(false),
+				},
+				prepareReq: func(t *testing.T, req *model.APIInstanceCreateRequest) {
+					mc := testInstanceBuildMachine(t, dbSession, ip.ID, st1.ID, cdb.GetBoolPtr(false), nil)
+					testInstanceBuildMachineInstanceType(t, dbSession, mc, ist1)
+					testUpdateMachineStatusAndControllerState(t, dbSession, mc, cdbm.MachineStatusError, "Ready")
+					req.MachineID = cdb.GetStrPtr(mc.ID)
+				},
+				reqOrg:   tnOrg,
+				reqUser:  tnu1,
+				respCode: http.StatusCreated,
+			},
+			wantErr: false,
+		},
+		{
 			name: "test Instance create API endpoint success with secondary VPC Prefix interface",
 			fields: fields{
 				dbSession: dbSession,
@@ -3438,6 +3473,8 @@ func TestCreateInstanceHandler_Handle(t *testing.T) {
 				// Check that the list of IDs match in size and order.
 				if len(tt.args.reqData.SSHKeyGroupIDs) > 0 {
 					assert.Equal(t, req.Config.Tenant.TenantKeysetIds, tt.args.reqData.SSHKeyGroupIDs)
+				} else {
+					assert.Empty(t, req.Config.Tenant.TenantKeysetIds)
 				}
 
 				// Check that the allow unhealthy machine flag is set correctly


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
- Instance creation tests are currently not capturing whether `allowUnhealthyMachine` flag is set for data sent to Core. This PR updates tests to ensure the data is correct
- It also updates the logic to send Instance Type ID to Core only when Instance is being created specifying Instance Type ID

## Type of Change
- [x] **Chore** - Modification or removal of existing functionality (chore:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **API** - API models or endpoints updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->
None

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
None
