### PR TITLE
chore: Reduce tests duration by up to 36% during CI/CD or local run by trading durability for speed

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -281,6 +281,23 @@ jobs:
       - name: Install go-junit-report
         run: go install github.com/jstemmer/go-junit-report/v2@latest
 
+      # Trade durability for speed in tests. The service container is ephemeral
+      # and recreated per job, so corruption on crash is irrelevant. Only
+      # SIGHUP-reloadable flags are applied here because GitHub Actions
+      # `services:` does not allow overriding the container CMD. Each ALTER
+      # SYSTEM is passed via its own -c flag because ALTER SYSTEM cannot run
+      # inside a transaction block, and a single multi-statement -c string is
+      # wrapped in an implicit transaction by psql.
+      - name: Tune PostgreSQL for faster tests
+        run: |
+          docker exec ${{ job.services.postgres.id }} \
+            psql -U postgres -d forgetest -v ON_ERROR_STOP=1 \
+              -c "ALTER SYSTEM SET fsync = 'off'" \
+              -c "ALTER SYSTEM SET synchronous_commit = 'off'" \
+              -c "ALTER SYSTEM SET full_page_writes = 'off'" \
+              -c "ALTER SYSTEM SET autovacuum = 'off'" \
+              -c "SELECT pg_reload_conf()"
+
       - name: Run unit tests for ${{ matrix.module }}
         run: |
           set -o pipefail

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,8 @@ HELM_SET_KEYCLOAK := --set carbide-rest-api.config.keycloak.enabled=true \
 	--set carbide-rest-api.config.keycloak.clientID=carbide-api \
 	--set carbide-rest-api.config.keycloak.serviceAccount=true
 
+# Tuning flags trade durability for speed. Safe because the container is
+# ephemeral (--rm) and the database is recreated for every test run.
 postgres-up:
 	docker run -d --rm \
 		--name $(POSTGRES_CONTAINER_NAME) \
@@ -55,7 +57,12 @@ postgres-up:
 		-e POSTGRES_USER=$(POSTGRES_USER) \
 		-e POSTGRES_PASSWORD=$(POSTGRES_PASSWORD) \
 		-e POSTGRES_DB=$(POSTGRES_DB) \
-		$(POSTGRES_IMAGE)
+		$(POSTGRES_IMAGE) \
+		-c fsync=off \
+		-c synchronous_commit=off \
+		-c full_page_writes=off \
+		-c wal_level=minimal \
+		-c max_wal_senders=0
 
 postgres-down:
 	-docker rm -f $(POSTGRES_CONTAINER_NAME)

--- a/api/scripts/start-test-postgres.sh
+++ b/api/scripts/start-test-postgres.sh
@@ -16,4 +16,14 @@
 
 #
 
-docker run -d --rm --name project-test -p 30432:5432 -e POSTGRES_PASSWORD=postgres -e POSTGRES_USER=postgres -e POSTGRES_DB=project postgres:14.4-alpine
+# Durability is intentionally disabled: this container is ephemeral and the
+# database is recreated for every test run. Do NOT copy these flags to any
+# non-test environment.
+docker run -d --rm --name project-test -p 30432:5432 \
+    -e POSTGRES_PASSWORD=postgres -e POSTGRES_USER=postgres -e POSTGRES_DB=project \
+    postgres:14.4-alpine \
+    -c fsync=off \
+    -c synchronous_commit=off \
+    -c full_page_writes=off \
+    -c wal_level=minimal \
+    -c max_wal_senders=0

--- a/rla/scripts/start-test-postgres.sh
+++ b/rla/scripts/start-test-postgres.sh
@@ -58,13 +58,20 @@ case "$1" in
         docker rm "$CONTAINER_NAME" 2>/dev/null
 
         echo "Starting PostgreSQL container: $CONTAINER_NAME"
+        # Durability is intentionally disabled: this container is for tests only
+        # and the database is recreated for every test run.
         docker run -d \
             --name "$CONTAINER_NAME" \
             -p "${POSTGRES_PORT}:5432" \
             -e POSTGRES_USER="$POSTGRES_USER" \
             -e POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
             -e POSTGRES_DB="$POSTGRES_DB" \
-            postgres:14.4-alpine
+            postgres:14.4-alpine \
+            -c fsync=off \
+            -c synchronous_commit=off \
+            -c full_page_writes=off \
+            -c wal_level=minimal \
+            -c max_wal_senders=0
 
         echo ""
         echo "PostgreSQL is starting..."


### PR DESCRIPTION
## Description
Reduce tests duration during CI/CD or local run by trading durability for speed.
Local test show time reduction of 36% (from 10:38 to 6:46).

## Type of Change
- [X] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)

## Services Affected: none.

## Breaking Changes: no.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)
