### PR TITLE
fix: Harden component manager lookup in RLA

### DIFF
--- a/rla/docs/component-manager-architecture.md
+++ b/rla/docs/component-manager-architecture.md
@@ -93,7 +93,9 @@ Factory functions create component manager instances. They receive the `Provider
 The `Registry` stores factories and active managers:
 - `RegisterFactory()` - Register a factory for a component type + implementation name
 - `Initialize()` - Create managers based on configuration
-- `GetManager()` - Retrieve active manager for a component type
+- `GetManager()` - Retrieve active manager for a component type, returning a
+  descriptive error when the registry is not configured or no manager is active
+- `FindManager()` - Probe for an active manager, returning nil when absent
 
 ## Directory Structure
 

--- a/rla/internal/task/componentmanager/componentmanager.go
+++ b/rla/internal/task/componentmanager/componentmanager.go
@@ -19,7 +19,6 @@ package componentmanager
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/rs/zerolog/log"
@@ -33,30 +32,46 @@ import (
 // components. Implementations handle component-specific operations like
 // power control, firmware management, and status monitoring.
 type ComponentManager interface {
+	// Type returns the component type this manager is responsible for.
 	Type() devicetypes.ComponentType
-	InjectExpectation(ctx context.Context, target common.Target, info operations.InjectExpectationTaskInfo) error //nolint
-	PowerControl(ctx context.Context, target common.Target, info operations.PowerControlTaskInfo) error           //nolint
-	GetPowerStatus(ctx context.Context, target common.Target) (map[string]operations.PowerStatus, error)          //nolint
 
-	// FirmwareControl initiates firmware update without waiting for completion.
+	// InjectExpectation registers expected component configurations with the
+	// component manager service for the target components.
+	InjectExpectation(ctx context.Context, target common.Target, info operations.InjectExpectationTaskInfo) error //nolint
+
+	// PowerControl applies a power state transition to the target components.
+	PowerControl(ctx context.Context, target common.Target, info operations.PowerControlTaskInfo) error //nolint
+
+	// GetPowerStatus queries the current power state of each component in the
+	// target. Returns a map of component ID to PowerStatus.
+	GetPowerStatus(ctx context.Context, target common.Target) (map[string]operations.PowerStatus, error) //nolint
+
+	// FirmwareControl initiates a firmware update without waiting for completion.
 	// Returns immediately after the update request is accepted.
 	FirmwareControl(ctx context.Context, target common.Target, info operations.FirmwareControlTaskInfo) error //nolint
 
-	// GetFirmwareStatus returns the current status of firmware updates for the target components.
-	// Returns a map of component ID to FirmwareUpdateStatus.
+	// GetFirmwareStatus returns the current firmware update state for each
+	// component in the target. Returns a map of component ID to FirmwareUpdateStatus.
 	GetFirmwareStatus(ctx context.Context, target common.Target) (map[string]operations.FirmwareUpdateStatus, error) //nolint
 }
 
 // BringUpController is an optional interface for component managers that support
 // bring-up operations.
 type BringUpController interface {
+	// BringUpControl opens the power-on gate for the target components, allowing
+	// them to proceed through the bring-up sequence.
 	BringUpControl(ctx context.Context, target common.Target) error
+
+	// GetBringUpStatus returns the current bring-up state for each component in
+	// the target. Returns a map of component ID to MachineBringUpState.
 	GetBringUpStatus(ctx context.Context, target common.Target) (map[string]operations.MachineBringUpState, error)
 }
 
 // FirmwareConsistencyChecker is an optional interface for component managers
 // that can verify firmware version consistency across a set of components.
 type FirmwareConsistencyChecker interface {
+	// VerifyFirmwareConsistency checks that all target components report the same
+	// firmware version set. Returns an error if versions diverge.
 	VerifyFirmwareConsistency(ctx context.Context, target common.Target) error
 }
 
@@ -119,10 +134,9 @@ func (r *Registry) Initialize(config Config, providers *ProviderRegistry) error 
 	for componentType, implName := range config.ComponentManagers {
 		factories, ok := r.factories[componentType]
 		if !ok {
-			return fmt.Errorf(
-				"no factories registered for component type: %s",
-				devicetypes.ComponentTypeToString(componentType),
-			)
+			return ComponentManagerFactoryNotRegisteredError{
+				ComponentType: componentType,
+			}
 		}
 
 		factory, ok := factories[implName]
@@ -131,22 +145,20 @@ func (r *Registry) Initialize(config Config, providers *ProviderRegistry) error 
 			for name := range factories {
 				available = append(available, name)
 			}
-			return fmt.Errorf(
-				"unknown implementation '%s' for component type %s, available: %v",
-				implName,
-				devicetypes.ComponentTypeToString(componentType),
-				available,
-			)
+			return UnknownComponentManagerImplementationError{
+				ComponentType:  componentType,
+				Implementation: implName,
+				Available:      available,
+			}
 		}
 
 		manager, err := factory(providers)
 		if err != nil {
-			return fmt.Errorf(
-				"failed to create manager for component type %s with implementation '%s': %w",
-				devicetypes.ComponentTypeToString(componentType),
-				implName,
-				err,
-			)
+			return ManagerCreationError{
+				ComponentType:  componentType,
+				Implementation: implName,
+				Err:            err,
+			}
 		}
 
 		r.active[componentType] = manager
@@ -159,12 +171,40 @@ func (r *Registry) Initialize(config Config, providers *ProviderRegistry) error 
 	return nil
 }
 
-// GetManager returns the active manager for the specified component type.
-// Returns nil if no manager is active for the type.
-func (r *Registry) GetManager(componentType devicetypes.ComponentType) ComponentManager {
+// FindManager returns the active manager for the specified component type.
+// It returns nil when the registry is nil or when no manager is active for the
+// type. Use GetManager when the caller needs a descriptive configuration error.
+func (r *Registry) FindManager(
+	componentType devicetypes.ComponentType,
+) ComponentManager {
+	if r == nil {
+		return nil
+	}
+
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.active[componentType]
+}
+
+// GetManager returns the active manager for the specified component type.
+// It returns a descriptive error when the registry is nil or when no manager is
+// active for the type.
+func (r *Registry) GetManager(
+	componentType devicetypes.ComponentType,
+) (ComponentManager, error) {
+	if r == nil {
+		return nil, ErrRegistryNotConfigured
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	manager := r.active[componentType]
+	if manager == nil {
+		return nil, ManagerNotConfiguredError{ComponentType: componentType}
+	}
+
+	return manager, nil
 }
 
 // GetAllManagers returns all active managers.

--- a/rla/internal/task/componentmanager/componentmanager_test.go
+++ b/rla/internal/task/componentmanager/componentmanager_test.go
@@ -1,0 +1,216 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package componentmanager
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/pkg/common/devicetypes"
+)
+
+func TestRegistryGetManager(t *testing.T) {
+	t.Run("nil registry", func(t *testing.T) {
+		var registry *Registry
+
+		manager, err := registry.GetManager(devicetypes.ComponentTypeCompute)
+
+		require.Nil(t, manager)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrRegistryNotConfigured))
+	})
+
+	t.Run("missing active manager", func(t *testing.T) {
+		registry := NewRegistry()
+
+		manager, err := registry.GetManager(devicetypes.ComponentTypeCompute)
+
+		require.Nil(t, manager)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrManagerNotConfigured))
+
+		var managerErr ManagerNotConfiguredError
+		require.True(t, errors.As(err, &managerErr))
+		require.Equal(t, devicetypes.ComponentTypeCompute, managerErr.ComponentType)
+	})
+
+}
+
+func TestRegistryInitializeErrors(t *testing.T) {
+	t.Run("factory not registered", func(t *testing.T) {
+		registry := NewRegistry()
+
+		err := registry.Initialize(Config{
+			ComponentManagers: map[devicetypes.ComponentType]string{
+				devicetypes.ComponentTypeCompute: "mock",
+			},
+		}, NewProviderRegistry())
+
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrComponentManagerFactoryNotRegistered))
+
+		var factoryErr ComponentManagerFactoryNotRegisteredError
+		require.True(t, errors.As(err, &factoryErr))
+		require.Equal(t, devicetypes.ComponentTypeCompute, factoryErr.ComponentType)
+	})
+
+	t.Run("unknown implementation", func(t *testing.T) {
+		registry := NewRegistry()
+		registry.RegisterFactory(
+			devicetypes.ComponentTypeCompute,
+			"known",
+			func(*ProviderRegistry) (ComponentManager, error) {
+				return nil, nil
+			},
+		)
+
+		err := registry.Initialize(Config{
+			ComponentManagers: map[devicetypes.ComponentType]string{
+				devicetypes.ComponentTypeCompute: "missing",
+			},
+		}, NewProviderRegistry())
+
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrUnknownComponentManagerImplementation))
+
+		var implErr UnknownComponentManagerImplementationError
+		require.True(t, errors.As(err, &implErr))
+		require.Equal(t, devicetypes.ComponentTypeCompute, implErr.ComponentType)
+		require.Equal(t, "missing", implErr.Implementation)
+		require.ElementsMatch(t, []string{"known"}, implErr.Available)
+	})
+
+	t.Run("manager creation failed", func(t *testing.T) {
+		rootErr := errors.New("boom")
+		registry := NewRegistry()
+		registry.RegisterFactory(
+			devicetypes.ComponentTypeCompute,
+			"broken",
+			func(*ProviderRegistry) (ComponentManager, error) {
+				return nil, rootErr
+			},
+		)
+
+		err := registry.Initialize(Config{
+			ComponentManagers: map[devicetypes.ComponentType]string{
+				devicetypes.ComponentTypeCompute: "broken",
+			},
+		}, NewProviderRegistry())
+
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrManagerCreationFailed))
+		require.True(t, errors.Is(err, rootErr))
+
+		var creationErr ManagerCreationError
+		require.True(t, errors.As(err, &creationErr))
+		require.Equal(t, devicetypes.ComponentTypeCompute, creationErr.ComponentType)
+		require.Equal(t, "broken", creationErr.Implementation)
+	})
+}
+
+func TestRegistryFindManager(t *testing.T) {
+	t.Run("nil registry", func(t *testing.T) {
+		var registry *Registry
+
+		manager := registry.FindManager(devicetypes.ComponentTypeCompute)
+
+		require.Nil(t, manager)
+	})
+
+	t.Run("missing active manager", func(t *testing.T) {
+		registry := NewRegistry()
+
+		manager := registry.FindManager(devicetypes.ComponentTypeCompute)
+
+		require.Nil(t, manager)
+	})
+
+}
+
+func TestParseConfigUnknownComponentTypeError(t *testing.T) {
+	_, err := ParseConfig([]byte(`
+component_managers:
+  madeup: mock
+`))
+
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrUnknownComponentType))
+
+	var componentTypeErr UnknownComponentTypeError
+	require.True(t, errors.As(err, &componentTypeErr))
+	require.Equal(t, "madeup", componentTypeErr.Name)
+}
+
+type testProvider struct {
+	name string
+}
+
+func (p *testProvider) Name() string {
+	return p.name
+}
+
+type otherProvider struct {
+	name string
+}
+
+func (p *otherProvider) Name() string {
+	return p.name
+}
+
+func TestGetTypedErrors(t *testing.T) {
+	t.Run("provider registry not configured", func(t *testing.T) {
+		var registry *ProviderRegistry
+
+		provider, err := GetTyped[*testProvider](registry, "missing")
+
+		require.Nil(t, provider)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrProviderRegistryNotConfigured))
+	})
+
+	t.Run("provider not found", func(t *testing.T) {
+		registry := NewProviderRegistry()
+
+		provider, err := GetTyped[*testProvider](registry, "missing")
+
+		require.Nil(t, provider)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrUnknownProvider))
+
+		var providerErr UnknownProviderError
+		require.True(t, errors.As(err, &providerErr))
+		require.Equal(t, "missing", providerErr.Name)
+	})
+
+	t.Run("provider type mismatch", func(t *testing.T) {
+		registry := NewProviderRegistry()
+		registry.Register(&otherProvider{name: "provider"})
+
+		provider, err := GetTyped[*testProvider](registry, "provider")
+
+		require.Nil(t, provider)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrProviderTypeMismatch))
+
+		var mismatchErr ProviderTypeMismatchError
+		require.True(t, errors.As(err, &mismatchErr))
+		require.Equal(t, "provider", mismatchErr.Name)
+	})
+}

--- a/rla/internal/task/componentmanager/config.go
+++ b/rla/internal/task/componentmanager/config.go
@@ -107,7 +107,7 @@ func ParseConfig(data []byte) (Config, error) {
 	for typeStr, implName := range raw.ComponentManagers {
 		componentType := devicetypes.ComponentTypeFromString(typeStr)
 		if componentType == devicetypes.ComponentTypeUnknown {
-			return Config{}, fmt.Errorf("unknown component type: %s", typeStr)
+			return Config{}, UnknownComponentTypeError{Name: typeStr}
 		}
 		config.ComponentManagers[componentType] = strings.TrimSpace(implName)
 	}

--- a/rla/internal/task/componentmanager/errors.go
+++ b/rla/internal/task/componentmanager/errors.go
@@ -1,0 +1,187 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package componentmanager
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/pkg/common/devicetypes"
+)
+
+var (
+	// ErrRegistryNotConfigured reports that the component manager registry is
+	// not available.
+	ErrRegistryNotConfigured = errors.New("component manager registry is not configured")
+
+	// ErrManagerNotConfigured reports that no active manager is configured for
+	// the requested component type.
+	ErrManagerNotConfigured = errors.New("component manager is not configured")
+
+	// ErrComponentManagerFactoryNotRegistered reports that no factories were
+	// registered for a component type.
+	ErrComponentManagerFactoryNotRegistered = errors.New("component manager factory is not registered")
+
+	// ErrUnknownComponentManagerImplementation reports that the configured
+	// implementation name is not registered for a component type.
+	ErrUnknownComponentManagerImplementation = errors.New("unknown component manager implementation")
+
+	// ErrManagerCreationFailed reports that a registered manager factory failed.
+	ErrManagerCreationFailed = errors.New("component manager creation failed")
+
+	// ErrUnknownComponentType reports an unrecognized component type in config.
+	ErrUnknownComponentType = errors.New("unknown component type")
+
+	// ErrProviderRegistryNotConfigured reports that the provider registry is not
+	// available.
+	ErrProviderRegistryNotConfigured = errors.New("provider registry is not configured")
+
+	// ErrUnknownProvider reports that a required provider is missing from the
+	// provider registry.
+	ErrUnknownProvider = errors.New("unknown provider")
+
+	// ErrProviderTypeMismatch reports that a provider exists but has a different
+	// concrete type than the caller requested.
+	ErrProviderTypeMismatch = errors.New("provider type mismatch")
+)
+
+// ManagerNotConfiguredError includes the component type that has no active
+// manager.
+type ManagerNotConfiguredError struct {
+	ComponentType devicetypes.ComponentType
+}
+
+func (e ManagerNotConfiguredError) Error() string {
+	return fmt.Sprintf(
+		"no active component manager configured for component type %s",
+		devicetypes.ComponentTypeToString(e.ComponentType),
+	)
+}
+
+func (e ManagerNotConfiguredError) Is(target error) bool {
+	return target == ErrManagerNotConfigured
+}
+
+// ComponentManagerFactoryNotRegisteredError includes the component type that
+// has no registered factories.
+type ComponentManagerFactoryNotRegisteredError struct {
+	ComponentType devicetypes.ComponentType
+}
+
+func (e ComponentManagerFactoryNotRegisteredError) Error() string {
+	return fmt.Sprintf(
+		"no factories registered for component type: %s",
+		devicetypes.ComponentTypeToString(e.ComponentType),
+	)
+}
+
+func (e ComponentManagerFactoryNotRegisteredError) Is(target error) bool {
+	return target == ErrComponentManagerFactoryNotRegistered
+}
+
+// UnknownComponentManagerImplementationError includes the implementation name
+// that was requested and the implementations that were available.
+type UnknownComponentManagerImplementationError struct {
+	ComponentType  devicetypes.ComponentType
+	Implementation string
+	Available      []string
+}
+
+func (e UnknownComponentManagerImplementationError) Error() string {
+	available := append([]string(nil), e.Available...)
+	sort.Strings(available)
+	return fmt.Sprintf(
+		"unknown implementation '%s' for component type %s, available: %v",
+		e.Implementation,
+		devicetypes.ComponentTypeToString(e.ComponentType),
+		available,
+	)
+}
+
+func (e UnknownComponentManagerImplementationError) Is(target error) bool {
+	return target == ErrUnknownComponentManagerImplementation
+}
+
+// ManagerCreationError includes the configured manager identity and wraps the
+// factory error.
+type ManagerCreationError struct {
+	ComponentType  devicetypes.ComponentType
+	Implementation string
+	Err            error
+}
+
+func (e ManagerCreationError) Error() string {
+	msg := fmt.Sprintf(
+		"failed to create manager for component type %s with implementation '%s'",
+		devicetypes.ComponentTypeToString(e.ComponentType),
+		e.Implementation,
+	)
+	if e.Err == nil {
+		return msg
+	}
+	return fmt.Sprintf("%s: %v", msg, e.Err)
+}
+
+func (e ManagerCreationError) Unwrap() error {
+	return e.Err
+}
+
+func (e ManagerCreationError) Is(target error) bool {
+	return target == ErrManagerCreationFailed
+}
+
+// UnknownComponentTypeError includes the unrecognized component type string.
+type UnknownComponentTypeError struct {
+	Name string
+}
+
+func (e UnknownComponentTypeError) Error() string {
+	return fmt.Sprintf("%s: %s", ErrUnknownComponentType, e.Name)
+}
+
+func (e UnknownComponentTypeError) Is(target error) bool {
+	return target == ErrUnknownComponentType
+}
+
+// UnknownProviderError includes the missing provider name.
+type UnknownProviderError struct {
+	Name string
+}
+
+func (e UnknownProviderError) Error() string {
+	return fmt.Sprintf("provider '%s' not found", e.Name)
+}
+
+func (e UnknownProviderError) Is(target error) bool {
+	return target == ErrUnknownProvider
+}
+
+// ProviderTypeMismatchError includes the provider name with the unexpected
+// concrete type.
+type ProviderTypeMismatchError struct {
+	Name string
+}
+
+func (e ProviderTypeMismatchError) Error() string {
+	return fmt.Sprintf("provider '%s' is not of expected type", e.Name)
+}
+
+func (e ProviderTypeMismatchError) Is(target error) bool {
+	return target == ErrProviderTypeMismatch
+}

--- a/rla/internal/task/componentmanager/provider.go
+++ b/rla/internal/task/componentmanager/provider.go
@@ -18,7 +18,6 @@
 package componentmanager
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/rs/zerolog/log"
@@ -78,14 +77,18 @@ func (pr *ProviderRegistry) Get(name string) Provider {
 // Returns an error if the provider is not found or cannot be cast to the expected type.
 func GetTyped[T Provider](pr *ProviderRegistry, name string) (T, error) {
 	var zero T
+	if pr == nil {
+		return zero, ErrProviderRegistryNotConfigured
+	}
+
 	provider := pr.Get(name)
 	if provider == nil {
-		return zero, fmt.Errorf("provider '%s' not found", name)
+		return zero, UnknownProviderError{Name: name}
 	}
 
 	typed, ok := provider.(T)
 	if !ok {
-		return zero, fmt.Errorf("provider '%s' is not of expected type", name)
+		return zero, ProviderTypeMismatchError{Name: name}
 	}
 
 	return typed, nil

--- a/rla/internal/task/executor/temporalworkflow/activity/activity.go
+++ b/rla/internal/task/executor/temporalworkflow/activity/activity.go
@@ -121,6 +121,7 @@ func (a *Activities) FirmwareControl(
 
 // GetFirmwareStatusResult is the result of GetFirmwareStatus activity.
 type GetFirmwareStatusResult struct {
+	// Statuses maps each component ID to its current firmware update state.
 	Statuses map[string]operations.FirmwareUpdateStatus
 }
 
@@ -163,6 +164,7 @@ func (a *Activities) BringUpControl(
 
 // GetBringUpStatusResult is the result of GetBringUpStatus activity.
 type GetBringUpStatusResult struct {
+	// States maps each component ID to its current bring-up state.
 	States map[string]operations.MachineBringUpState
 }
 
@@ -220,13 +222,5 @@ func (a *Activities) validAndGetComponentManager(
 		return nil, fmt.Errorf("target is invalid: %w", err)
 	}
 
-	cm := a.getComponentManager(target.Type)
-	if cm == nil {
-		return nil, fmt.Errorf(
-			"no component manager registered for type %s",
-			target.Type.String(),
-		)
-	}
-
-	return cm, nil
+	return a.registry.GetManager(target.Type)
 }

--- a/rla/internal/task/executor/temporalworkflow/activity/activity_test.go
+++ b/rla/internal/task/executor/temporalworkflow/activity/activity_test.go
@@ -1,0 +1,118 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package activity
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager"
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/executor/temporalworkflow/common"
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/operations"
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/pkg/common/devicetypes"
+)
+
+func TestActivitiesReturnErrorWhenComponentManagerRegistryIsMissing(t *testing.T) {
+	acts := New(nil, nil)
+
+	for name, call := range activityCallsForMissingManagerTest(t, acts) {
+		t.Run(name, func(t *testing.T) {
+			err := call()
+			require.Error(t, err)
+			require.True(t, errors.Is(err, componentmanager.ErrRegistryNotConfigured))
+		})
+	}
+}
+
+func TestActivitiesReturnErrorWhenComponentManagerIsMissing(t *testing.T) {
+	acts := New(nil, componentmanager.NewRegistry())
+
+	for name, call := range activityCallsForMissingManagerTest(t, acts) {
+		t.Run(name, func(t *testing.T) {
+			err := call()
+			require.Error(t, err)
+			require.True(t, errors.Is(err, componentmanager.ErrManagerNotConfigured))
+		})
+	}
+}
+
+func activityCallsForMissingManagerTest(
+	t *testing.T,
+	acts *Activities,
+) map[string]func() error {
+	t.Helper()
+
+	ctx := context.Background()
+	target := newActivityTestTarget()
+
+	return map[string]func() error{
+		"InjectExpectation": func() error {
+			return acts.InjectExpectation(
+				ctx,
+				target,
+				operations.InjectExpectationTaskInfo{},
+			)
+		},
+		"PowerControl": func() error {
+			return acts.PowerControl(
+				ctx,
+				target,
+				operations.PowerControlTaskInfo{
+					Operation: operations.PowerOperationPowerOn,
+				},
+			)
+		},
+		"GetPowerStatus": func() error {
+			_, err := acts.GetPowerStatus(ctx, target)
+			return err
+		},
+		"VerifyFirmwareConsistency": func() error {
+			return acts.VerifyFirmwareConsistency(ctx, target)
+		},
+		"BringUpControl": func() error {
+			return acts.BringUpControl(ctx, target)
+		},
+		"GetBringUpStatus": func() error {
+			_, err := acts.GetBringUpStatus(ctx, target)
+			return err
+		},
+		"FirmwareControl": func() error {
+			return acts.FirmwareControl(
+				ctx,
+				target,
+				operations.FirmwareControlTaskInfo{
+					Operation: operations.FirmwareOperationUpgrade,
+				},
+			)
+		},
+		"GetFirmwareStatus": func() error {
+			_, err := acts.GetFirmwareStatus(ctx, target)
+			return err
+		},
+	}
+}
+
+func newActivityTestTarget() common.Target {
+	return common.Target{
+		Type:         devicetypes.ComponentTypeCompute,
+		ComponentIDs: []string{"machine-1"},
+	}
+}

--- a/rla/internal/task/executor/temporalworkflow/activity/registry.go
+++ b/rla/internal/task/executor/temporalworkflow/activity/registry.go
@@ -20,7 +20,6 @@ package activity
 import (
 	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager"
 	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/task"
-	"github.com/NVIDIA/ncx-infra-controller-rest/rla/pkg/common/devicetypes"
 )
 
 // Activities holds the per-manager-instance dependencies for all Temporal
@@ -62,13 +61,4 @@ func (a *Activities) All() map[string]any {
 		NameGetBringUpStatus:          a.GetBringUpStatus,
 		NameVerifyFirmwareConsistency: a.VerifyFirmwareConsistency,
 	}
-}
-
-// getComponentManager returns the component manager for typ, or nil if no
-// registry is configured or no manager is registered for that type.
-func (a *Activities) getComponentManager(typ devicetypes.ComponentType) componentmanager.ComponentManager {
-	if a.registry == nil {
-		return nil
-	}
-	return a.registry.GetManager(typ)
 }

--- a/rla/internal/task/executor/temporalworkflow/activity/registry_test.go
+++ b/rla/internal/task/executor/temporalworkflow/activity/registry_test.go
@@ -18,12 +18,13 @@
 package activity
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/NVIDIA/ncx-infra-controller-rest/rla/pkg/common/devicetypes"
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager"
 )
 
 // TestActivities_All_ContainsAllActivities verifies that All() returns every
@@ -78,10 +79,11 @@ func TestActivities_Isolation(t *testing.T) {
 	assert.NotContains(t, m2, "isolation-sentinel", "mutations to one instance's map must not bleed into another instance's map")
 }
 
-// TestActivities_GetComponentManager_NilRegistry verifies that
-// getComponentManager returns nil gracefully when no registry is configured.
-func TestActivities_GetComponentManager_NilRegistry(t *testing.T) {
+// TestActivities_ValidAndGetComponentManager_NilRegistry verifies that manager
+// lookup returns a clear configuration error when no registry is configured.
+func TestActivities_ValidAndGetComponentManager_NilRegistry(t *testing.T) {
 	acts := New(nil, nil)
-	result := acts.getComponentManager(devicetypes.ComponentTypeCompute)
-	assert.Nil(t, result)
+	_, err := acts.validAndGetComponentManager(newActivityTestTarget())
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, componentmanager.ErrRegistryNotConfigured))
 }


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
- Return explicit errors when the component manager registry is missing or no active manager is configured, and add FindManager for nil-returning probe semantics.
- Update Temporal activity lookup paths and tests to cover missing registry and missing manager cases.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [x] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [ ] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [x] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
