### PR TITLE
fix: Remove additional VPC Prefix validation logic in Site Workflow

### DIFF
--- a/site-workflow/pkg/activity/vpcprefix.go
+++ b/site-workflow/pkg/activity/vpcprefix.go
@@ -53,17 +53,10 @@ func (mvp *ManageVpcPrefix) CreateVpcPrefixOnSite(ctx context.Context, request *
 
 	// Validate request
 	if request == nil {
-		err = errors.New("received empty create VPC prefix request")
-	} else if request.Name == "" {
-		err = errors.New("received create VPC prefix request missing Name")
-	} else if request.Prefix == "" {
-		err = errors.New("received create VPC prefix request missing Prefix")
+		err = errors.New("received empty create VPC Prefix request")
 	} else if request.Id == nil || request.Id.Value == "" {
-		// Don't let a request come in without a cloud-provided ID
-		// or carbide will generate one and cloud won't know the relationship.
-		err = errors.New("received create VPC prefix request missing ID")
-	} else if request.VpcId == nil || request.VpcId.Value == "" {
-		err = errors.New("received create VPC prefix request missing VPC ID")
+		// Don't let a request come in without an ID or Site will generate one and REST won't know the relationship
+		err = errors.New("received create VPC Prefix request without ID")
 	}
 
 	if err != nil {
@@ -79,7 +72,7 @@ func (mvp *ManageVpcPrefix) CreateVpcPrefixOnSite(ctx context.Context, request *
 
 	_, err = forgeClient.CreateVpcPrefix(ctx, request)
 	if err != nil {
-		logger.Warn().Err(err).Msg("Failed to create VPC prefix using Site Controller API")
+		logger.Warn().Err(err).Msg("Failed to create VPC Prefix using Site Controller API")
 		return swe.WrapErr(err)
 	}
 
@@ -98,9 +91,9 @@ func (mvp *ManageVpcPrefix) UpdateVpcPrefixOnSite(ctx context.Context, request *
 
 	// Validate request
 	if request == nil {
-		err = errors.New("received empty update VPC prefix request")
+		err = errors.New("received empty update VPC Prefix request")
 	} else if request.Id == nil || request.Id.Value == "" {
-		err = errors.New("received update VPC prefix request missing ID")
+		err = errors.New("received update VPC Prefix request without ID")
 	}
 
 	if err != nil {
@@ -116,7 +109,7 @@ func (mvp *ManageVpcPrefix) UpdateVpcPrefixOnSite(ctx context.Context, request *
 
 	_, err = forgeClient.UpdateVpcPrefix(ctx, request)
 	if err != nil {
-		logger.Warn().Err(err).Msg("Failed to update VPC prefix using Site Controller API")
+		logger.Warn().Err(err).Msg("Failed to update VPC Prefix using Site Controller API")
 		return swe.WrapErr(err)
 	}
 
@@ -135,9 +128,9 @@ func (mvp *ManageVpcPrefix) DeleteVpcPrefixOnSite(ctx context.Context, request *
 
 	// Validate request
 	if request == nil {
-		err = errors.New("received empty delete VPC prefix request")
+		err = errors.New("received empty delete VPC Prefix request")
 	} else if request.Id == nil || request.Id.Value == "" {
-		err = errors.New("reveived delete VPC prefix missing VPC Prefix ID")
+		err = errors.New("received delete VPC Prefix request without ID")
 	}
 
 	if err != nil {
@@ -153,7 +146,7 @@ func (mvp *ManageVpcPrefix) DeleteVpcPrefixOnSite(ctx context.Context, request *
 
 	_, err = forgeClient.DeleteVpcPrefix(ctx, request)
 	if err != nil {
-		logger.Warn().Err(err).Msg("Failed to delete VPC prefix using Site Controller API")
+		logger.Warn().Err(err).Msg("Failed to delete VPC Prefix using Site Controller API")
 		return swe.WrapErr(err)
 	}
 

--- a/site-workflow/pkg/activity/vpcprefix_test.go
+++ b/site-workflow/pkg/activity/vpcprefix_test.go
@@ -173,39 +173,7 @@ func TestManageVpcPrefix_CreateVpcPrefixOnSite(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "test create VpcPrefix fail on missing name",
-			fields: fields{
-				CarbideAtomicClient: carbideAtomicClient,
-			},
-			args: args{
-				ctx: context.Background(),
-				request: &cwssaws.VpcPrefixCreationRequest{
-					Id:     &cwssaws.VpcPrefixId{Value: "b410867c-655a-11ef-bc4a-0393098e5d09"},
-					Name:   "",
-					Prefix: prefix,
-					VpcId:  &cwssaws.VpcId{Value: uuid.NewString()},
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "test create VpcPrefix fail on missing prefix",
-			fields: fields{
-				CarbideAtomicClient: carbideAtomicClient,
-			},
-			args: args{
-				ctx: context.Background(),
-				request: &cwssaws.VpcPrefixCreationRequest{
-					Id:     &cwssaws.VpcPrefixId{Value: "b410867c-655a-11ef-bc4a-0393098e5d09"},
-					Name:   name,
-					Prefix: "",
-					VpcId:  &cwssaws.VpcId{Value: uuid.NewString()},
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "test create VpcPrefix fail on missing id",
+			name: "test create VpcPrefix fail on missing ID",
 			fields: fields{
 				CarbideAtomicClient: carbideAtomicClient,
 			},
@@ -216,22 +184,6 @@ func TestManageVpcPrefix_CreateVpcPrefixOnSite(t *testing.T) {
 					Name:   name,
 					Prefix: prefix,
 					VpcId:  &cwssaws.VpcId{Value: uuid.NewString()},
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "test create VpcPrefix fail on missing vpc id",
-			fields: fields{
-				CarbideAtomicClient: carbideAtomicClient,
-			},
-			args: args{
-				ctx: context.Background(),
-				request: &cwssaws.VpcPrefixCreationRequest{
-					Id:     &cwssaws.VpcPrefixId{Value: "b410867c-655a-11ef-bc4a-0393098e5d09"},
-					Name:   name,
-					Prefix: prefix,
-					VpcId:  nil,
 				},
 			},
 			wantErr: true,
@@ -294,7 +246,7 @@ func TestManageVpcPrefix_UpdateVpcPrefixOnSiteOnSite(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "test update VpcPrefix fail on missing id",
+			name: "test update VpcPrefix fail on missing ID",
 			fields: fields{
 				CarbideAtomicClient: carbideAtomicClient,
 			},
@@ -364,7 +316,7 @@ func TestManageVpcPrefix_DeleteVpcPrefixOnSiteOnSite(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "test delete VpcPrefix fail on blank id",
+			name: "test delete VpcPrefix fail on blank ID",
 			fields: fields{
 				CarbideAtomicClient: carbideAtomicClient,
 			},


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
Currently we have additional validation logic in Site Workflow for VPC Prefix creation. Validation should happen in:
- REST API handler
- gRPC API handler
 
Maintaining validation in-between can cause confusion when request format change.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Fix** - Bug fixes (fix:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **Workflow** - Workflow service updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->
None

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
None