### PR TITLE
fix: Update over SSH Key Group status after successful sync to Site

### DIFF
--- a/workflow/pkg/activity/sshkeygroup/sshkeygroup.go
+++ b/workflow/pkg/activity/sshkeygroup/sshkeygroup.go
@@ -261,12 +261,16 @@ func (mskg ManageSSHKeyGroup) SyncSSHKeyGroupViaSiteAgent(ctx context.Context, s
 		}
 	}
 
+	// Log status detail regardless of success or failure
 	_ = mskg.updateSSHKeyGroupSiteAssociationStatusInDB(ctx, nil, skgsa.ID, &status, &statusMessage)
+
+	// If workflow wasn't successful, return error to retry workflow
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to trigger site agent SyncSSHKeyGroup workflow")
 		return err
 	}
 
+	// Create/update was successful
 	if we != nil {
 		logger.Info().Str("Workflow ID", we.GetID()).Msg(fmt.Sprintf("successfully executed %s SSHKeyGroup workflow on Site", workflowMethod))
 	}

--- a/workflow/pkg/workflow/sshkeygroup/sync.go
+++ b/workflow/pkg/workflow/sshkeygroup/sync.go
@@ -60,10 +60,18 @@ func SyncSSHKeyGroup(ctx workflow.Context, siteID uuid.UUID, sshKeyGroupID uuid.
 
 	var sshKeyGroupManager sshKeyGroupActivity.ManageSSHKeyGroup
 
+	// Sync SSH Key Group via Site Agent
 	err := workflow.ExecuteActivity(ctx, sshKeyGroupManager.SyncSSHKeyGroupViaSiteAgent, siteID, sshKeyGroupID, version).Get(ctx, nil)
 	if err != nil {
 		logger.Warn().Err(err).Msg("failed to execute activity: SyncSSHKeyGroupViaSiteAgent")
 		return err
+	}
+
+	// Update overall SSH Key Group status in DB
+	serr := workflow.ExecuteActivity(ctx, sshKeyGroupManager.UpdateSSHKeyGroupStatusInDB, sshKeyGroupID.String()).Get(ctx, nil)
+	if serr != nil {
+		// Log error but continue as we don't want to fail the entire workflow if sync was successful
+		logger.Warn().Err(serr).Msg("failed to execute activity: UpdateSSHKeyGroupStatusInDB")
 	}
 
 	logger.Info().Msg("completing workflow")

--- a/workflow/pkg/workflow/sshkeygroup/sync_test.go
+++ b/workflow/pkg/workflow/sshkeygroup/sync_test.go
@@ -48,7 +48,7 @@ func (s *SyncSSHKeyGroupTestSuite) AfterTest(suiteName, testName string) {
 	s.env.AssertExpectations(s.T())
 }
 
-func (s *SyncSSHKeyGroupTestSuite) Test_CreateSSHKeyGroupWorkflow_Success() {
+func (s *SyncSSHKeyGroupTestSuite) Test_SyncSSHKeyGroupWorkflow_Success() {
 	var sshKeyGroupManager sshKeyGroupActivity.ManageSSHKeyGroup
 
 	siteID := uuid.New()
@@ -58,13 +58,37 @@ func (s *SyncSSHKeyGroupTestSuite) Test_CreateSSHKeyGroupWorkflow_Success() {
 	s.env.RegisterActivity(sshKeyGroupManager.SyncSSHKeyGroupViaSiteAgent)
 	s.env.OnActivity(sshKeyGroupManager.SyncSSHKeyGroupViaSiteAgent, mock.Anything, siteID, sshKeyGroupID, mock.Anything).Return(nil)
 
-	// execute CreateSSHKeyGroup workflow
+	// Mock UpdateSSHKeyGroupStatusInDB activity
+	s.env.RegisterActivity(sshKeyGroupManager.UpdateSSHKeyGroupStatusInDB)
+	s.env.OnActivity(sshKeyGroupManager.UpdateSSHKeyGroupStatusInDB, mock.Anything, sshKeyGroupID.String()).Return(nil)
+
+	// Execute SyncSSHKeyGroup workflow
 	s.env.ExecuteWorkflow(SyncSSHKeyGroup, siteID, sshKeyGroupID, mock.Anything)
 	s.True(s.env.IsWorkflowCompleted())
 	s.NoError(s.env.GetWorkflowError())
 }
 
-func (s *SyncSSHKeyGroupTestSuite) Test_CreateSSHKeyGroupWorkflow_ActivityFails() {
+func (s *SyncSSHKeyGroupTestSuite) Test_SyncSSHKeyGroupWorkflow_Success_With_UpdateSSHKeyGroupStatusInDB_Failure() {
+	var sshKeyGroupManager sshKeyGroupActivity.ManageSSHKeyGroup
+
+	siteID := uuid.New()
+	sshKeyGroupID := uuid.New()
+
+	// Mock SyncSSHKeyGroupViaSiteAgent activity
+	s.env.RegisterActivity(sshKeyGroupManager.SyncSSHKeyGroupViaSiteAgent)
+	s.env.OnActivity(sshKeyGroupManager.SyncSSHKeyGroupViaSiteAgent, mock.Anything, siteID, sshKeyGroupID, mock.Anything).Return(nil)
+
+	// Mock UpdateSSHKeyGroupStatusInDB activity
+	s.env.RegisterActivity(sshKeyGroupManager.UpdateSSHKeyGroupStatusInDB)
+	s.env.OnActivity(sshKeyGroupManager.UpdateSSHKeyGroupStatusInDB, mock.Anything, sshKeyGroupID.String()).Return(errors.New("UpdateSSHKeyGroupStatusInDB Failure"))
+
+	// Execute SyncSSHKeyGroup workflow
+	s.env.ExecuteWorkflow(SyncSSHKeyGroup, siteID, sshKeyGroupID, mock.Anything)
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
+}
+
+func (s *SyncSSHKeyGroupTestSuite) Test_SyncSSHKeyGroupWorkflow_SyncSSHKeyGroupViaSiteAgent_Failure() {
 
 	var sshKeyGroupManager sshKeyGroupActivity.ManageSSHKeyGroup
 
@@ -75,7 +99,10 @@ func (s *SyncSSHKeyGroupTestSuite) Test_CreateSSHKeyGroupWorkflow_ActivityFails(
 	s.env.RegisterActivity(sshKeyGroupManager.SyncSSHKeyGroupViaSiteAgent)
 	s.env.OnActivity(sshKeyGroupManager.SyncSSHKeyGroupViaSiteAgent, mock.Anything, siteID, sshKeyGroupID, mock.Anything).Return(errors.New("SyncSSHKeyGroupViaSiteAgent Failure"))
 
-	// execute CreateSSHKeyGroup workflow
+	// Mock UpdateSSHKeyGroupStatusInDB activity
+	s.env.RegisterActivity(sshKeyGroupManager.UpdateSSHKeyGroupStatusInDB)
+
+	// Execute SyncSSHKeyGroup workflow
 	s.env.ExecuteWorkflow(SyncSSHKeyGroup, siteID, sshKeyGroupID, mock.Anything)
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
@@ -86,7 +113,7 @@ func (s *SyncSSHKeyGroupTestSuite) Test_CreateSSHKeyGroupWorkflow_ActivityFails(
 	s.Equal("SyncSSHKeyGroupViaSiteAgent Failure", applicationErr.Error())
 }
 
-func (s *SyncSSHKeyGroupTestSuite) Test_ExecuteCreateSSHKeyGroupWorkflow_Success() {
+func (s *SyncSSHKeyGroupTestSuite) Test_ExecuteSyncSSHKeyGroupWorkflow_Success() {
 	ctx := context.Background()
 	siteID := uuid.New()
 	sshKeyGroupID := uuid.New()


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
When an SSH Key Group is synced to a particular Site, current workflow code is only updating status of the Site Association but not updating the overall SSH Key Group status (that may be connected to more than one Site). This PR fixes that.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Fix** - Bug fixes (fix:)

## Services Affected
- [x] **Workflow** - Workflow service updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->
None

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
None