### PR TITLE
fix: Resolve required query param for tenant-account list in TUI

### DIFF
--- a/cli/tui/commands.go
+++ b/cli/tui/commands.go
@@ -1760,8 +1760,15 @@ func cmdVPCPrefixDelete(s *Session, args []string) error {
 }
 
 func cmdTenantAccountList(s *Session, _ []string) error {
-	LogCmd(s, "tenant-account", "list")
-	items, err := s.Resolver.Fetch(context.Background(), "tenant-account")
+	ctx := context.Background()
+	var extraFlags []string
+	if id, err := s.getInfrastructureProviderID(ctx); err == nil {
+		extraFlags = append(extraFlags, "--infrastructure-provider-id", id)
+	} else if id, err := s.getTenantID(ctx); err == nil {
+		extraFlags = append(extraFlags, "--tenant-id", id)
+	}
+	LogCmd(s, append([]string{"tenant-account", "list"}, extraFlags...)...)
+	items, err := s.Resolver.Fetch(ctx, "tenant-account")
 	if err != nil {
 		return err
 	}

--- a/cli/tui/session.go
+++ b/cli/tui/session.go
@@ -236,6 +236,27 @@ func (s *Session) getTenantID(_ context.Context) (string, error) {
 	return id, nil
 }
 
+// getInfrastructureProviderID returns the current infrastructure provider ID, caching it for the session.
+func (s *Session) getInfrastructureProviderID(_ context.Context) (string, error) {
+	if cached := s.Cache.LookupByName("_infra_provider", s.Org); cached != nil {
+		return cached.ID, nil
+	}
+	body, _, err := s.Client.Do("GET", apiPath(s, "infrastructure-provider/current"), nil, nil, nil)
+	if err != nil {
+		return "", fmt.Errorf("fetching infrastructure provider: %w", err)
+	}
+	var p map[string]interface{}
+	if err := json.Unmarshal(body, &p); err != nil {
+		return "", fmt.Errorf("parsing infrastructure provider: %w", err)
+	}
+	id := str(p, "id")
+	if id == "" {
+		return "", fmt.Errorf("infrastructure provider has no id")
+	}
+	s.Cache.Set("_infra_provider", []NamedItem{{Name: s.Org, ID: id}})
+	return id, nil
+}
+
 // -- Fetchers --
 
 func (s *Session) fetchSites(_ context.Context) ([]NamedItem, error) {
@@ -578,8 +599,14 @@ func (s *Session) fetchVPCPrefixes(_ context.Context) ([]NamedItem, error) {
 	return result, nil
 }
 
-func (s *Session) fetchTenantAccounts(_ context.Context) ([]NamedItem, error) {
-	items, err := s.fetchAll(apiPath(s, "tenant/account"), nil)
+func (s *Session) fetchTenantAccounts(ctx context.Context) ([]NamedItem, error) {
+	q := map[string]string{}
+	if id, err := s.getInfrastructureProviderID(ctx); err == nil {
+		q["infrastructureProviderId"] = id
+	} else if id, err := s.getTenantID(ctx); err == nil {
+		q["tenantId"] = id
+	}
+	items, err := s.fetchAll(apiPath(s, "tenant/account"), q)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/tui/session.go
+++ b/cli/tui/session.go
@@ -603,8 +603,15 @@ func (s *Session) fetchTenantAccounts(ctx context.Context) ([]NamedItem, error) 
 	q := map[string]string{}
 	if id, err := s.getInfrastructureProviderID(ctx); err == nil {
 		q["infrastructureProviderId"] = id
-	} else if id, err := s.getTenantID(ctx); err == nil {
-		q["tenantId"] = id
+	} else {
+		tenantID, tenantErr := s.getTenantID(ctx)
+		if tenantErr != nil {
+			return nil, fmt.Errorf(
+				"resolving tenant-account scope: infrastructure provider: %v; tenant: %w",
+				err, tenantErr,
+			)
+		}
+		q["tenantId"] = tenantID
 	}
 	items, err := s.fetchAll(apiPath(s, "tenant/account"), q)
 	if err != nil {


### PR DESCRIPTION
## Summary

- The `tenant-account list` command in TUI/interactive mode was failing with `API error 400: Either infrastructureProviderId or tenantId query param must be specified` because the fetcher passed no query params
- Auto-resolve the infrastructure provider ID via `infrastructure-provider/current` (or fall back to tenant ID via `tenant/current`) and pass it as a query param in the fetcher
- Include the resolved ID in the logged `carbidecli` command for reproducibility

This fix applies to all TUI commands that use the `tenant-account` fetcher (list, get, update, delete).

## Test plan

- Run `carbidecli tui` and execute `tenant-account list` -- should return results instead of a 400 error
- Verify the INFO line includes `--infrastructure-provider-id <id>` (or `--tenant-id <id>` for tenant-only orgs)
- Run `tenant-account get` from TUI to confirm the resolver-level fix works for downstream commands