### PR TITLE
refactor: Improve provider config pluggability in RLA

### DIFF
--- a/rla/internal/scheduler/jobs/inventorysync/inventory_test.go
+++ b/rla/internal/scheduler/jobs/inventorysync/inventory_test.go
@@ -82,7 +82,7 @@ func TestInventory(t *testing.T) {
 
 	psmMock := psmapi.NewMockClient()
 	nsmMock := nsmapi.NewMockClient()
-	runInventoryOne(ctx, pool, grpcMock, psmMock, nsmMock, componentmanager.DefaultTestConfig())
+	runInventoryOne(ctx, pool, grpcMock, psmMock, nsmMock, defaultComponentManagerTestConfig())
 
 	rows, err := pool.DB.Query("SELECT serial_number, power_state FROM component;")
 	assert.NotNil(t, rows)
@@ -150,7 +150,7 @@ func TestSyncFirmwareVersion(t *testing.T) {
 
 	psmMock := psmapi.NewMockClient()
 	nsmMock := nsmapi.NewMockClient()
-	runInventoryOne(ctx, pool, grpcMock, psmMock, nsmMock, componentmanager.DefaultTestConfig())
+	runInventoryOne(ctx, pool, grpcMock, psmMock, nsmMock, defaultComponentManagerTestConfig())
 
 	var updated1 model.Component
 	err = pool.DB.NewSelect().Model(&updated1).Where("id = ?", c1.ID).Scan(ctx)
@@ -419,7 +419,7 @@ func TestHandleExpectedPowershelves(t *testing.T) {
 
 	// Run the inventory loop
 	nsmMock := nsmapi.NewMockClient()
-	runInventoryOne(ctx, pool, carbideMock, psmMock, nsmMock, componentmanager.DefaultTestConfig())
+	runInventoryOne(ctx, pool, carbideMock, psmMock, nsmMock, defaultComponentManagerTestConfig())
 
 	// Verify that only expected PMCs that have DHCPed were registered with PSM
 	registeredPowershelves, err := psmMock.GetPowershelves(ctx, []string{})
@@ -742,7 +742,7 @@ func TestHandleExpectedNVSwitches(t *testing.T) {
 	assert.Equal(t, 1, len(preRegistered), "Should have 1 pre-registered switch (SW7)")
 
 	// Run the inventory loop
-	runInventoryOne(ctx, pool, carbideMock, psmMock, nsmMock, componentmanager.DefaultTestConfig())
+	runInventoryOne(ctx, pool, carbideMock, psmMock, nsmMock, defaultComponentManagerTestConfig())
 
 	// --- Verify NSM registrations ---
 	registeredSwitches, err := nsmMock.GetNVSwitches(ctx, nil)
@@ -808,7 +808,7 @@ func TestHandleExpectedNVSwitches(t *testing.T) {
 	nsmMock.SetNVSwitchFirmware("aa:bb:cc:11:11:01", "3.0.0")
 	nsmMock.SetNVSwitchFirmware("aa:bb:cc:11:11:02", "3.1.0")
 
-	runInventoryOne(ctx, pool, carbideMock, psmMock, nsmMock, componentmanager.DefaultTestConfig())
+	runInventoryOne(ctx, pool, carbideMock, psmMock, nsmMock, defaultComponentManagerTestConfig())
 
 	// SW1: external_id and firmware_version should now be set
 	var updatedSw1 model.Component
@@ -862,5 +862,17 @@ func TestHandleExpectedNVSwitches(t *testing.T) {
 			assert.Equal(t, "sw-serial-007", sw7Drift.Diffs[0].ExpectedValue)
 			assert.Equal(t, "actual-serial-007", sw7Drift.Diffs[0].ActualValue)
 		}
+	}
+}
+
+func defaultComponentManagerTestConfig() componentmanager.Config {
+	return componentmanager.Config{
+		ComponentManagers: map[devicetypes.ComponentType]string{
+			devicetypes.ComponentTypeCompute:    "mock",
+			devicetypes.ComponentTypeNVLSwitch:  "mock",
+			devicetypes.ComponentTypePowerShelf: "mock",
+		},
+		Providers:       componentmanager.LegacyProviderConfig{},
+		ProviderConfigs: map[string]componentmanager.ProviderConfig{},
 	}
 }

--- a/rla/internal/task/componentmanager/builtin/provider_config_decoders.go
+++ b/rla/internal/task/componentmanager/builtin/provider_config_decoders.go
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package builtin registers the component manager extensions compiled into the
+// RLA binary.
+package builtin
+
+import (
+	"fmt"
+
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager/providerapi"
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager/providers/carbide"
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager/providers/nvswitchmanager"
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager/providers/psm"
+)
+
+// NewServiceProviderConfigDecoderRegistry creates the provider config decoder
+// registry used by the RLA service.
+func NewServiceProviderConfigDecoderRegistry() (*providerapi.ProviderConfigDecoderRegistry, error) {
+	registry := providerapi.NewProviderConfigDecoderRegistry()
+
+	for _, decoder := range serviceProviderConfigDecoders() {
+		if err := registry.Register(decoder); err != nil {
+			return nil, fmt.Errorf(
+				"register service provider config decoder %q: %w",
+				decoder.Name(),
+				err,
+			)
+		}
+	}
+
+	return registry, nil
+}
+
+// serviceProviderConfigDecoders returns all provider config decoders supported
+// by the RLA service. Add a new provider's decoder here when adding a provider
+// compiled into the service.
+func serviceProviderConfigDecoders() []providerapi.ProviderConfigDecoder {
+	return []providerapi.ProviderConfigDecoder{
+		carbide.ConfigDecoder{},
+		psm.ConfigDecoder{},
+		nvswitchmanager.ConfigDecoder{},
+	}
+}

--- a/rla/internal/task/componentmanager/builtin/provider_config_decoders_test.go
+++ b/rla/internal/task/componentmanager/builtin/provider_config_decoders_test.go
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package builtin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager/providers/carbide"
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager/providers/nvswitchmanager"
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager/providers/psm"
+)
+
+func TestNewServiceProviderConfigDecoderRegistry(t *testing.T) {
+	registry, err := NewServiceProviderConfigDecoderRegistry()
+	require.NoError(t, err)
+
+	assert.ElementsMatch(
+		t,
+		[]string{
+			carbide.ProviderName,
+			psm.ProviderName,
+			nvswitchmanager.ProviderName,
+		},
+		registry.List(),
+	)
+
+	_, ok := registry.Get(carbide.ProviderName)
+	assert.True(t, ok)
+
+	_, ok = registry.Get(psm.ProviderName)
+	assert.True(t, ok)
+
+	_, ok = registry.Get(nvswitchmanager.ProviderName)
+	assert.True(t, ok)
+}

--- a/rla/internal/task/componentmanager/componentmanager_test.go
+++ b/rla/internal/task/componentmanager/componentmanager_test.go
@@ -50,7 +50,6 @@ func TestRegistryGetManager(t *testing.T) {
 		require.True(t, errors.As(err, &managerErr))
 		require.Equal(t, devicetypes.ComponentTypeCompute, managerErr.ComponentType)
 	})
-
 }
 
 func TestRegistryInitializeErrors(t *testing.T) {
@@ -141,14 +140,13 @@ func TestRegistryFindManager(t *testing.T) {
 
 		require.Nil(t, manager)
 	})
-
 }
 
 func TestParseConfigUnknownComponentTypeError(t *testing.T) {
-	_, err := ParseConfig([]byte(`
+	_, err := parseConfigWithBuiltins(t, `
 component_managers:
   madeup: mock
-`))
+`)
 
 	require.Error(t, err)
 	require.True(t, errors.Is(err, ErrUnknownComponentType))

--- a/rla/internal/task/componentmanager/config.go
+++ b/rla/internal/task/componentmanager/config.go
@@ -20,20 +20,23 @@ package componentmanager
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
-	"time"
 
 	"gopkg.in/yaml.v3"
 
+	cmbuiltin "github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager/builtin"
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager/providerapi"
 	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager/providers/carbide"
 	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager/providers/nvswitchmanager"
 	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager/providers/psm"
 	"github.com/NVIDIA/ncx-infra-controller-rest/rla/pkg/common/devicetypes"
 )
 
-// ProviderConfig holds the configuration for API providers.
+// LegacyProviderConfig holds the typed configuration fields used by the
+// current bootstrap path.
 // A nil pointer means the provider is not enabled.
-type ProviderConfig struct {
+type LegacyProviderConfig struct {
 	// Carbide holds Carbide-specific configuration. Nil means disabled.
 	Carbide *carbide.Config
 
@@ -50,36 +53,17 @@ type Config struct {
 	ComponentManagers map[devicetypes.ComponentType]string
 
 	// Providers holds provider-specific configuration.
-	Providers ProviderConfig
+	Providers LegacyProviderConfig
+
+	// ProviderConfigs holds provider-specific typed configs keyed by provider
+	// name. It is the bridge to future generic provider bootstrap.
+	ProviderConfigs map[string]ProviderConfig
 }
 
 // rawConfig is the raw YAML structure before conversion.
 type rawConfig struct {
-	ComponentManagers map[string]string `yaml:"component_managers"`
-	Providers         rawProviderConfig `yaml:"providers"`
-}
-
-// rawProviderConfig is the raw YAML structure for provider configuration.
-type rawProviderConfig struct {
-	Carbide         *rawCarbideConfig         `yaml:"carbide"`
-	PSM             *rawPSMConfig             `yaml:"psm"`
-	NVSwitchManager *rawNVSwitchManagerConfig `yaml:"nvswitchmanager"`
-}
-
-// rawCarbideConfig is the raw YAML structure for Carbide configuration.
-type rawCarbideConfig struct {
-	Timeout           string `yaml:"timeout"`
-	ComputePowerDelay string `yaml:"compute_power_delay"`
-}
-
-// rawPSMConfig is the raw YAML structure for PSM configuration.
-type rawPSMConfig struct {
-	Timeout string `yaml:"timeout"`
-}
-
-// rawNVSwitchManagerConfig is the raw YAML structure for NV-Switch Manager configuration.
-type rawNVSwitchManagerConfig struct {
-	Timeout string `yaml:"timeout"`
+	ComponentManagers map[string]string    `yaml:"component_managers"`
+	Providers         map[string]yaml.Node `yaml:"providers"`
 }
 
 // LoadConfig loads the component manager configuration from a YAML file.
@@ -89,11 +73,28 @@ func LoadConfig(path string) (Config, error) {
 		return Config{}, fmt.Errorf("failed to read config file: %w", err)
 	}
 
-	return ParseConfig(data)
+	// TODO: In the provider bootstrap PR, pass the decoder registry into
+	// LoadConfig instead of constructing the built-in registry here.
+	decoders, err := cmbuiltin.NewServiceProviderConfigDecoderRegistry()
+	if err != nil {
+		return Config{}, fmt.Errorf(
+			"failed to create provider config decoder registry: %w", err,
+		)
+	}
+
+	return ParseConfig(data, decoders)
 }
 
-// ParseConfig parses the component manager configuration from YAML data.
-func ParseConfig(data []byte) (Config, error) {
+// ParseConfig parses the component manager configuration from YAML data using
+// the supplied provider config decoders.
+func ParseConfig(
+	data []byte,
+	decoders *ProviderConfigDecoderRegistry,
+) (Config, error) {
+	if decoders == nil {
+		return Config{}, providerapi.ErrProviderConfigDecoderRegistryNotConfigured
+	}
+
 	var raw rawConfig
 	if err := yaml.Unmarshal(data, &raw); err != nil {
 		return Config{}, fmt.Errorf("failed to parse config: %w", err)
@@ -101,9 +102,10 @@ func ParseConfig(data []byte) (Config, error) {
 
 	config := Config{
 		ComponentManagers: make(map[devicetypes.ComponentType]string),
+		ProviderConfigs:   make(map[string]ProviderConfig),
 	}
 
-	// Parse component managers
+	// Parse component managers.
 	for typeStr, implName := range raw.ComponentManagers {
 		componentType := devicetypes.ComponentTypeFromString(typeStr)
 		if componentType == devicetypes.ComponentTypeUnknown {
@@ -112,99 +114,185 @@ func ParseConfig(data []byte) (Config, error) {
 		config.ComponentManagers[componentType] = strings.TrimSpace(implName)
 	}
 
-	// Parse Carbide config if present in YAML
-	if raw.Providers.Carbide != nil {
-		carbideConfig := &carbide.Config{
-			Timeout:           carbide.DefaultTimeout,
-			ComputePowerDelay: carbide.DefaultComputePowerDelay,
+	if raw.Providers != nil {
+		// Preserve the current config semantics: when a providers section is
+		// present, it is treated as the complete explicit provider set. Missing
+		// providers are not auto-derived here; manager/provider requirement
+		// validation should report those missing dependencies in a later PR.
+		if err := decodeConfiguredProviders(&config, raw.Providers, decoders); err != nil {
+			return Config{}, err
 		}
-		if raw.Providers.Carbide.Timeout != "" {
-			timeout, err := time.ParseDuration(raw.Providers.Carbide.Timeout)
-			if err != nil {
-				return Config{}, fmt.Errorf("invalid carbide timeout: %w", err)
-			}
-			carbideConfig.Timeout = timeout
-		}
-		if raw.Providers.Carbide.ComputePowerDelay != "" {
-			delay, err := time.ParseDuration(raw.Providers.Carbide.ComputePowerDelay)
-			if err != nil {
-				return Config{}, fmt.Errorf(
-					"invalid carbide compute_power_delay: %w", err,
-				)
-			}
-			carbideConfig.ComputePowerDelay = delay
-		}
-		config.Providers.Carbide = carbideConfig
+		return config, nil
 	}
 
-	// Parse PSM config if present in YAML
-	if raw.Providers.PSM != nil {
-		psmConfig := &psm.Config{
-			Timeout: psm.DefaultTimeout,
-		}
-		if raw.Providers.PSM.Timeout != "" {
-			timeout, err := time.ParseDuration(raw.Providers.PSM.Timeout)
-			if err != nil {
-				return Config{}, fmt.Errorf("invalid psm timeout: %w", err)
-			}
-			psmConfig.Timeout = timeout
-		}
-		config.Providers.PSM = psmConfig
-	}
-
-	// Parse NV-Switch Manager config if present in YAML
-	if raw.Providers.NVSwitchManager != nil {
-		nsmConfig := &nvswitchmanager.Config{
-			Timeout: nvswitchmanager.DefaultTimeout,
-		}
-		if raw.Providers.NVSwitchManager.Timeout != "" {
-			timeout, err := time.ParseDuration(raw.Providers.NVSwitchManager.Timeout)
-			if err != nil {
-				return Config{}, fmt.Errorf("invalid nvswitchmanager timeout: %w", err)
-			}
-			nsmConfig.Timeout = timeout
-		}
-		config.Providers.NVSwitchManager = nsmConfig
-	}
-
-	// If no providers are explicitly configured, derive from component manager implementations
-	if config.Providers.Carbide == nil && config.Providers.PSM == nil && config.Providers.NVSwitchManager == nil {
-		deriveProviders(&config)
+	if err := deriveProviders(&config, decoders); err != nil {
+		return Config{}, err
 	}
 
 	return config, nil
 }
 
-// deriveProviders enables providers based on the component manager implementations configured.
-func deriveProviders(config *Config) {
+func decodeConfiguredProviders(
+	config *Config,
+	rawProviders map[string]yaml.Node,
+	decoders *ProviderConfigDecoderRegistry,
+) error {
+	providers, err := normalizeConfiguredProviders(rawProviders)
+	if err != nil {
+		return err
+	}
+
+	for _, provider := range providers {
+		name := provider.name
+		decoder, ok := decoders.Get(name)
+		if !ok {
+			return UnknownProviderError{Name: name}
+		}
+
+		decoded, err := decoder.DecodeYAML(provider.raw)
+		if err != nil {
+			return err
+		}
+
+		if err := applyProviderConfig(config, name, decoded); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type configuredProvider struct {
+	name string
+	raw  yaml.Node
+}
+
+// normalizeConfiguredProviders trims provider names, rejects duplicate
+// normalized names, and returns providers in deterministic order before any
+// provider-specific decoding runs.
+func normalizeConfiguredProviders(
+	rawProviders map[string]yaml.Node,
+) ([]configuredProvider, error) {
+	providersByName := make(map[string]yaml.Node, len(rawProviders))
+	for rawName, rawNode := range rawProviders {
+		name := strings.TrimSpace(rawName)
+		if name == "" {
+			return nil, ErrProviderNameEmpty
+		}
+		if _, exists := providersByName[name]; exists {
+			return nil, DuplicateProviderConfigError{Name: name}
+		}
+		providersByName[name] = rawNode
+	}
+
+	names := make([]string, 0, len(providersByName))
+	for name := range providersByName {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	providers := make([]configuredProvider, 0, len(names))
+	for _, name := range names {
+		providers = append(providers, configuredProvider{
+			name: name,
+			raw:  providersByName[name],
+		})
+	}
+	return providers, nil
+}
+
+// deriveProviders enables providers based on the component manager
+// implementations configured.
+func deriveProviders(config *Config, decoders *ProviderConfigDecoderRegistry) error {
+	for _, name := range deriveProviderNames(*config) {
+		decoder, ok := decoders.Get(name)
+		if !ok {
+			return ProviderConfigDecoderNotRegisteredError{Name: name}
+		}
+
+		if err := applyProviderConfig(config, name, decoder.DefaultConfig()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deriveProviderNames(config Config) []string {
+	// Transitional compatibility shim. The final architecture should derive
+	// required providers from manager descriptors rather than assuming an
+	// implementation name maps directly to a provider name.
+	names := make(map[string]struct{})
 	for _, implName := range config.ComponentManagers {
 		switch implName {
 		case carbide.ProviderName:
-			if config.Providers.Carbide == nil {
-				config.Providers.Carbide = &carbide.Config{
-					Timeout:           carbide.DefaultTimeout,
-					ComputePowerDelay: carbide.DefaultComputePowerDelay,
-				}
-			}
+			names[carbide.ProviderName] = struct{}{}
 		case psm.ProviderName:
-			if config.Providers.PSM == nil {
-				config.Providers.PSM = &psm.Config{
-					Timeout: psm.DefaultTimeout,
-				}
-			}
+			names[psm.ProviderName] = struct{}{}
 		case nvswitchmanager.ProviderName:
-			if config.Providers.NVSwitchManager == nil {
-				config.Providers.NVSwitchManager = &nvswitchmanager.Config{
-					Timeout: nvswitchmanager.DefaultTimeout,
-				}
-			}
-			// mock implementations don't require any providers
+			names[nvswitchmanager.ProviderName] = struct{}{}
 		}
 	}
+
+	result := make([]string, 0, len(names))
+	for name := range names {
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func applyProviderConfig(config *Config, name string, decoded ProviderConfig) error {
+	if config.ProviderConfigs == nil {
+		config.ProviderConfigs = make(map[string]ProviderConfig)
+	}
+	config.ProviderConfigs[name] = decoded
+	return applyLegacyProviderConfig(config, name, decoded)
+}
+
+func applyLegacyProviderConfig(config *Config, name string, decoded ProviderConfig) error {
+	switch name {
+	case carbide.ProviderName:
+		carbideConfig, ok := decoded.(*carbide.Config)
+		if !ok {
+			return ProviderConfigTypeMismatchError{
+				Name: name,
+				Got:  decoded,
+				Want: "*carbide.Config",
+			}
+		}
+		config.Providers.Carbide = carbideConfig
+	case psm.ProviderName:
+		psmConfig, ok := decoded.(*psm.Config)
+		if !ok {
+			return ProviderConfigTypeMismatchError{
+				Name: name,
+				Got:  decoded,
+				Want: "*psm.Config",
+			}
+		}
+		config.Providers.PSM = psmConfig
+	case nvswitchmanager.ProviderName:
+		nsmConfig, ok := decoded.(*nvswitchmanager.Config)
+		if !ok {
+			return ProviderConfigTypeMismatchError{
+				Name: name,
+				Got:  decoded,
+				Want: "*nvswitchmanager.Config",
+			}
+		}
+		config.Providers.NVSwitchManager = nsmConfig
+	}
+
+	return nil
 }
 
 // HasProvider checks if a provider is enabled in the configuration.
 func (c *Config) HasProvider(name string) bool {
+	if c.ProviderConfigs != nil {
+		if _, ok := c.ProviderConfigs[name]; ok {
+			return true
+		}
+	}
+
 	switch name {
 	case carbide.ProviderName:
 		return c.Providers.Carbide != nil
@@ -216,40 +304,32 @@ func (c *Config) HasProvider(name string) bool {
 	return false
 }
 
-// DefaultTestConfig returns the default configuration for testing/development.
-// Uses mock implementations that don't require external services.
-func DefaultTestConfig() Config {
-	return Config{
-		ComponentManagers: map[devicetypes.ComponentType]string{
-			devicetypes.ComponentTypeCompute:    "mock",
-			devicetypes.ComponentTypeNVLSwitch:  "mock",
-			devicetypes.ComponentTypePowerShelf: "mock",
-		},
-		Providers: ProviderConfig{
-			// No providers needed for mock - both nil
-		},
-	}
-}
-
 // DefaultProdConfig returns the embedded production configuration.
 // Used when no config file is specified. Connects to external services
 //
 // Timing parameters for operations are configured per-rule via action parameters.
 func DefaultProdConfig() Config {
+	carbideConfig := &carbide.Config{
+		Timeout:           carbide.DefaultTimeout,
+		ComputePowerDelay: carbide.DefaultComputePowerDelay,
+	}
+	psmConfig := &psm.Config{
+		Timeout: psm.DefaultTimeout,
+	}
+
 	return Config{
 		ComponentManagers: map[devicetypes.ComponentType]string{
 			devicetypes.ComponentTypeCompute:    carbide.ProviderName,
 			devicetypes.ComponentTypeNVLSwitch:  carbide.ProviderName,
 			devicetypes.ComponentTypePowerShelf: carbide.ProviderName,
 		},
-		Providers: ProviderConfig{
-			Carbide: &carbide.Config{
-				Timeout:           carbide.DefaultTimeout,
-				ComputePowerDelay: carbide.DefaultComputePowerDelay,
-			},
-			PSM: &psm.Config{
-				Timeout: psm.DefaultTimeout,
-			},
+		Providers: LegacyProviderConfig{
+			Carbide: carbideConfig,
+			PSM:     psmConfig,
+		},
+		ProviderConfigs: map[string]ProviderConfig{
+			carbide.ProviderName: carbideConfig,
+			psm.ProviderName:     psmConfig,
 		},
 	}
 }

--- a/rla/internal/task/componentmanager/config_test.go
+++ b/rla/internal/task/componentmanager/config_test.go
@@ -1,0 +1,415 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package componentmanager
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	cmbuiltin "github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager/builtin"
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager/providerapi"
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager/providers/carbide"
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager/providers/nvswitchmanager"
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager/providers/psm"
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/pkg/common/devicetypes"
+)
+
+type customProviderConfig struct {
+	name string
+}
+
+func (c customProviderConfig) Name() string {
+	return c.name
+}
+
+func (c customProviderConfig) NewProvider(context.Context) (Provider, error) {
+	return nil, nil
+}
+
+type customProviderConfigDecoder struct {
+	name string
+}
+
+func (d customProviderConfigDecoder) Name() string {
+	return d.name
+}
+
+func (d customProviderConfigDecoder) DefaultConfig() ProviderConfig {
+	return customProviderConfig{name: d.name}
+}
+
+func (d customProviderConfigDecoder) DecodeYAML(raw yaml.Node) (ProviderConfig, error) {
+	return d.DefaultConfig(), nil
+}
+
+func TestParseConfigWithExplicitProviders(t *testing.T) {
+	config, err := parseConfigWithBuiltins(t, `
+component_managers:
+  compute: carbide
+  nvlswitch: nvswitchmanager
+  powershelf: psm
+providers:
+  carbide:
+    timeout: 45s
+    compute_power_delay: 0s
+  psm:
+    timeout: 20s
+  nvswitchmanager:
+    timeout: 90s
+`)
+	require.NoError(t, err)
+
+	assert.Equal(t, carbide.ProviderName, config.ComponentManagers[devicetypes.ComponentTypeCompute])
+	assert.Equal(t, nvswitchmanager.ProviderName, config.ComponentManagers[devicetypes.ComponentTypeNVLSwitch])
+	assert.Equal(t, psm.ProviderName, config.ComponentManagers[devicetypes.ComponentTypePowerShelf])
+
+	require.NotNil(t, config.Providers.Carbide)
+	assert.Equal(t, 45*time.Second, config.Providers.Carbide.Timeout)
+	assert.Equal(t, 0*time.Second, config.Providers.Carbide.ComputePowerDelay)
+
+	require.NotNil(t, config.Providers.PSM)
+	assert.Equal(t, 20*time.Second, config.Providers.PSM.Timeout)
+
+	require.NotNil(t, config.Providers.NVSwitchManager)
+	assert.Equal(t, 90*time.Second, config.Providers.NVSwitchManager.Timeout)
+
+	assert.Same(t, config.Providers.Carbide, config.ProviderConfigs[carbide.ProviderName])
+	assert.Same(t, config.Providers.PSM, config.ProviderConfigs[psm.ProviderName])
+	assert.Same(t, config.Providers.NVSwitchManager, config.ProviderConfigs[nvswitchmanager.ProviderName])
+}
+
+func TestParseConfigDerivesProviders(t *testing.T) {
+	tests := []struct {
+		name        string
+		configYAML  string
+		wantEnabled []string
+	}{
+		{
+			name: "mock managers do not need providers",
+			configYAML: `
+component_managers:
+  compute: mock
+  nvlswitch: mock
+  powershelf: mock
+`,
+			wantEnabled: nil,
+		},
+		{
+			name: "carbide",
+			configYAML: `
+component_managers:
+  compute: carbide
+`,
+			wantEnabled: []string{carbide.ProviderName},
+		},
+		{
+			name: "psm",
+			configYAML: `
+component_managers:
+  powershelf: psm
+`,
+			wantEnabled: []string{psm.ProviderName},
+		},
+		{
+			name: "nvswitchmanager",
+			configYAML: `
+component_managers:
+  nvlswitch: nvswitchmanager
+`,
+			wantEnabled: []string{nvswitchmanager.ProviderName},
+		},
+		{
+			name: "deduplicates providers",
+			configYAML: `
+component_managers:
+  compute: carbide
+  nvlswitch: carbide
+  powershelf: psm
+`,
+			wantEnabled: []string{carbide.ProviderName, psm.ProviderName},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			config, err := parseConfigWithBuiltins(t, tc.configYAML)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tc.wantEnabled, providerConfigNames(config))
+		})
+	}
+}
+
+func TestParseConfigKeepsExplicitProviderBehavior(t *testing.T) {
+	config, err := parseConfigWithBuiltins(t, `
+component_managers:
+  compute: carbide
+  powershelf: psm
+providers:
+  psm:
+    timeout: 20s
+`)
+	require.NoError(t, err)
+
+	assert.Nil(t, config.Providers.Carbide)
+	require.NotNil(t, config.Providers.PSM)
+	assert.Equal(t, 20*time.Second, config.Providers.PSM.Timeout)
+	assert.False(t, config.HasProvider(carbide.ProviderName))
+	assert.True(t, config.HasProvider(psm.ProviderName))
+}
+
+func TestParseConfigTreatsEmptyProvidersAsExplicit(t *testing.T) {
+	config, err := parseConfigWithBuiltins(t, `
+component_managers:
+  compute: carbide
+providers: {}
+`)
+	require.NoError(t, err)
+
+	assert.Empty(t, config.ProviderConfigs)
+	assert.Nil(t, config.Providers.Carbide)
+	assert.False(t, config.HasProvider(carbide.ProviderName))
+}
+
+func TestParseConfigErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		configYAML string
+		wantErr    error
+		checkErr   func(*testing.T, error)
+	}{
+		{
+			name: "unknown provider",
+			configYAML: `
+component_managers:
+  compute: mock
+providers:
+  madeup: {}
+`,
+			wantErr: ErrUnknownProvider,
+			checkErr: func(t *testing.T, err error) {
+				t.Helper()
+				var providerErr UnknownProviderError
+				require.True(t, errors.As(err, &providerErr))
+				assert.Equal(t, "madeup", providerErr.Name)
+			},
+		},
+		{
+			name: "unknown component type",
+			configYAML: `
+component_managers:
+  madeup: mock
+`,
+			wantErr: ErrUnknownComponentType,
+			checkErr: func(t *testing.T, err error) {
+				t.Helper()
+				var componentTypeErr UnknownComponentTypeError
+				require.True(t, errors.As(err, &componentTypeErr))
+				assert.Equal(t, "madeup", componentTypeErr.Name)
+			},
+		},
+		{
+			name: "duplicate provider after trimming name",
+			configYAML: `
+component_managers:
+  compute: mock
+providers:
+  carbide:
+    timeout: 30s
+  " carbide ":
+    timeout: 45s
+`,
+			wantErr: ErrDuplicateProviderConfig,
+			checkErr: func(t *testing.T, err error) {
+				t.Helper()
+				var duplicateErr DuplicateProviderConfigError
+				require.True(t, errors.As(err, &duplicateErr))
+				assert.Equal(t, carbide.ProviderName, duplicateErr.Name)
+			},
+		},
+		{
+			name: "invalid carbide timeout",
+			configYAML: `
+component_managers:
+  compute: mock
+providers:
+  carbide:
+    timeout: nope
+`,
+			wantErr: providerapi.ErrInvalidProviderConfigField,
+			checkErr: func(t *testing.T, err error) {
+				t.Helper()
+				assertInvalidProviderConfigField(t, err, carbide.ProviderName, "timeout")
+			},
+		},
+		{
+			name: "invalid psm timeout",
+			configYAML: `
+component_managers:
+  compute: mock
+providers:
+  psm:
+    timeout: nope
+`,
+			wantErr: providerapi.ErrInvalidProviderConfigField,
+			checkErr: func(t *testing.T, err error) {
+				t.Helper()
+				assertInvalidProviderConfigField(t, err, psm.ProviderName, "timeout")
+			},
+		},
+		{
+			name: "invalid nvswitchmanager timeout",
+			configYAML: `
+component_managers:
+  compute: mock
+providers:
+  nvswitchmanager:
+    timeout: nope
+`,
+			wantErr: providerapi.ErrInvalidProviderConfigField,
+			checkErr: func(t *testing.T, err error) {
+				t.Helper()
+				assertInvalidProviderConfigField(t, err, nvswitchmanager.ProviderName, "timeout")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseConfigWithBuiltins(t, tc.configYAML)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, tc.wantErr))
+			if tc.checkErr != nil {
+				tc.checkErr(t, err)
+			}
+		})
+	}
+}
+
+func TestParseConfigAllowsCustomProviderDecoderRegistry(t *testing.T) {
+	registry := providerapi.NewProviderConfigDecoderRegistry()
+	require.NoError(t, registry.Register(customProviderConfigDecoder{name: "custom"}))
+
+	config, err := ParseConfig([]byte(`
+component_managers:
+  compute: mock
+providers:
+  custom: {}
+`), registry)
+	require.NoError(t, err)
+
+	assert.True(t, config.HasProvider("custom"))
+	assert.Equal(t, customProviderConfig{name: "custom"}, config.ProviderConfigs["custom"])
+	assert.Nil(t, config.Providers.Carbide)
+	assert.Nil(t, config.Providers.PSM)
+	assert.Nil(t, config.Providers.NVSwitchManager)
+}
+
+func TestParseConfigRequiresDecoderRegistry(t *testing.T) {
+	_, err := ParseConfig([]byte(`component_managers: {}`), nil)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, providerapi.ErrProviderConfigDecoderRegistryNotConfigured))
+}
+
+func assertInvalidProviderConfigField(
+	t *testing.T,
+	err error,
+	provider string,
+	field string,
+) {
+	t.Helper()
+
+	var fieldErr providerapi.InvalidProviderConfigFieldError
+	require.True(t, errors.As(err, &fieldErr))
+	assert.Equal(t, provider, fieldErr.Provider)
+	assert.Equal(t, field, fieldErr.Field)
+}
+
+func TestHasProviderFallsBackToLegacyFields(t *testing.T) {
+	config := Config{
+		Providers: LegacyProviderConfig{
+			Carbide: &carbide.Config{},
+		},
+	}
+
+	assert.True(t, config.HasProvider(carbide.ProviderName))
+	assert.False(t, config.HasProvider(psm.ProviderName))
+}
+
+func TestDefaultConfigCompatibility(t *testing.T) {
+	prod := DefaultProdConfig()
+	require.NotNil(t, prod.Providers.Carbide)
+	require.NotNil(t, prod.Providers.PSM)
+	assert.True(t, prod.HasProvider(carbide.ProviderName))
+	assert.True(t, prod.HasProvider(psm.ProviderName))
+
+	testConfig := defaultTestConfig()
+	assert.Nil(t, testConfig.Providers.Carbide)
+	assert.Nil(t, testConfig.Providers.PSM)
+	assert.Nil(t, testConfig.Providers.NVSwitchManager)
+	assert.False(t, testConfig.HasProvider(carbide.ProviderName))
+}
+
+func TestLoadConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "componentmanager.yaml")
+	err := os.WriteFile(path, []byte(`
+component_managers:
+  compute: carbide
+`), 0o600)
+	require.NoError(t, err)
+
+	config, err := LoadConfig(path)
+	require.NoError(t, err)
+	assert.True(t, config.HasProvider(carbide.ProviderName))
+}
+
+func providerConfigNames(config Config) []string {
+	names := make([]string, 0, len(config.ProviderConfigs))
+	for name := range config.ProviderConfigs {
+		names = append(names, name)
+	}
+	return names
+}
+
+func parseConfigWithBuiltins(t *testing.T, data string) (Config, error) {
+	t.Helper()
+	decoders, err := cmbuiltin.NewServiceProviderConfigDecoderRegistry()
+	if err != nil {
+		return Config{}, err
+	}
+	return ParseConfig([]byte(data), decoders)
+}
+
+func defaultTestConfig() Config {
+	return Config{
+		ComponentManagers: map[devicetypes.ComponentType]string{
+			devicetypes.ComponentTypeCompute:    "mock",
+			devicetypes.ComponentTypeNVLSwitch:  "mock",
+			devicetypes.ComponentTypePowerShelf: "mock",
+		},
+		Providers:       LegacyProviderConfig{},
+		ProviderConfigs: map[string]ProviderConfig{},
+	}
+}

--- a/rla/internal/task/componentmanager/errors.go
+++ b/rla/internal/task/componentmanager/errors.go
@@ -52,13 +52,28 @@ var (
 	// available.
 	ErrProviderRegistryNotConfigured = errors.New("provider registry is not configured")
 
-	// ErrUnknownProvider reports that a required provider is missing from the
-	// provider registry.
+	// ErrUnknownProvider reports that a provider name is not known in the
+	// current provider context.
 	ErrUnknownProvider = errors.New("unknown provider")
 
 	// ErrProviderTypeMismatch reports that a provider exists but has a different
 	// concrete type than the caller requested.
 	ErrProviderTypeMismatch = errors.New("provider type mismatch")
+
+	// ErrProviderNameEmpty reports an empty provider name in configuration.
+	ErrProviderNameEmpty = errors.New("provider name is empty")
+
+	// ErrDuplicateProviderConfig reports duplicate provider configuration after
+	// provider names are normalized.
+	ErrDuplicateProviderConfig = errors.New("duplicate provider config")
+
+	// ErrProviderConfigDecoderNotRegistered reports that a provider is required
+	// but no config decoder is registered for it.
+	ErrProviderConfigDecoderNotRegistered = errors.New("provider config decoder is not registered")
+
+	// ErrProviderConfigTypeMismatch reports that a provider config decoder
+	// returned the wrong typed config for the provider.
+	ErrProviderConfigTypeMismatch = errors.New("provider config type mismatch")
 )
 
 // ManagerNotConfiguredError includes the component type that has no active
@@ -159,13 +174,13 @@ func (e UnknownComponentTypeError) Is(target error) bool {
 	return target == ErrUnknownComponentType
 }
 
-// UnknownProviderError includes the missing provider name.
+// UnknownProviderError includes the unknown provider name.
 type UnknownProviderError struct {
 	Name string
 }
 
 func (e UnknownProviderError) Error() string {
-	return fmt.Sprintf("provider '%s' not found", e.Name)
+	return fmt.Sprintf("%s: %s", ErrUnknownProvider, e.Name)
 }
 
 func (e UnknownProviderError) Is(target error) bool {
@@ -184,4 +199,52 @@ func (e ProviderTypeMismatchError) Error() string {
 
 func (e ProviderTypeMismatchError) Is(target error) bool {
 	return target == ErrProviderTypeMismatch
+}
+
+// DuplicateProviderConfigError includes the normalized duplicate provider name.
+type DuplicateProviderConfigError struct {
+	Name string
+}
+
+func (e DuplicateProviderConfigError) Error() string {
+	return fmt.Sprintf("duplicate provider config for %q", e.Name)
+}
+
+func (e DuplicateProviderConfigError) Is(target error) bool {
+	return target == ErrDuplicateProviderConfig
+}
+
+// ProviderConfigDecoderNotRegisteredError includes the provider name with no
+// registered config decoder.
+type ProviderConfigDecoderNotRegisteredError struct {
+	Name string
+}
+
+func (e ProviderConfigDecoderNotRegisteredError) Error() string {
+	return fmt.Sprintf("provider config decoder %q is not registered", e.Name)
+}
+
+func (e ProviderConfigDecoderNotRegisteredError) Is(target error) bool {
+	return target == ErrProviderConfigDecoderNotRegistered
+}
+
+// ProviderConfigTypeMismatchError includes the provider config type returned by
+// a decoder and the type expected by the current bootstrap path.
+type ProviderConfigTypeMismatchError struct {
+	Name string
+	Got  any
+	Want string
+}
+
+func (e ProviderConfigTypeMismatchError) Error() string {
+	return fmt.Sprintf(
+		"provider %q returned config type %T, want %s",
+		e.Name,
+		e.Got,
+		e.Want,
+	)
+}
+
+func (e ProviderConfigTypeMismatchError) Is(target error) bool {
+	return target == ErrProviderConfigTypeMismatch
 }

--- a/rla/internal/task/componentmanager/provider.go
+++ b/rla/internal/task/componentmanager/provider.go
@@ -21,14 +21,24 @@ import (
 	"sync"
 
 	"github.com/rs/zerolog/log"
+
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager/providerapi"
 )
 
 // Provider is a marker interface for API client providers.
 // Each provider wraps an API client and exposes it to component manager implementations.
-type Provider interface {
-	// Name returns the unique identifier for this provider type.
-	Name() string
-}
+type Provider = providerapi.Provider
+
+// ProviderConfig is a decoded provider-specific configuration that can create
+// its provider.
+type ProviderConfig = providerapi.ProviderConfig
+
+// ProviderConfigDecoder owns provider-specific config defaults and YAML
+// decoding.
+type ProviderConfigDecoder = providerapi.ProviderConfigDecoder
+
+// ProviderConfigDecoderRegistry manages provider config decoders by provider name.
+type ProviderConfigDecoderRegistry = providerapi.ProviderConfigDecoderRegistry
 
 // ProviderRegistry manages API providers for component manager implementations.
 // It allows implementations to request their required providers by name.

--- a/rla/internal/task/componentmanager/providerapi/errors.go
+++ b/rla/internal/task/componentmanager/providerapi/errors.go
@@ -1,0 +1,107 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package providerapi
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrProviderConfigDecoderRegistryNotConfigured reports that a decoder
+	// registry was required but not configured.
+	ErrProviderConfigDecoderRegistryNotConfigured = errors.New("provider config decoder registry is not configured")
+
+	// ErrProviderConfigDecoderNotConfigured reports that a nil decoder was
+	// provided for registration.
+	ErrProviderConfigDecoderNotConfigured = errors.New("provider config decoder is not configured")
+
+	// ErrProviderConfigDecoderNameEmpty reports that a decoder returned an empty
+	// provider name.
+	ErrProviderConfigDecoderNameEmpty = errors.New("provider config decoder name is empty")
+
+	// ErrProviderConfigDecoderAlreadyRegistered reports a duplicate decoder
+	// registration.
+	ErrProviderConfigDecoderAlreadyRegistered = errors.New("provider config decoder already registered")
+
+	// ErrInvalidProviderConfig reports that provider-specific YAML was invalid.
+	ErrInvalidProviderConfig = errors.New("invalid provider config")
+
+	// ErrInvalidProviderConfigField reports that a provider config field value
+	// was invalid.
+	ErrInvalidProviderConfigField = errors.New("invalid provider config field")
+)
+
+// ProviderConfigDecoderAlreadyRegisteredError includes the duplicate provider
+// decoder name.
+type ProviderConfigDecoderAlreadyRegisteredError struct {
+	Name string
+}
+
+func (e ProviderConfigDecoderAlreadyRegisteredError) Error() string {
+	return fmt.Sprintf("provider config decoder %q already registered", e.Name)
+}
+
+func (e ProviderConfigDecoderAlreadyRegisteredError) Is(target error) bool {
+	return target == ErrProviderConfigDecoderAlreadyRegistered
+}
+
+// InvalidProviderConfigError wraps provider-specific YAML decode errors.
+type InvalidProviderConfigError struct {
+	Provider string
+	Err      error
+}
+
+func (e InvalidProviderConfigError) Error() string {
+	msg := fmt.Sprintf("invalid %s config", e.Provider)
+	if e.Err == nil {
+		return msg
+	}
+	return fmt.Sprintf("%s: %v", msg, e.Err)
+}
+
+func (e InvalidProviderConfigError) Unwrap() error {
+	return e.Err
+}
+
+func (e InvalidProviderConfigError) Is(target error) bool {
+	return target == ErrInvalidProviderConfig
+}
+
+// InvalidProviderConfigFieldError wraps invalid provider config field values.
+type InvalidProviderConfigFieldError struct {
+	Provider string
+	Field    string
+	Err      error
+}
+
+func (e InvalidProviderConfigFieldError) Error() string {
+	msg := fmt.Sprintf("invalid %s %s", e.Provider, e.Field)
+	if e.Err == nil {
+		return msg
+	}
+	return fmt.Sprintf("%s: %v", msg, e.Err)
+}
+
+func (e InvalidProviderConfigFieldError) Unwrap() error {
+	return e.Err
+}
+
+func (e InvalidProviderConfigFieldError) Is(target error) bool {
+	return target == ErrInvalidProviderConfigField
+}

--- a/rla/internal/task/componentmanager/providerapi/providerapi.go
+++ b/rla/internal/task/componentmanager/providerapi/providerapi.go
@@ -1,0 +1,143 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package providerapi contains provider abstractions that must be shared
+// between the componentmanager package and provider implementation packages
+// without creating an import cycle.
+package providerapi
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Provider is a marker interface for API client providers.
+// Each provider wraps an API client and exposes it to component manager
+// implementations.
+type Provider interface {
+	// Name returns the unique identifier for this provider type.
+	Name() string
+}
+
+// ProviderConfig is a decoded provider-specific configuration that can create
+// its provider.
+type ProviderConfig interface {
+	// Name returns the provider name for this config.
+	Name() string
+
+	// NewProvider creates a provider using this config.
+	NewProvider(context.Context) (Provider, error)
+}
+
+// ProviderConfigDecoder owns provider-specific config defaults and YAML
+// decoding. Provider construction belongs to the decoded ProviderConfig.
+type ProviderConfigDecoder interface {
+	// Name returns the provider name handled by this decoder.
+	Name() string
+
+	// DefaultConfig returns a typed default config for this provider.
+	DefaultConfig() ProviderConfig
+
+	// DecodeYAML decodes a provider-specific YAML node into a typed config.
+	DecodeYAML(raw yaml.Node) (ProviderConfig, error)
+}
+
+// DecodeYAMLStrict decodes a YAML node into out and rejects unknown fields.
+// An empty node is treated as "no provider-specific YAML"; callers keep their
+// default config values in that case.
+func DecodeYAMLStrict(raw yaml.Node, out any) error {
+	if raw.Kind == 0 {
+		return nil
+	}
+
+	data, err := yaml.Marshal(&raw)
+	if err != nil {
+		return fmt.Errorf("marshal YAML node: %w", err)
+	}
+
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+
+	return decoder.Decode(out)
+}
+
+// ProviderConfigDecoderRegistry manages provider config decoders by provider name.
+type ProviderConfigDecoderRegistry struct {
+	mu       sync.RWMutex
+	decoders map[string]ProviderConfigDecoder
+}
+
+// NewProviderConfigDecoderRegistry creates a new ProviderConfigDecoderRegistry instance.
+func NewProviderConfigDecoderRegistry() *ProviderConfigDecoderRegistry {
+	return &ProviderConfigDecoderRegistry{
+		decoders: make(map[string]ProviderConfigDecoder),
+	}
+}
+
+// Register adds a provider config decoder to the registry.
+// It returns an error when the decoder cannot be registered so bootstrap code
+// can fail fast instead of losing the failure in logs.
+func (r *ProviderConfigDecoderRegistry) Register(decoder ProviderConfigDecoder) error {
+	if r == nil {
+		return ErrProviderConfigDecoderRegistryNotConfigured
+	}
+
+	if decoder == nil {
+		return ErrProviderConfigDecoderNotConfigured
+	}
+
+	name := strings.TrimSpace(decoder.Name())
+	if name == "" {
+		return ErrProviderConfigDecoderNameEmpty
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.decoders[name]; exists {
+		return ProviderConfigDecoderAlreadyRegisteredError{Name: name}
+	}
+
+	r.decoders[name] = decoder
+	return nil
+}
+
+// Get retrieves a provider config decoder by name.
+func (r *ProviderConfigDecoderRegistry) Get(name string) (ProviderConfigDecoder, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	decoder, ok := r.decoders[name]
+	return decoder, ok
+}
+
+// List returns the names of all registered provider config decoders.
+func (r *ProviderConfigDecoderRegistry) List() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	names := make([]string, 0, len(r.decoders))
+	for name := range r.decoders {
+		names = append(names, name)
+	}
+	return names
+}

--- a/rla/internal/task/componentmanager/providerapi/providerapi_test.go
+++ b/rla/internal/task/componentmanager/providerapi/providerapi_test.go
@@ -1,0 +1,109 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package providerapi
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+type testProvider struct {
+	name string
+}
+
+func (p testProvider) Name() string {
+	return p.name
+}
+
+type testProviderConfig struct {
+	name string
+}
+
+func (c testProviderConfig) Name() string {
+	return c.name
+}
+
+func (c testProviderConfig) NewProvider(context.Context) (Provider, error) {
+	return testProvider{name: c.name}, nil
+}
+
+type testProviderConfigDecoder struct {
+	name string
+}
+
+func (d testProviderConfigDecoder) Name() string {
+	return d.name
+}
+
+func (d testProviderConfigDecoder) DefaultConfig() ProviderConfig {
+	return testProviderConfig{name: d.name}
+}
+
+func (d testProviderConfigDecoder) DecodeYAML(raw yaml.Node) (ProviderConfig, error) {
+	return d.DefaultConfig(), nil
+}
+
+func TestProviderConfigDecoderRegistry(t *testing.T) {
+	registry := NewProviderConfigDecoderRegistry()
+	decoder := testProviderConfigDecoder{name: "test"}
+
+	require.NoError(t, registry.Register(decoder))
+	err := registry.Register(decoder)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrProviderConfigDecoderAlreadyRegistered))
+
+	var duplicateErr ProviderConfigDecoderAlreadyRegisteredError
+	require.True(t, errors.As(err, &duplicateErr))
+	assert.Equal(t, "test", duplicateErr.Name)
+
+	got, ok := registry.Get("test")
+	require.True(t, ok)
+	assert.Equal(t, "test", got.Name())
+
+	_, ok = registry.Get("missing")
+	assert.False(t, ok)
+
+	assert.ElementsMatch(t, []string{"test"}, registry.List())
+
+	config := got.DefaultConfig()
+	provider, err := config.NewProvider(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "test", provider.Name())
+}
+
+func TestProviderConfigDecoderRegistryRegisterValidation(t *testing.T) {
+	registry := NewProviderConfigDecoderRegistry()
+
+	err := registry.Register(nil)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrProviderConfigDecoderNotConfigured))
+
+	err = registry.Register(testProviderConfigDecoder{})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrProviderConfigDecoderNameEmpty))
+
+	var nilRegistry *ProviderConfigDecoderRegistry
+	err = nilRegistry.Register(testProviderConfigDecoder{name: "test"})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrProviderConfigDecoderRegistryNotConfigured))
+}

--- a/rla/internal/task/componentmanager/providers/carbide/provider.go
+++ b/rla/internal/task/componentmanager/providers/carbide/provider.go
@@ -18,11 +18,14 @@
 package carbide
 
 import (
+	"context"
 	"time"
 
 	"github.com/rs/zerolog/log"
+	"gopkg.in/yaml.v3"
 
 	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/carbideapi"
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager/providerapi"
 )
 
 const (
@@ -49,6 +52,79 @@ type Config struct {
 	ComputePowerDelay time.Duration
 }
 
+type rawConfig struct {
+	Timeout           string `yaml:"timeout"`
+	ComputePowerDelay string `yaml:"compute_power_delay"`
+}
+
+// Name returns the provider name for this config.
+func (*Config) Name() string {
+	return ProviderName
+}
+
+// NewProvider creates a Carbide provider from this config.
+func (c *Config) NewProvider(ctx context.Context) (providerapi.Provider, error) {
+	// TODO: Thread ctx into carbideapi client creation if provider construction
+	// starts performing cancellable work.
+	_ = ctx
+	return New(*c)
+}
+
+// ConfigDecoder owns Carbide provider config defaults and YAML decoding.
+type ConfigDecoder struct{}
+
+// Name returns the provider name handled by this decoder.
+func (ConfigDecoder) Name() string {
+	return ProviderName
+}
+
+// DefaultConfig returns the default Carbide provider config.
+func (ConfigDecoder) DefaultConfig() providerapi.ProviderConfig {
+	return &Config{
+		Timeout:           DefaultTimeout,
+		ComputePowerDelay: DefaultComputePowerDelay,
+	}
+}
+
+// DecodeYAML decodes Carbide provider YAML into a typed config.
+func (d ConfigDecoder) DecodeYAML(raw yaml.Node) (providerapi.ProviderConfig, error) {
+	config := d.DefaultConfig().(*Config)
+
+	var parsed rawConfig
+	if err := providerapi.DecodeYAMLStrict(raw, &parsed); err != nil {
+		return nil, providerapi.InvalidProviderConfigError{
+			Provider: ProviderName,
+			Err:      err,
+		}
+	}
+
+	if parsed.Timeout != "" {
+		timeout, err := time.ParseDuration(parsed.Timeout)
+		if err != nil {
+			return nil, providerapi.InvalidProviderConfigFieldError{
+				Provider: ProviderName,
+				Field:    "timeout",
+				Err:      err,
+			}
+		}
+		config.Timeout = timeout
+	}
+
+	if parsed.ComputePowerDelay != "" {
+		delay, err := time.ParseDuration(parsed.ComputePowerDelay)
+		if err != nil {
+			return nil, providerapi.InvalidProviderConfigFieldError{
+				Provider: ProviderName,
+				Field:    "compute_power_delay",
+				Err:      err,
+			}
+		}
+		config.ComputePowerDelay = delay
+	}
+
+	return config, nil
+}
+
 // Provider wraps a carbideapi.Client and provides it to component manager
 // implementations.
 type Provider struct {
@@ -68,9 +144,8 @@ func New(config Config) (*Provider, error) {
 
 // NewWithDefault creates a new Provider with the default configuration.
 func NewWithDefault() (*Provider, error) {
-	return New(Config{
-		Timeout: DefaultTimeout,
-	})
+	cfg := ConfigDecoder{}.DefaultConfig().(*Config)
+	return New(*cfg)
 }
 
 // NewFromClient creates a Provider from an existing client.

--- a/rla/internal/task/componentmanager/providers/carbide/provider_test.go
+++ b/rla/internal/task/componentmanager/providers/carbide/provider_test.go
@@ -1,0 +1,89 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package carbide
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager/providerapi"
+)
+
+func TestConfigName(t *testing.T) {
+	assert.Equal(t, ProviderName, (&Config{}).Name())
+}
+
+func TestConfigDecoderDecodeYAML(t *testing.T) {
+	decoder := ConfigDecoder{}
+
+	decoded, err := decoder.DecodeYAML(yaml.Node{})
+	require.NoError(t, err)
+	config := decoded.(*Config)
+	assert.Equal(t, DefaultTimeout, config.Timeout)
+	assert.Equal(t, DefaultComputePowerDelay, config.ComputePowerDelay)
+
+	decoded, err = decoder.DecodeYAML(providerYAMLNode(t, `
+timeout: 15s
+compute_power_delay: 0s
+`))
+	require.NoError(t, err)
+	config = decoded.(*Config)
+	assert.Equal(t, 15*time.Second, config.Timeout)
+	assert.Equal(t, 0*time.Second, config.ComputePowerDelay)
+
+	_, err = decoder.DecodeYAML(providerYAMLNode(t, `timeout: nope`))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, providerapi.ErrInvalidProviderConfigField))
+	assertInvalidConfigField(t, err, "timeout")
+
+	_, err = decoder.DecodeYAML(providerYAMLNode(t, `compute_power_delay: nope`))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, providerapi.ErrInvalidProviderConfigField))
+	assertInvalidConfigField(t, err, "compute_power_delay")
+
+	_, err = decoder.DecodeYAML(providerYAMLNode(t, `timout: 15s`))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, providerapi.ErrInvalidProviderConfig))
+
+	var configErr providerapi.InvalidProviderConfigError
+	require.True(t, errors.As(err, &configErr))
+	assert.Equal(t, ProviderName, configErr.Provider)
+}
+
+func assertInvalidConfigField(t *testing.T, err error, field string) {
+	t.Helper()
+
+	var fieldErr providerapi.InvalidProviderConfigFieldError
+	require.True(t, errors.As(err, &fieldErr))
+	assert.Equal(t, ProviderName, fieldErr.Provider)
+	assert.Equal(t, field, fieldErr.Field)
+}
+
+func providerYAMLNode(t *testing.T, data string) yaml.Node {
+	t.Helper()
+
+	var node yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(data), &node))
+	require.NotEmpty(t, node.Content)
+	return *node.Content[0]
+}

--- a/rla/internal/task/componentmanager/providers/nvswitchmanager/provider.go
+++ b/rla/internal/task/componentmanager/providers/nvswitchmanager/provider.go
@@ -17,11 +17,14 @@
 package nvswitchmanager
 
 import (
+	"context"
 	"time"
 
 	"github.com/rs/zerolog/log"
+	"gopkg.in/yaml.v3"
 
 	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/nsmapi"
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager/providerapi"
 )
 
 const (
@@ -36,6 +39,66 @@ const (
 type Config struct {
 	// Timeout is the gRPC call timeout for NV-Switch Manager operations.
 	Timeout time.Duration
+}
+
+type rawConfig struct {
+	Timeout string `yaml:"timeout"`
+}
+
+// Name returns the provider name for this config.
+func (*Config) Name() string {
+	return ProviderName
+}
+
+// NewProvider creates an NV-Switch Manager provider from this config.
+func (c *Config) NewProvider(ctx context.Context) (providerapi.Provider, error) {
+	// TODO: Thread ctx into nsmapi client creation if provider construction
+	// starts performing cancellable work.
+	_ = ctx
+	return New(*c)
+}
+
+// ConfigDecoder owns NV-Switch Manager provider config defaults and YAML
+// decoding.
+type ConfigDecoder struct{}
+
+// Name returns the provider name handled by this decoder.
+func (ConfigDecoder) Name() string {
+	return ProviderName
+}
+
+// DefaultConfig returns the default NV-Switch Manager provider config.
+func (ConfigDecoder) DefaultConfig() providerapi.ProviderConfig {
+	return &Config{
+		Timeout: DefaultTimeout,
+	}
+}
+
+// DecodeYAML decodes NV-Switch Manager provider YAML into a typed config.
+func (d ConfigDecoder) DecodeYAML(raw yaml.Node) (providerapi.ProviderConfig, error) {
+	config := d.DefaultConfig().(*Config)
+
+	var parsed rawConfig
+	if err := providerapi.DecodeYAMLStrict(raw, &parsed); err != nil {
+		return nil, providerapi.InvalidProviderConfigError{
+			Provider: ProviderName,
+			Err:      err,
+		}
+	}
+
+	if parsed.Timeout != "" {
+		timeout, err := time.ParseDuration(parsed.Timeout)
+		if err != nil {
+			return nil, providerapi.InvalidProviderConfigFieldError{
+				Provider: ProviderName,
+				Field:    "timeout",
+				Err:      err,
+			}
+		}
+		config.Timeout = timeout
+	}
+
+	return config, nil
 }
 
 // Provider wraps an nsmapi.Client and provides it to component manager implementations.
@@ -56,9 +119,8 @@ func New(config Config) (*Provider, error) {
 
 // NewWithDefault creates a new Provider with the default configuration.
 func NewWithDefault() (*Provider, error) {
-	return New(Config{
-		Timeout: DefaultTimeout,
-	})
+	cfg := ConfigDecoder{}.DefaultConfig().(*Config)
+	return New(*cfg)
 }
 
 // NewFromClient creates a Provider from an existing client.

--- a/rla/internal/task/componentmanager/providers/nvswitchmanager/provider_test.go
+++ b/rla/internal/task/componentmanager/providers/nvswitchmanager/provider_test.go
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nvswitchmanager
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager/providerapi"
+)
+
+func TestConfigName(t *testing.T) {
+	assert.Equal(t, ProviderName, (&Config{}).Name())
+}
+
+func TestConfigDecoderDecodeYAML(t *testing.T) {
+	decoder := ConfigDecoder{}
+
+	decoded, err := decoder.DecodeYAML(yaml.Node{})
+	require.NoError(t, err)
+	config := decoded.(*Config)
+	assert.Equal(t, DefaultTimeout, config.Timeout)
+
+	decoded, err = decoder.DecodeYAML(providerYAMLNode(t, `timeout: 15s`))
+	require.NoError(t, err)
+	config = decoded.(*Config)
+	assert.Equal(t, 15*time.Second, config.Timeout)
+
+	_, err = decoder.DecodeYAML(providerYAMLNode(t, `timeout: nope`))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, providerapi.ErrInvalidProviderConfigField))
+	assertInvalidConfigField(t, err, "timeout")
+
+	_, err = decoder.DecodeYAML(providerYAMLNode(t, `timout: 15s`))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, providerapi.ErrInvalidProviderConfig))
+
+	var configErr providerapi.InvalidProviderConfigError
+	require.True(t, errors.As(err, &configErr))
+	assert.Equal(t, ProviderName, configErr.Provider)
+}
+
+func assertInvalidConfigField(t *testing.T, err error, field string) {
+	t.Helper()
+
+	var fieldErr providerapi.InvalidProviderConfigFieldError
+	require.True(t, errors.As(err, &fieldErr))
+	assert.Equal(t, ProviderName, fieldErr.Provider)
+	assert.Equal(t, field, fieldErr.Field)
+}
+
+func providerYAMLNode(t *testing.T, data string) yaml.Node {
+	t.Helper()
+
+	var node yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(data), &node))
+	require.NotEmpty(t, node.Content)
+	return *node.Content[0]
+}

--- a/rla/internal/task/componentmanager/providers/psm/provider.go
+++ b/rla/internal/task/componentmanager/providers/psm/provider.go
@@ -18,11 +18,14 @@
 package psm
 
 import (
+	"context"
 	"time"
 
 	"github.com/rs/zerolog/log"
+	"gopkg.in/yaml.v3"
 
 	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/psmapi"
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager/providerapi"
 )
 
 const (
@@ -37,6 +40,65 @@ const (
 type Config struct {
 	// Timeout is the gRPC call timeout for PSM operations.
 	Timeout time.Duration
+}
+
+type rawConfig struct {
+	Timeout string `yaml:"timeout"`
+}
+
+// Name returns the provider name for this config.
+func (*Config) Name() string {
+	return ProviderName
+}
+
+// NewProvider creates a PSM provider from this config.
+func (c *Config) NewProvider(ctx context.Context) (providerapi.Provider, error) {
+	// TODO: Thread ctx into psmapi client creation if provider construction
+	// starts performing cancellable work.
+	_ = ctx
+	return New(*c)
+}
+
+// ConfigDecoder owns PSM provider config defaults and YAML decoding.
+type ConfigDecoder struct{}
+
+// Name returns the provider name handled by this decoder.
+func (ConfigDecoder) Name() string {
+	return ProviderName
+}
+
+// DefaultConfig returns the default PSM provider config.
+func (ConfigDecoder) DefaultConfig() providerapi.ProviderConfig {
+	return &Config{
+		Timeout: DefaultTimeout,
+	}
+}
+
+// DecodeYAML decodes PSM provider YAML into a typed config.
+func (d ConfigDecoder) DecodeYAML(raw yaml.Node) (providerapi.ProviderConfig, error) {
+	config := d.DefaultConfig().(*Config)
+
+	var parsed rawConfig
+	if err := providerapi.DecodeYAMLStrict(raw, &parsed); err != nil {
+		return nil, providerapi.InvalidProviderConfigError{
+			Provider: ProviderName,
+			Err:      err,
+		}
+	}
+
+	if parsed.Timeout != "" {
+		timeout, err := time.ParseDuration(parsed.Timeout)
+		if err != nil {
+			return nil, providerapi.InvalidProviderConfigFieldError{
+				Provider: ProviderName,
+				Field:    "timeout",
+				Err:      err,
+			}
+		}
+		config.Timeout = timeout
+	}
+
+	return config, nil
 }
 
 // Provider wraps a psmapi.Client and provides it to component manager implementations.
@@ -57,9 +119,8 @@ func New(config Config) (*Provider, error) {
 
 // NewWithDefault creates a new Provider with the default configuration.
 func NewWithDefault() (*Provider, error) {
-	return New(Config{
-		Timeout: DefaultTimeout,
-	})
+	cfg := ConfigDecoder{}.DefaultConfig().(*Config)
+	return New(*cfg)
 }
 
 // NewFromClient creates a Provider from an existing client.

--- a/rla/internal/task/componentmanager/providers/psm/provider_test.go
+++ b/rla/internal/task/componentmanager/providers/psm/provider_test.go
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package psm
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/NVIDIA/ncx-infra-controller-rest/rla/internal/task/componentmanager/providerapi"
+)
+
+func TestConfigName(t *testing.T) {
+	assert.Equal(t, ProviderName, (&Config{}).Name())
+}
+
+func TestConfigDecoderDecodeYAML(t *testing.T) {
+	decoder := ConfigDecoder{}
+
+	decoded, err := decoder.DecodeYAML(yaml.Node{})
+	require.NoError(t, err)
+	config := decoded.(*Config)
+	assert.Equal(t, DefaultTimeout, config.Timeout)
+
+	decoded, err = decoder.DecodeYAML(providerYAMLNode(t, `timeout: 15s`))
+	require.NoError(t, err)
+	config = decoded.(*Config)
+	assert.Equal(t, 15*time.Second, config.Timeout)
+
+	_, err = decoder.DecodeYAML(providerYAMLNode(t, `timeout: nope`))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, providerapi.ErrInvalidProviderConfigField))
+	assertInvalidConfigField(t, err, "timeout")
+
+	_, err = decoder.DecodeYAML(providerYAMLNode(t, `Time_out: 15s`))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, providerapi.ErrInvalidProviderConfig))
+
+	var configErr providerapi.InvalidProviderConfigError
+	require.True(t, errors.As(err, &configErr))
+	assert.Equal(t, ProviderName, configErr.Provider)
+}
+
+func assertInvalidConfigField(t *testing.T, err error, field string) {
+	t.Helper()
+
+	var fieldErr providerapi.InvalidProviderConfigFieldError
+	require.True(t, errors.As(err, &fieldErr))
+	assert.Equal(t, ProviderName, fieldErr.Provider)
+	assert.Equal(t, field, fieldErr.Field)
+}
+
+func providerYAMLNode(t *testing.T, data string) yaml.Node {
+	t.Helper()
+
+	var node yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(data), &node))
+	require.NotEmpty(t, node.Content)
+	return *node.Content[0]
+}


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
- Move provider-specific YAML decoding and defaults into provider packages as part of the component manager pluggability work.
- Introduce provider config interfaces and a built-in decoder registry so provider packages own their configuration behavior.
- Keep the current bootstrap path compatible through legacy provider fields while storing decoded provider configs for the future generic bootstrap path.
- Add focused parser, registry, built-in registration, and provider-local decoder tests.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [x] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [ ] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [x] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
