### PR TITLE
feat: Update Site Agent Helm chart to adopt Core prereqs for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Test database configuration:
 - Port: `30432`
 - User/Password: `postgres` / `postgres`
 
-### Local Deployment with Kind
+### Option A: Local Development with Kind
+
+The fastest path to a running stack on your laptop. Builds images locally, spins up a Kind cluster, and deploys a mock NCX Infra Controller Core automatically — no external registry or bare-metal cluster required.
 
 ```bash
 make kind-reset
@@ -79,7 +81,44 @@ make helm-uninstall      # Uninstall Helm releases
 make kind-down           # Tear down cluster
 ```
 
-### Production Cluster Deployment
+### Option B: Bare-Metal Cluster with helm-prereqs
+
+For deploying onto a real Kubernetes cluster alongside NCX Infra Controller Core. Uses `helm-prereqs/setup.sh` from the [ncx-infra-controller-core](https://github.com/NVIDIA/ncx-infra-controller-core) repo, which installs the full prerequisite stack (cert-manager, Vault, external-secrets, PostgreSQL, Temporal, Keycloak) and deploys both NCX Core and NCX REST in the correct order.
+
+```bash
+# 1. Build and push images to your registry
+make docker-build IMAGE_REGISTRY=my-registry.example.com/ncx IMAGE_TAG=v1.0.4
+
+for image in carbide-rest-api carbide-rest-workflow carbide-rest-site-manager \
+             carbide-rest-site-agent carbide-rest-db carbide-rest-cert-manager; do
+    docker push my-registry.example.com/ncx/$image:v1.0.4
+done
+
+# 2. Set environment variables
+export KUBECONFIG=/path/to/kubeconfig
+export REGISTRY_PULL_SECRET=<pull-secret-or-api-key>
+export NCX_IMAGE_REGISTRY=my-registry.example.com/ncx
+export NCX_CORE_IMAGE_TAG=<ncx-core-tag>    # NCX Infra Controller Core image tag
+export NCX_REST_IMAGE_TAG=v1.0.4               # NCX REST image tag
+
+# 3. Clone ncx-infra-controller-core (if not already present as a sibling directory)
+git clone https://github.com/NVIDIA/ncx-infra-controller-core.git ../ncx-infra-controller-core
+
+# 4. Run setup from the ncx-infra-controller-core repo
+cd ../ncx-infra-controller-core/helm-prereqs
+./setup.sh -y     # or ./setup.sh for interactive prompts
+```
+
+The setup script auto-detects this repo from the sibling path `ncx-infra-controller-rest`. Set `NCX_REPO=/path/to/this/repo` to override.
+
+To tear everything down:
+```bash
+./clean.sh
+```
+
+See [ncx-infra-controller-core/helm-prereqs/README.md](https://github.com/NVIDIA/ncx-infra-controller-core/blob/main/helm-prereqs/README.md) for the full reference: PKI architecture, phase-by-phase description, site customization, secrets reference, and troubleshooting (including site-agent gRPC connectivity).
+
+### Option C: Manual / Kustomize Production Deployment
 
 See **[Deployment QuickStart Guide](deploy/README.md)** for a concise bring-up guide, and **[Detailed Installation Guide](deploy/INSTALLATION.md)** for the full step-by-step reference with per-component explanations.
 

--- a/helm/charts/carbide-rest-site-agent/Chart.yaml
+++ b/helm/charts/carbide-rest-site-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: carbide-rest-site-agent
 description: Helm chart for the Carbide REST site agent
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: "latest"
 keywords:
   - carbide

--- a/helm/charts/carbide-rest-site-agent/templates/certificate.yaml
+++ b/helm/charts/carbide-rest-site-agent/templates/certificate.yaml
@@ -26,7 +26,11 @@ spec:
     - {{ include "carbide-rest-site-agent.name" . }}.{{ include "carbide-rest-site-agent.namespace" . }}
     - {{ include "carbide-rest-site-agent.name" . }}.{{ include "carbide-rest-site-agent.namespace" . }}.svc.cluster.local
   uris:
+    {{- if .Values.certificate.uris }}
+    {{- toYaml .Values.certificate.uris | nindent 4 }}
+    {{- else }}
     - spiffe://carbide.local/{{ include "carbide-rest-site-agent.namespace" . }}/sa/{{ include "carbide-rest-site-agent.name" . }}
+    {{- end }}
   issuerRef:
     name: {{ .Values.global.certificate.issuerRef.name }}
     kind: {{ .Values.global.certificate.issuerRef.kind }}

--- a/helm/charts/carbide-rest-site-agent/templates/statefulset.yaml
+++ b/helm/charts/carbide-rest-site-agent/templates/statefulset.yaml
@@ -20,6 +20,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "carbide-rest-site-agent.name" . }}
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
       containers:
         - name: site-agent
           image: "{{ include "carbide-rest-site-agent.image" . }}"

--- a/helm/charts/carbide-rest-site-agent/values.yaml
+++ b/helm/charts/carbide-rest-site-agent/values.yaml
@@ -50,6 +50,10 @@ certificate:
   privateKey:
     algorithm: ECDSA
     size: 384
+  # -- Override SPIFFE URIs for the certificate. Must match the service identifier
+  # expected by carbide-api's InternalRBACRules (SiteAgent = "elektra-site-agent").
+  # For forge deployments set to: ["spiffe://forge.local/forge-system/sa/elektra-site-agent"]
+  uris: []
 
 rbac:
   create: true

--- a/helm/charts/carbide-rest/Chart.yaml
+++ b/helm/charts/carbide-rest/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: carbide-rest
 description: Umbrella chart for the Carbide REST API platform
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "1.3.0"
 keywords:
   - carbide

--- a/helm/charts/carbide-rest/charts/carbide-rest-common/templates/secrets.yaml
+++ b/helm/charts/carbide-rest/charts/carbide-rest-common/templates/secrets.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "carbide-rest-common.labels" . | nindent 4 }}
 type: Opaque
 stringData:
+  username: {{ .Values.secrets.dbCreds.username | quote }}
   password: {{ .Values.secrets.dbCreds.password | quote }}
 ---
 apiVersion: v1

--- a/helm/charts/carbide-rest/charts/carbide-rest-common/values.yaml
+++ b/helm/charts/carbide-rest/charts/carbide-rest-common/values.yaml
@@ -5,6 +5,8 @@ secrets:
   # -- Set to false to skip Secret creation (e.g. when migrating from Kustomize with pre-existing Secrets).
   create: true
   dbCreds:
+    # -- DB username. Replace with real credentials in production.
+    username: "forge"
     # -- DB password. Replace with real credentials in production.
     password: "forge"
   keycloakClientSecret:


### PR DESCRIPTION
## Description
- Update README to reference the helm-prereqs chart in ncx-infra-controller-core (https://github.com/NVIDIA/ncx-infra-controller-core) as the recommended installation path for bare-metal cluster setup
- Add username keys to carbide-rest-common db-creds Secret template (alongside existing password key used by carbide-rest-api)

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Feature** - New feature or functionality (feat:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **Site Agent** - Site Agent updated
- [x] **Helm** - Helm Logic updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->
None

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Manual testing performed

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
None