### PR TITLE
chore: Switch from deprecated attributes for VPC Prefix create/update request to Site

### DIFF
--- a/api/pkg/api/handler/vpcprefix.go
+++ b/api/pkg/api/handler/vpcprefix.go
@@ -265,14 +265,18 @@ func (csh CreateVpcPrefixHandler) Handle(c echo.Context) error {
 	}
 
 	createVpcPrefixRequest := &cwssaws.VpcPrefixCreationRequest{
-		Id:     &cwssaws.VpcPrefixId{Value: vpcPrefix.ID.String()},
-		Name:   vpcPrefix.Name,
-		VpcId:  &cwssaws.VpcId{Value: common.GetSiteVpcID(vpc).String()},
-		Prefix: vpcPrefix.Prefix,
+		Id:    &cwssaws.VpcPrefixId{Value: vpcPrefix.ID.String()},
+		VpcId: &cwssaws.VpcId{Value: common.GetSiteVpcID(vpc).String()},
+		Config: &cwssaws.VpcPrefixConfig{
+			Prefix: vpcPrefix.Prefix,
+		},
+		Metadata: &cwssaws.Metadata{
+			Name: vpcPrefix.Name,
+		},
 	}
 
 	workflowOptions := temporalClient.StartWorkflowOptions{
-		ID:                       "vpcprefix-create-" + vpcPrefix.ID.String(),
+		ID:                       "vpc-prefix-create-" + vpcPrefix.ID.String(),
 		WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
 		TaskQueue:                queue.SiteTaskQueue,
 	}
@@ -822,12 +826,14 @@ func (ush UpdateVpcPrefixHandler) Handle(c echo.Context) error {
 	}
 
 	updateVpcPrefixRequest := &cwssaws.VpcPrefixUpdateRequest{
-		Id:   &cwssaws.VpcPrefixId{Value: vpcPrefix.ID.String()},
-		Name: &vpcPrefix.Name,
+		Id: &cwssaws.VpcPrefixId{Value: vpcPrefix.ID.String()},
+		Metadata: &cwssaws.Metadata{
+			Name: vpcPrefix.Name,
+		},
 	}
 
 	workflowOptions := temporalClient.StartWorkflowOptions{
-		ID:                       "vpcprefix-update-" + vpcPrefix.ID.String(),
+		ID:                       "vpc-prefix-update-" + vpcPrefix.ID.String(),
 		WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
 		TaskQueue:                queue.SiteTaskQueue,
 	}

--- a/api/pkg/api/handler/vpcprefix_test.go
+++ b/api/pkg/api/handler/vpcprefix_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/NVIDIA/ncx-infra-controller-rest/db/pkg/db/paginator"
 	cipam "github.com/NVIDIA/ncx-infra-controller-rest/ipam"
 	swe "github.com/NVIDIA/ncx-infra-controller-rest/site-workflow/pkg/error"
+	cwssaws "github.com/NVIDIA/ncx-infra-controller-rest/workflow-schema/schema/site-agent/workflows/v1"
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
@@ -463,6 +464,9 @@ func TestVpcPrefixHandler_Create(t *testing.T) {
 			expectedStatus: http.StatusInternalServerError,
 		},
 	}
+
+	tscCallCount := 0
+
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.NotEqual(t, tc.name, "")
@@ -491,40 +495,49 @@ func TestVpcPrefixHandler_Create(t *testing.T) {
 			err := cipbh.Handle(ec)
 			assert.Nil(t, err)
 			assert.Equal(t, tc.expectedErr, rec.Code != http.StatusCreated)
-			assert.Equal(t, tc.expectedStatus, rec.Code)
+			require.Equal(t, tc.expectedStatus, rec.Code, rec.Body.String())
 
-			if tc.expectedStatus != rec.Code {
-				t.Errorf("Response: %v", rec.Body.String())
-			}
-
-			if !tc.expectedErr {
-				rsp := &model.APIVpcPrefix{}
-				err := json.Unmarshal(rec.Body.Bytes(), rsp)
-				assert.Nil(t, err)
-				// validate response fields
-				assert.Equal(t, len(rsp.StatusHistory), 1)
-				// validate prefix
-				assert.NotNil(t, rsp.Prefix)
-				assert.Equal(t, tc.expectedPrefix, *rsp.Prefix)
-
-				// validate ipam exists for vpcprefix
-				if tc.expectedIpam {
-					parentIPBID := rsp.IPBlockID
-					parentIPBUUID, err := uuid.Parse(*parentIPBID)
-					assert.Nil(t, err)
-					ipbDAO := cdbm.NewIPBlockDAO(dbSession)
-					parentIPB, err := ipbDAO.GetByID(ctx, nil, parentIPBUUID, nil)
-					assert.Nil(t, err)
-					ipamer := cipam.NewWithStorage(ipamStorage)
-					ipamer.SetNamespace(ipam.GetIpamNamespaceForIPBlock(ctx, parentIPB.RoutingType, parentIPB.InfrastructureProviderID.String(), parentIPB.SiteID.String()))
-					pref := ipamer.PrefixFrom(ctx, ipam.GetCidrForIPBlock(ctx, *rsp.Prefix, rsp.PrefixLength))
-					assert.NotNil(t, pref)
-				}
-			} else {
+			if tc.expectedErr {
 				if tc.expectedIpamErrMsg != "" {
 					assert.Contains(t, rec.Body.String(), tc.expectedIpamErrMsg)
 				}
+
+				return
 			}
+
+			resp := &model.APIVpcPrefix{}
+			err = json.Unmarshal(rec.Body.Bytes(), resp)
+			assert.Nil(t, err)
+			// Validate response fields
+			assert.Equal(t, len(resp.StatusHistory), 1)
+			// Validate prefix
+			assert.NotNil(t, resp.Prefix)
+			assert.Equal(t, tc.expectedPrefix, *resp.Prefix)
+
+			// Validate ipam exists for vpcprefix
+			if tc.expectedIpam {
+				parentIPBID := resp.IPBlockID
+				parentIPBUUID, err := uuid.Parse(*parentIPBID)
+				assert.Nil(t, err)
+				ipbDAO := cdbm.NewIPBlockDAO(dbSession)
+				parentIPB, err := ipbDAO.GetByID(ctx, nil, parentIPBUUID, nil)
+				assert.Nil(t, err)
+				ipamer := cipam.NewWithStorage(ipamStorage)
+				ipamer.SetNamespace(ipam.GetIpamNamespaceForIPBlock(ctx, parentIPB.RoutingType, parentIPB.InfrastructureProviderID.String(), parentIPB.SiteID.String()))
+				pref := ipamer.PrefixFrom(ctx, ipam.GetCidrForIPBlock(ctx, *resp.Prefix, resp.PrefixLength))
+				assert.NotNil(t, pref)
+			}
+
+			require.Equal(t, tscCallCount+1, len(tsc.Calls))
+			tscCallCount++
+			require.Equal(t, "ExecuteWorkflow", tsc.Calls[len(tsc.Calls)-1].Method)
+			require.Equal(t, 4, len(tsc.Calls[len(tsc.Calls)-1].Arguments))
+
+			// Check Temporal workflow call arguments
+			temporalReq, ok := tsc.Calls[len(tsc.Calls)-1].Arguments[3].(*cwssaws.VpcPrefixCreationRequest)
+			require.True(t, ok)
+			assert.Equal(t, resp.Name, temporalReq.Metadata.Name)
+			assert.Equal(t, *resp.Prefix, temporalReq.Config.Prefix)
 
 			if tc.verifyChildSpanner {
 				span := oteltrace.SpanFromContext(ec.Request().Context())
@@ -1325,10 +1338,13 @@ func TestVpcPrefixHandler_Update(t *testing.T) {
 	vpcprefixBody2, err := json.Marshal(model.APIVpcPrefixCreateRequest{Name: "test-vpcprefix-2", VpcID: vpc1.ID.String(), IPBlockID: cdb.GetStrPtr(ipb1.ID.String()), PrefixLength: prefixLen})
 	assert.Nil(t, err)
 
+	tscCallCount := 0
+
 	vpcprefix := testCreateVpcPrefix(t, dbSession, scp, ipamStorage, tnu, tnOrg1, string(vpcprefixBody))
+	tscCallCount++
 
 	vpcprefix2 := testCreateVpcPrefix(t, dbSession, scp, ipamStorage, tnu, tnOrg1, string(vpcprefixBody2))
-	assert.NotNil(t, vpcprefix2)
+	tscCallCount++
 
 	errBody1, err := json.Marshal(model.APIAllocationUpdateRequest{Name: cdb.GetStrPtr("a")})
 	assert.Nil(t, err)
@@ -1456,6 +1472,7 @@ func TestVpcPrefixHandler_Update(t *testing.T) {
 			expectedName:   "test-vpcprefix-2",
 		},
 	}
+
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.NotEqual(t, tc.name, "")
@@ -1486,17 +1503,30 @@ func TestVpcPrefixHandler_Update(t *testing.T) {
 			err := tah.Handle(ec)
 			assert.Nil(t, err)
 			assert.Equal(t, tc.expectedErr, rec.Code != http.StatusOK)
-			assert.Equal(t, tc.expectedStatus, rec.Code)
-			if !tc.expectedErr {
-				rsp := &model.APIVpcPrefix{}
-				err := json.Unmarshal(rec.Body.Bytes(), rsp)
-				assert.Nil(t, err)
-				// validate response fields
-				assert.Equal(t, 1, len(rsp.StatusHistory))
-				assert.Equal(t, tc.expectedName, rsp.Name)
+			require.Equal(t, tc.expectedStatus, rec.Code, rec.Body.String())
 
-				assert.NotEqual(t, rsp.Updated.String(), vpcprefix.Updated.String())
+			if tc.expectedErr {
+				return
 			}
+
+			resp := &model.APIVpcPrefix{}
+			err = json.Unmarshal(rec.Body.Bytes(), resp)
+			assert.Nil(t, err)
+			// validate response fields
+			assert.Equal(t, 1, len(resp.StatusHistory))
+			assert.Equal(t, tc.expectedName, resp.Name)
+
+			assert.NotEqual(t, resp.Updated.String(), vpcprefix.Updated.String())
+
+			require.Equal(t, tscCallCount+1, len(tsc.Calls))
+			tscCallCount++
+			require.Equal(t, "ExecuteWorkflow", tsc.Calls[len(tsc.Calls)-1].Method)
+			require.Equal(t, 4, len(tsc.Calls[len(tsc.Calls)-1].Arguments))
+
+			// Check Temporal workflow call arguments
+			temporalReq, ok := tsc.Calls[len(tsc.Calls)-1].Arguments[3].(*cwssaws.VpcPrefixUpdateRequest)
+			require.True(t, ok)
+			assert.Equal(t, resp.Name, temporalReq.Metadata.Name)
 
 			if tc.verifyChildSpanner {
 				span := oteltrace.SpanFromContext(ec.Request().Context())

--- a/api/pkg/api/model/vpcprefix.go
+++ b/api/pkg/api/model/vpcprefix.go
@@ -97,7 +97,7 @@ func (vpur APIVpcPrefixUpdateRequest) Validate() error {
 
 	if vpur.IPBlockID != nil || vpur.PrefixLength != nil {
 		return validation.Errors{
-			"prefix": errors.New("update has not been supported yet, only name allowed"),
+			"prefixLength": errors.New("prefix length modification is not supported at this time"),
 		}
 	}
 


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
VPC Prefix create and update API handlers are currently using attributes that have been deprecated in Core proto. This PR updates the requests to use newer attributes.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Chore** - Modification or removal of existing functionality (chore:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **API** - API models or endpoints updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->
None

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
None