### PR TITLE
fix: Create VPC in 'provisioning' state

### DIFF
--- a/api/pkg/api/handler/vpc.go
+++ b/api/pkg/api/handler/vpc.go
@@ -336,7 +336,7 @@ func (cvh CreateVPCHandler) Handle(c echo.Context) error {
 		RoutingProfile:            routingProfile,
 		NVLinkLogicalPartitionID:  defaultNvllPartitionId,
 		Labels:                    labels,
-		Status:                    cdbm.VpcStatusReady,
+		Status:                    cdbm.VpcStatusProvisioning,
 		CreatedBy:                 *dbUser,
 		Vni:                       apiRequest.Vni,
 	}
@@ -362,8 +362,8 @@ func (cvh CreateVPCHandler) Handle(c echo.Context) error {
 
 	// Create status detail
 	sdDAO := cdbm.NewStatusDetailDAO(cvh.dbSession)
-	ssd, err := sdDAO.CreateFromParams(ctx, tx, vpc.ID.String(), *cdb.GetStrPtr(cdbm.VpcStatusReady),
-		cdb.GetStrPtr("VPC successfully provisioned on Site"))
+	ssd, err := sdDAO.CreateFromParams(ctx, tx, vpc.ID.String(), cdbm.VpcStatusProvisioning,
+		cdb.GetStrPtr("VPC provisioning has been initiated on Site"))
 	if err != nil {
 		logger.Error().Err(err).Msg("error creating Status Detail DB entry")
 		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to create Status Detail for VPC", nil)
@@ -446,7 +446,9 @@ func (cvh CreateVPCHandler) Handle(c echo.Context) error {
 	logger.Info().Str("Workflow ID", wid).Msg("executed synchronous create VPC workflow")
 
 	// Block until the workflow has completed and returned success/error.
-	err = we.Get(ctx, nil)
+	controllerVpc := &cwssaws.Vpc{}
+
+	err = we.Get(ctx, controllerVpc)
 	if err != nil {
 		var timeoutErr *tp.TimeoutError
 		if errors.As(err, &timeoutErr) || err == context.DeadlineExceeded || ctx.Err() != nil {
@@ -484,8 +486,39 @@ func (cvh CreateVPCHandler) Handle(c echo.Context) error {
 	}
 	// set committed so, deferred cleanup functions will do nothing
 	txCommitted = true
+
+	statusDetails := []cdbm.StatusDetail{*ssd}
+
+	// Make a best-effort attempt to return a response with the allocated VNI.
+	if controllerVpc.GetStatus() != nil {
+		activeVni := wutil.GetUint32PtrToIntPtr(controllerVpc.GetStatus().Vni)
+
+		uvpcInput := cdbm.VpcUpdateInput{
+			VpcID:     vpc.ID,
+			ActiveVni: activeVni,
+			Status:    cdb.GetStrPtr(cdbm.VpcStatusReady),
+		}
+		updatedVpc, err := vpcDAO.Update(ctx, nil, uvpcInput)
+		if err != nil {
+			logger.Error().Err(err).Msg("error while updating VPC DB entry for VNI")
+		} else {
+			// Update the vpc being returned if all went well.
+			vpc = updatedVpc
+
+			// Best effort create status detail
+			ssd, err = sdDAO.CreateFromParams(ctx, nil, vpc.ID.String(), cdbm.VpcStatusReady, cdb.GetStrPtr("VPC is ready for use"))
+			if err != nil {
+				logger.Error().Err(err).Msg("error creating Status Detail DB entry")
+			} else if ssd == nil {
+				logger.Error().Err(err).Msg("unexpected nil Status Detail returned from DB")
+			} else {
+				statusDetails = append(statusDetails, *ssd)
+			}
+		}
+	}
+
 	// Create response
-	apiVpc := model.NewAPIVpc(*vpc, []cdbm.StatusDetail{*ssd})
+	apiVpc := model.NewAPIVpc(*vpc, statusDetails)
 
 	logger.Info().Msg("finishing API handler")
 

--- a/api/pkg/api/handler/vpc_test.go
+++ b/api/pkg/api/handler/vpc_test.go
@@ -290,12 +290,19 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 		tc        temporalClient.Client
 		cfg       *config.Config
 	}
+	type expectedStatusDetail struct {
+		status  string
+		message string
+	}
 	type args struct {
-		reqData     *model.APIVpcCreateRequest
-		reqOrg      string
-		reqUser     *cdbm.User
-		respCode    int
-		respMessage string
+		reqData               *model.APIVpcCreateRequest
+		reqOrg                string
+		reqUser               *cdbm.User
+		respCode              int
+		respMessage           string
+		expectedStatus        string
+		expectedVni           *int
+		expectedStatusDetails []expectedStatusDetail
 	}
 
 	dbSession := testSiteInitDB(t)
@@ -402,18 +409,40 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 	scp.IDClientMap[st2.ID.String()] = tsc
 	scp.IDClientMap[st3.ID.String()] = tst3
 
+	vpcWithAllocatedVniName := "Test VPC with allocated VNI"
+	allocatedVni := uint32(7301)
+	expectedAllocatedVni := int(allocatedVni)
+
 	wid := "test-workflow-id"
 	wrun := &tmocks.WorkflowRun{}
 	wrun.On("GetID").Return(wid)
 
 	wrun.Mock.On("Get", mock.Anything, mock.Anything).Return(nil)
 
+	wrunWithAllocatedVni := &tmocks.WorkflowRun{}
+	wrunWithAllocatedVni.On("GetID").Return(wid)
+	wrunWithAllocatedVni.Mock.On("Get", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		controllerVpc, ok := args.Get(1).(*cwssaws.Vpc)
+		if ok {
+			controllerVpc.Status = &cwssaws.VpcStatus{
+				Vni: &allocatedVni,
+			}
+		}
+	}).Return(nil)
+
 	tc.Mock.On("ExecuteWorkflow", mock.Anything, mock.AnythingOfType("internal.StartWorkflowOptions"),
 		mock.AnythingOfType("func(internal.Context, uuid.UUID, uuid.UUID) error"), mock.AnythingOfType("uuid.UUID"),
 		mock.AnythingOfType("uuid.UUID")).Return(wrun, nil)
 
 	tsc.Mock.On("ExecuteWorkflow", mock.Anything, mock.AnythingOfType("internal.StartWorkflowOptions"),
-		"CreateVPCV2", mock.Anything).Return(wrun, nil)
+		"CreateVPCV2", mock.MatchedBy(func(req *cwssaws.VpcCreationRequest) bool {
+			return req != nil && req.Name == vpcWithAllocatedVniName
+		})).Return(wrunWithAllocatedVni, nil)
+
+	tsc.Mock.On("ExecuteWorkflow", mock.Anything, mock.AnythingOfType("internal.StartWorkflowOptions"),
+		"CreateVPCV2", mock.MatchedBy(func(req *cwssaws.VpcCreationRequest) bool {
+			return req == nil || req.Name != vpcWithAllocatedVniName
+		})).Return(wrun, nil)
 
 	// Mock timeout error
 	wruntimeout := &tmocks.WorkflowRun{}
@@ -457,9 +486,55 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 					},
 					NVLinkLogicalPartitionID: cdb.GetStrPtr(nvllp1.ID.String()),
 				},
-				reqOrg:   tnOrg,
-				reqUser:  tnu,
-				respCode: http.StatusCreated,
+				reqOrg:         tnOrg,
+				reqUser:        tnu,
+				respCode:       http.StatusCreated,
+				expectedStatus: cdbm.VpcStatusProvisioning,
+				expectedStatusDetails: []expectedStatusDetail{
+					{
+						status:  cdbm.VpcStatusProvisioning,
+						message: "VPC provisioning has been initiated on Site",
+					},
+				},
+			},
+			wantErr:            false,
+			verifyChildSpanner: true,
+		},
+		{
+			name: "test VPC create API endpoint returns allocated VNI from Site workflow response",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        tc,
+				cfg:       cfg,
+			},
+			args: args{
+				reqData: &model.APIVpcCreateRequest{
+					Name:                      vpcWithAllocatedVniName,
+					Description:               cdb.GetStrPtr("Test VPC Description"),
+					SiteID:                    st1.ID.String(),
+					NetworkVirtualizationType: cdb.GetStrPtr(cdbm.VpcFNN),
+					NetworkSecurityGroupID:    &nsgTenant1Site1.ID,
+					Labels: map[string]string{
+						"vpc-dpu-zone": "east1",
+						"vpc-gpu-zone": "west1",
+					},
+					NVLinkLogicalPartitionID: cdb.GetStrPtr(nvllp1.ID.String()),
+				},
+				reqOrg:         tnOrg,
+				reqUser:        tnu,
+				respCode:       http.StatusCreated,
+				expectedStatus: cdbm.VpcStatusReady,
+				expectedVni:    &expectedAllocatedVni,
+				expectedStatusDetails: []expectedStatusDetail{
+					{
+						status:  cdbm.VpcStatusProvisioning,
+						message: "VPC provisioning has been initiated on Site",
+					},
+					{
+						status:  cdbm.VpcStatusReady,
+						message: "VPC is ready for use",
+					},
+				},
 			},
 			wantErr:            false,
 			verifyChildSpanner: true,
@@ -486,9 +561,16 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 					},
 					NVLinkLogicalPartitionID: cdb.GetStrPtr(nvllp1.ID.String()),
 				},
-				reqOrg:   tnOrg,
-				reqUser:  tnu,
-				respCode: http.StatusCreated,
+				reqOrg:         tnOrg,
+				reqUser:        tnu,
+				respCode:       http.StatusCreated,
+				expectedStatus: cdbm.VpcStatusProvisioning,
+				expectedStatusDetails: []expectedStatusDetail{
+					{
+						status:  cdbm.VpcStatusProvisioning,
+						message: "VPC provisioning has been initiated on Site",
+					},
+				},
 			},
 			wantErr:            false,
 			verifyChildSpanner: true,
@@ -637,9 +719,16 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 					},
 					NVLinkLogicalPartitionID: cdb.GetStrPtr(nvllp1.ID.String()),
 				},
-				reqOrg:   tnOrg,
-				reqUser:  tnu,
-				respCode: http.StatusCreated,
+				reqOrg:         tnOrg,
+				reqUser:        tnu,
+				respCode:       http.StatusCreated,
+				expectedStatus: cdbm.VpcStatusProvisioning,
+				expectedStatusDetails: []expectedStatusDetail{
+					{
+						status:  cdbm.VpcStatusProvisioning,
+						message: "VPC provisioning has been initiated on Site",
+					},
+				},
 			},
 			wantErr:            false,
 			verifyChildSpanner: true,
@@ -969,8 +1058,19 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 			} else {
 				assert.Equal(t, *rst.NetworkVirtualizationType, cdbm.VpcEthernetVirtualizer)
 			}
-			assert.Equal(t, rst.Status, cdbm.VpcStatusReady)
-			assert.Equal(t, len(rst.StatusHistory), 1)
+			assert.Equal(t, tt.args.expectedStatus, rst.Status)
+			require.Len(t, rst.StatusHistory, len(tt.args.expectedStatusDetails))
+			for i, expectedStatusDetail := range tt.args.expectedStatusDetails {
+				assert.Equal(t, expectedStatusDetail.status, rst.StatusHistory[i].Status)
+				require.NotNil(t, rst.StatusHistory[i].Message)
+				assert.Equal(t, expectedStatusDetail.message, *rst.StatusHistory[i].Message)
+			}
+			if tt.args.expectedVni != nil {
+				require.NotNil(t, rst.Vni)
+				assert.Equal(t, *tt.args.expectedVni, *rst.Vni)
+			} else {
+				assert.Nil(t, rst.Vni)
+			}
 
 			if tt.args.reqData.NVLinkLogicalPartitionID != nil {
 				assert.Equal(t, *rst.NVLinkLogicalPartitionID, *tt.args.reqData.NVLinkLogicalPartitionID)

--- a/site-workflow/pkg/activity/vpc.go
+++ b/site-workflow/pkg/activity/vpc.go
@@ -142,7 +142,7 @@ func vpcPagedInventory(allItemIDs []*cwssaws.VpcId, pagedItems []*cwssaws.Vpc, i
 }
 
 // Function to create VPCS with Carbide
-func (mv *ManageVPC) CreateVpcOnSite(ctx context.Context, request *cwssaws.VpcCreationRequest) error {
+func (mv *ManageVPC) CreateVpcOnSite(ctx context.Context, request *cwssaws.VpcCreationRequest) (*cwssaws.Vpc, error) {
 	logger := log.With().Str("Activity", "CreateVpcOnSite").Logger()
 
 	logger.Info().Msg("Starting activity")
@@ -164,24 +164,24 @@ func (mv *ManageVPC) CreateVpcOnSite(ctx context.Context, request *cwssaws.VpcCr
 	}
 
 	if err != nil {
-		return temporal.NewNonRetryableApplicationError(err.Error(), swe.ErrTypeInvalidRequest, err)
+		return nil, temporal.NewNonRetryableApplicationError(err.Error(), swe.ErrTypeInvalidRequest, err)
 	}
 
 	// Call Site Controller gRPC endpoint
 	forgeClient, err := mv.CarbideAtomicClient.GetForgeClient()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	_, err = forgeClient.CreateVpc(ctx, request)
+	controllerVpc, err := forgeClient.CreateVpc(ctx, request)
 	if err != nil {
 		logger.Warn().Err(err).Msg("Failed to create VPC using Site Controller API")
-		return swe.WrapErr(err)
+		return nil, swe.WrapErr(err)
 	}
 
 	logger.Info().Msg("Completed activity")
 
-	return nil
+	return controllerVpc, nil
 }
 
 // Function to update VPCS with Carbide

--- a/site-workflow/pkg/activity/vpc_test.go
+++ b/site-workflow/pkg/activity/vpc_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	tmocks "go.temporal.io/sdk/mocks"
 )
 
@@ -155,6 +156,7 @@ func TestManageVpc_CreateVpcOnSite(t *testing.T) {
 		fields  fields
 		args    args
 		wantErr bool
+		wantVpc bool
 	}{
 		{
 			name: "test create vpc success",
@@ -170,6 +172,7 @@ func TestManageVpc_CreateVpcOnSite(t *testing.T) {
 				},
 			},
 			wantErr: false,
+			wantVpc: true,
 		},
 		{
 			name: "test create vpc fail on missing name",
@@ -231,11 +234,16 @@ func TestManageVpc_CreateVpcOnSite(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mm := NewManageVPC(tt.fields.CarbideAtomicClient)
-			err := mm.CreateVpcOnSite(tt.args.ctx, tt.args.request)
+			vpc, err := mm.CreateVpcOnSite(tt.args.ctx, tt.args.request)
 			if tt.wantErr {
 				assert.Error(t, err)
+				assert.Nil(t, vpc)
 			} else {
 				assert.NoError(t, err)
+				if tt.wantVpc {
+					require.NotNil(t, vpc)
+					require.NotNil(t, vpc.Id)
+				}
 			}
 		})
 	}

--- a/site-workflow/pkg/workflow/vpc.go
+++ b/site-workflow/pkg/workflow/vpc.go
@@ -66,7 +66,7 @@ func DiscoverVPCInventory(ctx workflow.Context) error {
 // CreateVPCV2 is a workflow to create new VPCs using the CreateVpcOnSite activity
 // V1 (CreateVPC) is found in cloud-workflow and uses a different activity that does not speak
 // to carbide directly.
-func CreateVPCV2(ctx workflow.Context, request *cwssaws.VpcCreationRequest) error {
+func CreateVPCV2(ctx workflow.Context, request *cwssaws.VpcCreationRequest) (*cwssaws.Vpc, error) {
 	logger := log.With().Str("Workflow", "VPC").Str("Action", "Create").Str("VPC ID", request.GetId().GetValue()).Str("Name", request.Name).Logger()
 
 	logger.Info().Msg("starting workflow")
@@ -88,16 +88,17 @@ func CreateVPCV2(ctx workflow.Context, request *cwssaws.VpcCreationRequest) erro
 	ctx = workflow.WithActivityOptions(ctx, options)
 
 	var vpcManager activity.ManageVPC
+	var controllerVpc cwssaws.Vpc
 
-	err := workflow.ExecuteActivity(ctx, vpcManager.CreateVpcOnSite, request).Get(ctx, nil)
+	err := workflow.ExecuteActivity(ctx, vpcManager.CreateVpcOnSite, request).Get(ctx, &controllerVpc)
 	if err != nil {
 		logger.Error().Err(err).Str("Activity", "CreateVpcOnSite").Msg("Failed to execute activity from workflow")
-		return err
+		return nil, err
 	}
 
 	logger.Info().Msg("completing workflow")
 
-	return nil
+	return &controllerVpc, nil
 }
 
 // UpdateVPC is a workflow to update VPCs using the UpdateVpcOnSite activity

--- a/site-workflow/pkg/workflow/vpc_test.go
+++ b/site-workflow/pkg/workflow/vpc_test.go
@@ -96,21 +96,35 @@ func (cvv2ts *CreateVpcV2TestSuite) AfterTest(suiteName, testName string) {
 
 func (cvv2ts *CreateVpcV2TestSuite) Test_CreateVpcV2_Success() {
 	var VpcManager iActivity.ManageVPC
+	activeVni := uint32(7301)
 
 	request := &cwssaws.VpcCreationRequest{
 		Id:                   &cwssaws.VpcId{Value: "b410867c-655a-11ef-bc4a-0393098e5d09"},
 		Name:                 "the_name",
 		TenantOrganizationId: "the_org",
 	}
+	controllerVpc := &cwssaws.Vpc{
+		Id:   request.Id,
+		Name: request.Name,
+		Status: &cwssaws.VpcStatus{
+			Vni: &activeVni,
+		},
+	}
 
 	// Mock CreateVpcOnSite activity
 	cvv2ts.env.RegisterActivity(VpcManager.CreateVpcOnSite)
-	cvv2ts.env.OnActivity(VpcManager.CreateVpcOnSite, mock.Anything, mock.Anything).Return(nil)
+	cvv2ts.env.OnActivity(VpcManager.CreateVpcOnSite, mock.Anything, mock.Anything).Return(controllerVpc, nil)
 
 	// Execute CreateVPCV2 workflow
 	cvv2ts.env.ExecuteWorkflow(CreateVPCV2, request)
 	cvv2ts.True(cvv2ts.env.IsWorkflowCompleted())
 	cvv2ts.NoError(cvv2ts.env.GetWorkflowError())
+
+	var result cwssaws.Vpc
+	cvv2ts.NoError(cvv2ts.env.GetWorkflowResult(&result))
+	cvv2ts.Equal(controllerVpc.Id.Value, result.Id.Value)
+	cvv2ts.Equal(controllerVpc.Name, result.Name)
+	cvv2ts.Equal(activeVni, result.GetStatus().GetVni())
 }
 
 func (cvv2ts *CreateVpcV2TestSuite) Test_CreateVpcV2_Failure() {
@@ -126,7 +140,7 @@ func (cvv2ts *CreateVpcV2TestSuite) Test_CreateVpcV2_Failure() {
 
 	// Mock CreateVpcOnSite activity
 	cvv2ts.env.RegisterActivity(VpcManager.CreateVpcOnSite)
-	cvv2ts.env.OnActivity(VpcManager.CreateVpcOnSite, mock.Anything, mock.Anything).Return(errors.New(errMsg))
+	cvv2ts.env.OnActivity(VpcManager.CreateVpcOnSite, mock.Anything, mock.Anything).Return(nil, errors.New(errMsg))
 
 	// execute CreateVPCV2 workflow
 	cvv2ts.env.ExecuteWorkflow(CreateVPCV2, request)

--- a/workflow/pkg/activity/vpc/vpc.go
+++ b/workflow/pkg/activity/vpc/vpc.go
@@ -232,7 +232,7 @@ func (mv ManageVpc) UpdateVpcsInDB(ctx context.Context, siteID uuid.UUID, vpcInv
 
 		// If VPC is not in Deleting state, then update status to Ready
 		if vpc.Status != cdbm.VpcStatusDeleting && vpc.Status != cdbm.VpcStatusReady {
-			err = mv.updateVpcStatusInDB(ctx, nil, vpc.ID, cdb.GetStrPtr(cdbm.VpcStatusReady), cdb.GetStrPtr("VPC has been re-detected on Site"))
+			err = mv.updateVpcStatusInDB(ctx, nil, vpc.ID, cdb.GetStrPtr(cdbm.VpcStatusReady), cdb.GetStrPtr("VPC is ready for use"))
 			if err != nil {
 				slogger.Error().Err(err).Msg("failed to update VPC status detail in DB")
 			}

--- a/workflow/pkg/activity/vpc/vpc_test.go
+++ b/workflow/pkg/activity/vpc/vpc_test.go
@@ -385,6 +385,7 @@ func TestManageVpc_UpdateVpcsInDB(t *testing.T) {
 		ethernetVirtualizationUpdatedVpcs []*cdbm.Vpc
 		routingProfileUpdatedVpcs         []*cdbm.Vpc
 		routingProfileClearedVpcs         []*cdbm.Vpc
+		readyStatusDetailVpcs             []*cdbm.Vpc
 		requiredMetadataUpdate            bool
 		metadataVpcUpdate                 *cdbm.Vpc
 		wantErr                           bool
@@ -479,6 +480,7 @@ func TestManageVpc_UpdateVpcsInDB(t *testing.T) {
 			missingVpcs:                       []*cdbm.Vpc{vpc7, vpc11},
 			restoredVpcs:                      []*cdbm.Vpc{vpc8},
 			unpairedVpcs:                      []*cdbm.Vpc{vpc9, vpc10},
+			readyStatusDetailVpcs:             []*cdbm.Vpc{vpc1},
 			wantErr:                           false,
 		},
 		{
@@ -696,6 +698,16 @@ func TestManageVpc_UpdateVpcsInDB(t *testing.T) {
 
 				scReq := tt.fields.clientPoolClient.Calls[0].Arguments[3].(*cwssaws.VpcUpdateRequest)
 				assert.Equal(t, tt.metadataVpcUpdate.ID.String(), scReq.Id.Value)
+			}
+
+			statusDetailDAO := cdbm.NewStatusDetailDAO(dbSession)
+			for _, vpc := range tt.readyStatusDetailVpcs {
+				statusDetails, _, err := statusDetailDAO.GetAllByEntityID(ctx, nil, vpc.ID.String(), nil, nil, nil)
+				require.NoError(t, err)
+				require.Len(t, statusDetails, 1)
+				assert.Equal(t, cdbm.VpcStatusReady, statusDetails[0].Status)
+				require.NotNil(t, statusDetails[0].Message)
+				assert.Equal(t, "VPC is ready for use", *statusDetails[0].Message)
 			}
 		})
 	}


### PR DESCRIPTION
## Description
VPCs are created with synchronous calls, but the VNI isn't know until it's returned by the site when not sent by the caller.  This means the VPC could be reported as ready before -rest knows the VNI, and then it would suddenly report the VNI without a status change in the VPC.
We now start VPC creation in a "provisioning" state.  We then take the response from the temporal call and pull the VNI from there and make a best-effort attempt to update the DB with the new details.   if all goes well, we return the updated details.  If not, we let inventory processes populate the VNI and update the status, which they already do.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [x] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **API** - API models or endpoints updated
- [x] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
