### PR TITLE
fix: Add Site Agent manager for VPC Peering and fix workflows

### DIFF
--- a/site-agent/pkg/components/managers/manager.go
+++ b/site-agent/pkg/components/managers/manager.go
@@ -49,6 +49,7 @@ import (
 	"github.com/NVIDIA/ncx-infra-controller-rest/site-agent/pkg/components/managers/subnet"
 	"github.com/NVIDIA/ncx-infra-controller-rest/site-agent/pkg/components/managers/tenant"
 	"github.com/NVIDIA/ncx-infra-controller-rest/site-agent/pkg/components/managers/vpc"
+	"github.com/NVIDIA/ncx-infra-controller-rest/site-agent/pkg/components/managers/vpcpeering"
 	"github.com/NVIDIA/ncx-infra-controller-rest/site-agent/pkg/components/managers/vpcprefix"
 	"github.com/NVIDIA/ncx-infra-controller-rest/site-agent/pkg/components/managers/workflow"
 
@@ -64,6 +65,7 @@ func NewAPIHandlers() {
 		Orchestrator:           &workflow.API{},
 		VPC:                    &vpc.API{},
 		VpcPrefix:              &vpcprefix.API{},
+		VpcPeering:             &vpcpeering.API{},
 		Subnet:                 &subnet.API{},
 		Instance:               &instance.API{},
 		Machine:                &machine.API{},
@@ -129,6 +131,7 @@ func (Managers *Manager) NewInstance() {
 	Managers.DpuExtensionService()
 	Managers.NVLinkLogicalPartition()
 	Managers.RLA()
+	Managers.VpcPeering()
 }
 
 // Init - initialize all the mgrs
@@ -177,7 +180,7 @@ func (Managers *Manager) Init() {
 	Managers.DpuExtensionService().Init()
 	Managers.NVLinkLogicalPartition().Init()
 	Managers.RLA().Init()
-
+	Managers.VpcPeering().Init()
 }
 
 // Start - start the mgrs

--- a/site-agent/pkg/components/managers/manageraccess.go
+++ b/site-agent/pkg/components/managers/manageraccess.go
@@ -40,6 +40,7 @@ import (
 	"github.com/NVIDIA/ncx-infra-controller-rest/site-agent/pkg/components/managers/subnet"
 	"github.com/NVIDIA/ncx-infra-controller-rest/site-agent/pkg/components/managers/tenant"
 	"github.com/NVIDIA/ncx-infra-controller-rest/site-agent/pkg/components/managers/vpc"
+	"github.com/NVIDIA/ncx-infra-controller-rest/site-agent/pkg/components/managers/vpcpeering"
 	"github.com/NVIDIA/ncx-infra-controller-rest/site-agent/pkg/components/managers/vpcprefix"
 	"github.com/NVIDIA/ncx-infra-controller-rest/site-agent/pkg/components/managers/workflow"
 )
@@ -76,6 +77,11 @@ func (m *Manager) VPC() *vpc.API {
 // VpcPrefix - Add vpcprefix manager instance here
 func (m *Manager) VpcPrefix() *vpcprefix.API {
 	return vpcprefix.NewVpcPrefixManager(m.Data.EB, m.API, m.Conf)
+}
+
+// VpcPeering - Add vpcpeering manager instance here
+func (m *Manager) VpcPeering() *vpcpeering.API {
+	return vpcpeering.NewVpcPeeringManager(m.Data.EB, m.API, m.Conf)
 }
 
 // Carbide manager instance here

--- a/site-agent/pkg/components/managers/managerapi/managerapi.go
+++ b/site-agent/pkg/components/managers/managerapi/managerapi.go
@@ -44,6 +44,7 @@ type ManagerAPI struct {
 	Bootstrap              BootstrapInterface
 	VPC                    VPCInterface
 	VpcPrefix              VpcPrefixInterface
+	VpcPeering             VpcPeeringInterface
 	Subnet                 SubnetInterface
 	Instance               InstanceInterface
 	Machine                MachineInterface

--- a/site-agent/pkg/components/managers/managerapi/vpcpeering_api.go
+++ b/site-agent/pkg/components/managers/managerapi/vpcpeering_api.go
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package managerapi
+
+// VpcPeeringExpansion - VpcPeering expansion hook for future APIs
+type VpcPeeringExpansion interface{}
+
+// VpcPeeringInterface - Interface for VPC Peering site-agent manager
+type VpcPeeringInterface interface {
+	Init()
+	RegisterSubscriber() error
+	RegisterPublisher() error
+	RegisterCron() error
+
+	GetState() []string
+	VpcPeeringExpansion
+}

--- a/site-agent/pkg/components/managers/vpcpeering/access.go
+++ b/site-agent/pkg/components/managers/vpcpeering/access.go
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vpcpeering
+
+import (
+	Manager "github.com/NVIDIA/ncx-infra-controller-rest/site-agent/pkg/components/managers/managerapi"
+	"github.com/NVIDIA/ncx-infra-controller-rest/site-agent/pkg/datatypes/elektratypes"
+)
+
+// ManagerAccess - access to all managers
+var ManagerAccess *Manager.ManagerAccess
+
+// API - all API interface
+type API struct{}
+
+// NewVpcPeeringManager - returns a new instance of VPC Peering manager
+func NewVpcPeeringManager(superForge *elektratypes.Elektra, superAPI *Manager.ManagerAPI, superConf *Manager.ManagerConf) *API {
+	ManagerAccess = &Manager.ManagerAccess{
+		Data: &Manager.ManagerData{
+			EB: superForge,
+		},
+		API:  superAPI,
+		Conf: superConf,
+	}
+	return &API{}
+}

--- a/site-agent/pkg/components/managers/vpcpeering/cron.go
+++ b/site-agent/pkg/components/managers/vpcpeering/cron.go
@@ -1,0 +1,75 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vpcpeering
+
+import (
+	"context"
+
+	"go.temporal.io/sdk/client"
+
+	sww "github.com/NVIDIA/ncx-infra-controller-rest/site-workflow/pkg/workflow"
+)
+
+const (
+	// InventoryCarbidePageSize is the number of items to fetch from Carbide API per page
+	InventoryCarbidePageSize = 100
+	// InventoryCloudPageSize is the number of items to send to cloud per Temporal workflow page
+	InventoryCloudPageSize = 25
+	// InventoryDefaultSchedule is the default schedule for VPC Peering inventory discovery
+	InventoryDefaultSchedule = "@every 3m"
+)
+
+// RegisterCron - register cron
+func (api *API) RegisterCron() error {
+	ManagerAccess.Data.EB.Log.Info().Msg("VpcPeering: Registering Inventory Discovery Cron")
+
+	workflowID := "inventory-vpcpeering-" + ManagerAccess.Conf.EB.Temporal.TemporalSubscribeNamespace
+
+	cronSchedule := InventoryDefaultSchedule
+	if ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule != "" {
+		cronSchedule = ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule
+	}
+
+	ManagerAccess.Data.EB.Log.Info().Str("Schedule", cronSchedule).Msg("VpcPeering: Inventory Discovery Cron Schedule")
+
+	workflowOptions := client.StartWorkflowOptions{
+		ID:           workflowID,
+		TaskQueue:    ManagerAccess.Conf.EB.Temporal.TemporalSubscribeQueue,
+		CronSchedule: cronSchedule,
+	}
+
+	we, err := ManagerAccess.Data.EB.Managers.Workflow.Temporal.Subscriber.ExecuteWorkflow(
+		context.Background(),
+		workflowOptions,
+		sww.DiscoverVpcPeeringInventory,
+	)
+
+	if err != nil {
+		ManagerAccess.Data.EB.Log.Error().Err(err).Msg("VpcPeering: Error registering Inventory Collect/Publish cron")
+		return err
+	}
+
+	wid := ""
+	if !ManagerAccess.Data.EB.Conf.UtMode {
+		wid = we.GetID()
+	}
+
+	ManagerAccess.Data.EB.Log.Info().Interface("Workflow ID", wid).Msg("VpcPeering: successfully registered Inventory Collect/Publish cron")
+
+	return nil
+}

--- a/site-agent/pkg/components/managers/vpcpeering/init.go
+++ b/site-agent/pkg/components/managers/vpcpeering/init.go
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vpcpeering
+
+import "fmt"
+
+// Init  VPC Peering manager
+func (api *API) Init() {
+	ManagerAccess.Data.EB.Log.Info().Msg("VpcPeering: Initializing the VPC Peering manager")
+}
+
+// GetState - handle http request
+func (api *API) GetState() []string {
+	state := ManagerAccess.Data.EB.Managers.Workflow.VpcPeeringState
+	var strs []string
+	strs = append(strs, fmt.Sprintln("vpcpeering_workflow_started", state.WflowStarted.Load()))
+	strs = append(strs, fmt.Sprintln("vpcpeering_workflow_activity_failed", state.WflowActFail.Load()))
+	strs = append(strs, fmt.Sprintln("vpcpeering_workflow_activity_succeeded", state.WflowActSucc.Load()))
+	strs = append(strs, fmt.Sprintln("vpcpeering_workflow_publishing_failed", state.WflowPubFail.Load()))
+	strs = append(strs, fmt.Sprintln("vpcpeering_workflow_publishing_succeeded", state.WflowPubSucc.Load()))
+
+	return strs
+}

--- a/site-agent/pkg/components/managers/vpcpeering/publisher.go
+++ b/site-agent/pkg/components/managers/vpcpeering/publisher.go
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vpcpeering
+
+import (
+	swa "github.com/NVIDIA/ncx-infra-controller-rest/site-workflow/pkg/activity"
+	sww "github.com/NVIDIA/ncx-infra-controller-rest/site-workflow/pkg/workflow"
+	"github.com/google/uuid"
+)
+
+// RegisterPublisher registers the VPC Peering workflows with Temporal client
+func (api *API) RegisterPublisher() error {
+	// Register publisher workflows
+	ManagerAccess.Data.EB.Log.Info().Msg("VpcPeering: Registering the publishers")
+
+	// Discover VPC Peering Inventory workflow
+	ManagerAccess.Data.EB.Managers.Workflow.Temporal.Worker.RegisterWorkflow(sww.DiscoverVpcPeeringInventory)
+	ManagerAccess.Data.EB.Log.Info().Msg("VpcPeering: successfully registered DiscoverVpcPeeringInventory workflow")
+
+	inventoryManager := swa.NewManageVpcPeeringInventory(swa.ManageInventoryConfig{
+		SiteID:                uuid.MustParse(ManagerAccess.Conf.EB.Temporal.ClusterID),
+		CarbideAtomicClient:   ManagerAccess.Data.EB.Managers.Carbide.Client,
+		TemporalPublishClient: ManagerAccess.Data.EB.Managers.Workflow.Temporal.Publisher,
+		TemporalPublishQueue:  ManagerAccess.Conf.EB.Temporal.TemporalPublishQueue,
+		SitePageSize:          InventoryCarbidePageSize,
+		CloudPageSize:         InventoryCloudPageSize,
+	})
+	ManagerAccess.Data.EB.Managers.Workflow.Temporal.Worker.RegisterActivity(inventoryManager.DiscoverVpcPeeringInventory)
+	ManagerAccess.Data.EB.Log.Info().Msg("VpcPeering: successfully registered DiscoverVpcPeeringInventory activity")
+
+	api.RegisterCron()
+
+	return nil
+}

--- a/site-agent/pkg/components/managers/vpcpeering/subscriber.go
+++ b/site-agent/pkg/components/managers/vpcpeering/subscriber.go
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vpcpeering
+
+import (
+	swa "github.com/NVIDIA/ncx-infra-controller-rest/site-workflow/pkg/activity"
+	sww "github.com/NVIDIA/ncx-infra-controller-rest/site-workflow/pkg/workflow"
+)
+
+// RegisterSubscriber registers VPC Peering workflows and activities with the Temporal worker
+func (api *API) RegisterSubscriber() error {
+	ManagerAccess.Data.EB.Log.Info().Msg("VpcPeering: Registering the subscribers")
+
+	// Register Workflows
+	// Register CreateVpcPeering workflow
+	ManagerAccess.Data.EB.Managers.Workflow.Temporal.Worker.RegisterWorkflow(sww.CreateVpcPeering)
+	ManagerAccess.Data.EB.Log.Info().Msg("VpcPeering: successfully registered CreateVpcPeering workflow")
+
+	// Register DeleteVpcPeering workflow
+	ManagerAccess.Data.EB.Managers.Workflow.Temporal.Worker.RegisterWorkflow(sww.DeleteVpcPeering)
+	ManagerAccess.Data.EB.Log.Info().Msg("VpcPeering: successfully registered DeleteVpcPeering workflow")
+
+	// Register Activities
+	vpcPeeringManager := swa.NewManageVpcPeering(ManagerAccess.Data.EB.Managers.Carbide.Client)
+
+	// Sync workflow activities
+	// Register CreateVpcPeeringOnSite
+	ManagerAccess.Data.EB.Managers.Workflow.Temporal.Worker.RegisterActivity(vpcPeeringManager.CreateVpcPeeringOnSite)
+	ManagerAccess.Data.EB.Log.Info().Msg("VpcPeering: successfully registered CreateVpcPeeringOnSite activity")
+
+	// Register DeleteVpcPeeringOnSite
+	ManagerAccess.Data.EB.Managers.Workflow.Temporal.Worker.RegisterActivity(vpcPeeringManager.DeleteVpcPeeringOnSite)
+	ManagerAccess.Data.EB.Log.Info().Msg("VpcPeering: successfully registered DeleteVpcPeeringOnSite activity")
+
+	return nil
+}

--- a/site-agent/pkg/components/managers/workflow/orchestrator.go
+++ b/site-agent/pkg/components/managers/workflow/orchestrator.go
@@ -237,6 +237,9 @@ func workflowOrchestrator() error {
 	ManagerAccess.API.VpcPrefix.RegisterSubscriber()
 	ManagerAccess.API.VpcPrefix.RegisterPublisher()
 
+	ManagerAccess.API.VpcPeering.RegisterSubscriber()
+	ManagerAccess.API.VpcPeering.RegisterPublisher()
+
 	ManagerAccess.API.Subnet.RegisterSubscriber()
 	ManagerAccess.API.Subnet.RegisterPublisher()
 

--- a/site-agent/pkg/datatypes/managertypes/workflow/workflowtypes.go
+++ b/site-agent/pkg/datatypes/managertypes/workflow/workflowtypes.go
@@ -81,6 +81,7 @@ type Workflow struct {
 	SKUState                    *MgrState
 	DpuExtensionServiceState    *MgrState
 	NVLinkLogicalPartitionState *MgrState
+	VpcPeeringState             *MgrState
 }
 
 // Temporal datastructure
@@ -113,6 +114,7 @@ func NewWorkflowInstance() *Workflow {
 		SKUState:                    &MgrState{},
 		DpuExtensionServiceState:    &MgrState{},
 		NVLinkLogicalPartitionState: &MgrState{},
+		VpcPeeringState:             &MgrState{},
 	}
 }
 

--- a/site-workflow/pkg/activity/vpcpeering.go
+++ b/site-workflow/pkg/activity/vpcpeering.go
@@ -57,6 +57,10 @@ func (mvp *ManageVpcPeering) CreateVpcPeeringOnSite(ctx context.Context, request
 		err = errors.New("received create VpcPeering request missing VpcId")
 	} else if request.PeerVpcId == nil || request.PeerVpcId.Value == "" {
 		err = errors.New("received create VpcPeering request missing PeerVpcId")
+	} else if request.Id == nil || request.Id.Value == "" {
+		// Don't let a request come in without a cloud-provided ID
+		// or carbide will generate one and cloud won't know the relationship.
+		err = errors.New("received create VpcPeering request missing VPC peering ID")
 	}
 
 	if err != nil {
@@ -166,7 +170,9 @@ func VpcPeeringFindByIDs(ctx context.Context, carbideClient *cClient.CarbideClie
 func VpcPeeringPagedInventory(allItemIDs []*cwssaws.VpcPeeringId, pagedItems []*cwssaws.VpcPeering, input *pagedInventoryInput) *cwssaws.VPCPeeringInventory {
 	itemIDs := make([]string, len(allItemIDs))
 	for i, id := range allItemIDs {
-		itemIDs[i] = id.GetValue()
+		if id != nil {
+			itemIDs[i] = id.GetValue()
+		}
 	}
 
 	// Create an inventory page with the subset of VpcPeerings

--- a/site-workflow/pkg/activity/vpcpeering.go
+++ b/site-workflow/pkg/activity/vpcpeering.go
@@ -168,11 +168,9 @@ func VpcPeeringFindByIDs(ctx context.Context, carbideClient *cClient.CarbideClie
 }
 
 func VpcPeeringPagedInventory(allItemIDs []*cwssaws.VpcPeeringId, pagedItems []*cwssaws.VpcPeering, input *pagedInventoryInput) *cwssaws.VPCPeeringInventory {
-	itemIDs := make([]string, len(allItemIDs))
-	for i, id := range allItemIDs {
-		if id != nil {
-			itemIDs[i] = id.GetValue()
-		}
+	itemIDs := []string{}
+	for _, id := range allItemIDs {
+		itemIDs = append(itemIDs, id.GetValue())
 	}
 
 	// Create an inventory page with the subset of VpcPeerings

--- a/site-workflow/pkg/activity/vpcpeering_test.go
+++ b/site-workflow/pkg/activity/vpcpeering_test.go
@@ -57,6 +57,7 @@ func TestManageVpcPeering_CreateVpcPeeringOnSite(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				request: &cwssaws.VpcPeeringCreationRequest{
+					Id:        &cwssaws.VpcPeeringId{Value: uuid.NewString()},
 					VpcId:     &cwssaws.VpcId{Value: uuid.NewString()},
 					PeerVpcId: &cwssaws.VpcId{Value: uuid.NewString()},
 				},
@@ -87,6 +88,20 @@ func TestManageVpcPeering_CreateVpcPeeringOnSite(t *testing.T) {
 				request: &cwssaws.VpcPeeringCreationRequest{
 					VpcId:     &cwssaws.VpcId{Value: uuid.NewString()},
 					PeerVpcId: nil,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "test create VpcPeering fail on missing VPC peering ID",
+			fields: fields{
+				CarbideAtomicClient: carbideAtomicClient,
+			},
+			args: args{
+				ctx: context.Background(),
+				request: &cwssaws.VpcPeeringCreationRequest{
+					VpcId:     &cwssaws.VpcId{Value: uuid.NewString()},
+					PeerVpcId: &cwssaws.VpcId{Value: uuid.NewString()},
 				},
 			},
 			wantErr: true,
@@ -266,6 +281,11 @@ func TestManageVpcPeeringInventory_DiscoverVpcPeeringInventory(t *testing.T) {
 			})
 
 			ctx := context.Background()
+			// Mock: vpcFindIDs uses ctx "wantCount" (see testing.go FindVpcIds); at least one VPC is
+			// required so VpcPeeringFindIDs queries FindVpcPeeringIds per vpc_id.
+			if tt.args.wantTotalItems > 0 {
+				ctx = context.WithValue(ctx, "wantCount", 1)
+			}
 			ctx = context.WithValue(ctx, "WantCount", tt.args.wantTotalItems)
 
 			totalPages := tt.args.wantTotalItems / tt.fields.cloudPageSize

--- a/site-workflow/pkg/grpc/client/testing.go
+++ b/site-workflow/pkg/grpc/client/testing.go
@@ -656,9 +656,21 @@ func (c *MockForgeClient) GetVpcPrefixes(ctx context.Context, in *wflows.VpcPref
 
 /* VPC Peering mock methods */
 func (c *MockForgeClient) CreateVpcPeering(ctx context.Context, in *wflows.VpcPeeringCreationRequest, opts ...grpc.CallOption) (*wflows.VpcPeering, error) {
-	out := new(wflows.VpcPeering)
-	out.Id = &wflows.VpcPeeringId{Value: uuid.NewString()}
-	return out, nil
+	if in == nil {
+		return &wflows.VpcPeering{Id: &wflows.VpcPeeringId{Value: uuid.NewString()}}, nil
+	}
+	var id *wflows.VpcPeeringId
+	if in.Id != nil && in.Id.Value != "" {
+		id = &wflows.VpcPeeringId{Value: in.Id.Value}
+	} else {
+		id = &wflows.VpcPeeringId{Value: uuid.NewString()}
+	}
+
+	return &wflows.VpcPeering{
+		Id:        id,
+		VpcId:     in.VpcId,
+		PeerVpcId: in.PeerVpcId,
+	}, nil
 }
 
 func (c *MockForgeClient) DeleteVpcPeering(ctx context.Context, in *wflows.VpcPeeringDeletionRequest, opts ...grpc.CallOption) (*wflows.VpcPeeringDeletionResult, error) {

--- a/workflow/pkg/activity/vpcpeering/vpcpeering.go
+++ b/workflow/pkg/activity/vpcpeering/vpcpeering.go
@@ -120,32 +120,7 @@ func (mvp ManageVpcPeering) UpdateVpcPeeringsInDB(
 		if !found {
 			slogger.Warn().Msg("VpcPeering does not have a record in DB, possibly created directly on Site. Creating in cloud DB.")
 
-			// Attempt to create the missing VPC Peering in the DB
-			// Set IsMultiTenant to false (default), Status to Ready, CreatedBy to zero UUID
-			// TODO: set proper CreatedByID if possible
-			vpcPeeringDAO := cdbm.NewVpcPeeringDAO(mvp.dbSession)
-
-			newVpcPeering, err := vpcPeeringDAO.Create(ctx, nil, cdbm.VpcPeeringCreateInput{
-				Vpc1ID:        uuid.MustParse(controllerVpcPeering.VpcId.Value),
-				Vpc2ID:        uuid.MustParse(controllerVpcPeering.PeerVpcId.Value),
-				SiteID:        siteID,
-				IsMultiTenant: false,
-				CreatedByID:   uuid.UUID{},
-			})
-			if err != nil {
-				slogger.Error().Err(err).Msg("VpcPeering could not be created from site data")
-				continue
-			}
-
-			slogger.Info().Msg("VpcPeering has been created from site data")
-
-			// Set status to Ready
-			err = mvp.updateVpcPeeringStatusInDB(ctx, nil, newVpcPeering.ID, cdb.GetStrPtr(cdbm.VpcPeeringStatusReady), cdb.GetStrPtr("VPC Peering was created in DB from site inventory"))
-			if err != nil {
-				slogger.Error().Err(err).Msg("failed to update status for newly created VPC Peering")
-			}
-
-			reportedVpcPeeringIDMap[newVpcPeering.ID] = true
+			// TODO: Create a new VPC Peering record in DB
 
 			continue
 		}


### PR DESCRIPTION
## Description
This PR adds VPC Peering site-agent manager and fixes VPC Peering workflows to require VPC Peering ID during creation. 

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Fix** - Bug fixes (fix:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **Site Agent** - Site Agent updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->
None

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
None
