### PR TITLE
chore: Drop unused tclient.Client from expected API handlers

### DIFF
--- a/api/pkg/api/handler/expectedmachine.go
+++ b/api/pkg/api/handler/expectedmachine.go
@@ -98,17 +98,15 @@ func ValidateProviderOrTenantSiteAccess(ctx context.Context, logger zerolog.Logg
 // CreateExpectedMachineHandler is the API Handler for creating new ExpectedMachine
 type CreateExpectedMachineHandler struct {
 	dbSession  *cdb.Session
-	tc         tclient.Client
 	scp        *sc.ClientPool
 	cfg        *config.Config
 	tracerSpan *cutil.TracerSpan
 }
 
 // NewCreateExpectedMachineHandler initializes and returns a new handler for creating ExpectedMachine
-func NewCreateExpectedMachineHandler(dbSession *cdb.Session, tc tclient.Client, scp *sc.ClientPool, cfg *config.Config) CreateExpectedMachineHandler {
+func NewCreateExpectedMachineHandler(dbSession *cdb.Session, scp *sc.ClientPool, cfg *config.Config) CreateExpectedMachineHandler {
 	return CreateExpectedMachineHandler{
 		dbSession:  dbSession,
-		tc:         tc,
 		scp:        scp,
 		cfg:        cfg,
 		tracerSpan: cutil.NewTracerSpan(),
@@ -366,16 +364,14 @@ func (cemh CreateExpectedMachineHandler) Handle(c echo.Context) error {
 // GetAllExpectedMachineHandler is the API Handler for getting all ExpectedMachines
 type GetAllExpectedMachineHandler struct {
 	dbSession  *cdb.Session
-	tc         tclient.Client
 	cfg        *config.Config
 	tracerSpan *cutil.TracerSpan
 }
 
 // NewGetAllExpectedMachineHandler initializes and returns a new handler for getting all ExpectedMachines
-func NewGetAllExpectedMachineHandler(dbSession *cdb.Session, tc tclient.Client, cfg *config.Config) GetAllExpectedMachineHandler {
+func NewGetAllExpectedMachineHandler(dbSession *cdb.Session, cfg *config.Config) GetAllExpectedMachineHandler {
 	return GetAllExpectedMachineHandler{
 		dbSession:  dbSession,
-		tc:         tc,
 		cfg:        cfg,
 		tracerSpan: cutil.NewTracerSpan(),
 	}
@@ -528,16 +524,14 @@ func (gaemh GetAllExpectedMachineHandler) Handle(c echo.Context) error {
 // GetExpectedMachineHandler is the API Handler for retrieving ExpectedMachine
 type GetExpectedMachineHandler struct {
 	dbSession  *cdb.Session
-	tc         tclient.Client
 	cfg        *config.Config
 	tracerSpan *cutil.TracerSpan
 }
 
 // NewGetExpectedMachineHandler initializes and returns a new handler to retrieve ExpectedMachine
-func NewGetExpectedMachineHandler(dbSession *cdb.Session, tc tclient.Client, cfg *config.Config) GetExpectedMachineHandler {
+func NewGetExpectedMachineHandler(dbSession *cdb.Session, cfg *config.Config) GetExpectedMachineHandler {
 	return GetExpectedMachineHandler{
 		dbSession:  dbSession,
-		tc:         tc,
 		cfg:        cfg,
 		tracerSpan: cutil.NewTracerSpan(),
 	}
@@ -632,17 +626,15 @@ func (gemh GetExpectedMachineHandler) Handle(c echo.Context) error {
 // UpdateExpectedMachineHandler is the API Handler for updating a ExpectedMachine
 type UpdateExpectedMachineHandler struct {
 	dbSession  *cdb.Session
-	tc         tclient.Client
 	scp        *sc.ClientPool
 	cfg        *config.Config
 	tracerSpan *cutil.TracerSpan
 }
 
 // NewUpdateExpectedMachineHandler initializes and returns a new handler for updating ExpectedMachine
-func NewUpdateExpectedMachineHandler(dbSession *cdb.Session, tc tclient.Client, scp *sc.ClientPool, cfg *config.Config) UpdateExpectedMachineHandler {
+func NewUpdateExpectedMachineHandler(dbSession *cdb.Session, scp *sc.ClientPool, cfg *config.Config) UpdateExpectedMachineHandler {
 	return UpdateExpectedMachineHandler{
 		dbSession:  dbSession,
-		tc:         tc,
 		scp:        scp,
 		cfg:        cfg,
 		tracerSpan: cutil.NewTracerSpan(),
@@ -898,17 +890,15 @@ func (uemh UpdateExpectedMachineHandler) Handle(c echo.Context) error {
 // DeleteExpectedMachineHandler is the API Handler for deleting a ExpectedMachine
 type DeleteExpectedMachineHandler struct {
 	dbSession  *cdb.Session
-	tc         tclient.Client
 	scp        *sc.ClientPool
 	cfg        *config.Config
 	tracerSpan *cutil.TracerSpan
 }
 
 // NewDeleteExpectedMachineHandler initializes and returns a new handler for deleting ExpectedMachine
-func NewDeleteExpectedMachineHandler(dbSession *cdb.Session, tc tclient.Client, scp *sc.ClientPool, cfg *config.Config) DeleteExpectedMachineHandler {
+func NewDeleteExpectedMachineHandler(dbSession *cdb.Session, scp *sc.ClientPool, cfg *config.Config) DeleteExpectedMachineHandler {
 	return DeleteExpectedMachineHandler{
 		dbSession:  dbSession,
-		tc:         tc,
 		scp:        scp,
 		cfg:        cfg,
 		tracerSpan: cutil.NewTracerSpan(),
@@ -1043,17 +1033,15 @@ func (demh DeleteExpectedMachineHandler) Handle(c echo.Context) error {
 // CreateExpectedMachinesHandler is the API Handler for creating multiple ExpectedMachines
 type CreateExpectedMachinesHandler struct {
 	dbSession  *cdb.Session
-	tc         tclient.Client
 	scp        *sc.ClientPool
 	cfg        *config.Config
 	tracerSpan *cutil.TracerSpan
 }
 
 // NewCreateExpectedMachinesHandler initializes and returns a new handler for creating multiple ExpectedMachines
-func NewCreateExpectedMachinesHandler(dbSession *cdb.Session, tc tclient.Client, scp *sc.ClientPool, cfg *config.Config) CreateExpectedMachinesHandler {
+func NewCreateExpectedMachinesHandler(dbSession *cdb.Session, scp *sc.ClientPool, cfg *config.Config) CreateExpectedMachinesHandler {
 	return CreateExpectedMachinesHandler{
 		dbSession:  dbSession,
-		tc:         tc,
 		scp:        scp,
 		cfg:        cfg,
 		tracerSpan: cutil.NewTracerSpan(),
@@ -1427,17 +1415,15 @@ func (cemh CreateExpectedMachinesHandler) Handle(c echo.Context) error {
 // UpdateExpectedMachinesHandler is the API Handler for batch updating ExpectedMachines
 type UpdateExpectedMachinesHandler struct {
 	dbSession  *cdb.Session
-	tc         tclient.Client
 	scp        *sc.ClientPool
 	cfg        *config.Config
 	tracerSpan *cutil.TracerSpan
 }
 
 // NewUpdateExpectedMachinesHandler initializes and returns a new handler for batch updating ExpectedMachines
-func NewUpdateExpectedMachinesHandler(dbSession *cdb.Session, tc tclient.Client, scp *sc.ClientPool, cfg *config.Config) UpdateExpectedMachinesHandler {
+func NewUpdateExpectedMachinesHandler(dbSession *cdb.Session, scp *sc.ClientPool, cfg *config.Config) UpdateExpectedMachinesHandler {
 	return UpdateExpectedMachinesHandler{
 		dbSession:  dbSession,
-		tc:         tc,
 		scp:        scp,
 		cfg:        cfg,
 		tracerSpan: cutil.NewTracerSpan(),

--- a/api/pkg/api/handler/expectedmachine_test.go
+++ b/api/pkg/api/handler/expectedmachine_test.go
@@ -184,7 +184,7 @@ func TestCreateExpectedMachineHandler_Handle(t *testing.T) {
 	mockTemporalClient.Mock.On("ExecuteWorkflow", mock.Anything, mock.Anything, "CreateExpectedMachine", mock.Anything).Return(mockWorkflowRun, nil)
 	scp.IDClientMap[site.ID.String()] = mockTemporalClient
 
-	handler := NewCreateExpectedMachineHandler(dbSession, nil, scp, cfg)
+	handler := NewCreateExpectedMachineHandler(dbSession, scp, cfg)
 
 	// Helper function to create mock user
 	createMockUser := func(org string) *cdbm.User {
@@ -419,7 +419,7 @@ func TestGetAllExpectedMachineHandler_Handle(t *testing.T) {
 
 	ctx := context.Background()
 	cfg := &config.Config{}
-	handler := NewGetAllExpectedMachineHandler(dbSession, nil, cfg)
+	handler := NewGetAllExpectedMachineHandler(dbSession, cfg)
 
 	org := "test-org"
 	infraProv, site := testExpectedMachineSetupTestData(t, dbSession, org)
@@ -707,7 +707,7 @@ func TestGetExpectedMachineHandler_Handle(t *testing.T) {
 	ctx := context.Background()
 
 	cfg := &config.Config{}
-	handler := NewGetExpectedMachineHandler(dbSession, nil, cfg)
+	handler := NewGetExpectedMachineHandler(dbSession, cfg)
 
 	org := "test-org"
 	infraProv, site := testExpectedMachineSetupTestData(t, dbSession, org)
@@ -986,7 +986,7 @@ func TestUpdateExpectedMachineHandler_Handle(t *testing.T) {
 	mockTemporalClient.Mock.On("ExecuteWorkflow", mock.Anything, mock.Anything, "UpdateExpectedMachine", mock.Anything).Return(mockWorkflowRun, nil)
 	scp.IDClientMap[site.ID.String()] = mockTemporalClient
 
-	handler := NewUpdateExpectedMachineHandler(dbSession, nil, scp, cfg)
+	handler := NewUpdateExpectedMachineHandler(dbSession, scp, cfg)
 
 	// Helper function to create mock user
 	createMockUser := func(org string) *cdbm.User {
@@ -1188,7 +1188,7 @@ func TestDeleteExpectedMachineHandler_Handle(t *testing.T) {
 	mockTemporalClient.Mock.On("ExecuteWorkflow", mock.Anything, mock.Anything, "DeleteExpectedMachine", mock.Anything).Return(mockWorkflowRun, nil)
 	scp.IDClientMap[site.ID.String()] = mockTemporalClient
 
-	handler := NewDeleteExpectedMachineHandler(dbSession, nil, scp, cfg)
+	handler := NewDeleteExpectedMachineHandler(dbSession, scp, cfg)
 
 	// Helper function to create mock user
 	createMockUser := func(org string) *cdbm.User {
@@ -1436,7 +1436,7 @@ func TestTenantWithTargetedInstanceCreationCapability(t *testing.T) {
 				Labels:                   map[string]string{"tenant": "test"},
 			},
 			setupHandler: func() interface{} {
-				return NewCreateExpectedMachineHandler(dbSession, tc, scp, cfg)
+				return NewCreateExpectedMachineHandler(dbSession, scp, cfg)
 			},
 			setupContext: func(c echo.Context) {
 				c.Set("user", tenantUser)
@@ -1458,7 +1458,7 @@ func TestTenantWithTargetedInstanceCreationCapability(t *testing.T) {
 			path:        "/v2/org/" + tenantOrg + "/carbide/expected-machine?siteId=" + site.ID.String(),
 			requestBody: nil,
 			setupHandler: func() interface{} {
-				return NewGetAllExpectedMachineHandler(dbSession, tc, cfg)
+				return NewGetAllExpectedMachineHandler(dbSession, cfg)
 			},
 			setupContext: func(c echo.Context) {
 				c.Set("user", tenantUser)
@@ -1479,7 +1479,7 @@ func TestTenantWithTargetedInstanceCreationCapability(t *testing.T) {
 			path:        "/v2/org/" + tenantOrg + "/carbide/expected-machine",
 			requestBody: nil,
 			setupHandler: func() interface{} {
-				return NewGetAllExpectedMachineHandler(dbSession, tc, cfg)
+				return NewGetAllExpectedMachineHandler(dbSession, cfg)
 			},
 			setupContext: func(c echo.Context) {
 				c.Set("user", tenantUser)
@@ -1501,7 +1501,7 @@ func TestTenantWithTargetedInstanceCreationCapability(t *testing.T) {
 				ChassisSerialNumber: "NO-CAP-CHASSIS",
 			},
 			setupHandler: func() interface{} {
-				return NewCreateExpectedMachineHandler(dbSession, tc, scp, cfg)
+				return NewCreateExpectedMachineHandler(dbSession, scp, cfg)
 			},
 			setupContext: func(c echo.Context) {
 				c.Set("user", tenantUser2)
@@ -1523,7 +1523,7 @@ func TestTenantWithTargetedInstanceCreationCapability(t *testing.T) {
 				ChassisSerialNumber: "NO-ACCOUNT-CHASSIS",
 			},
 			setupHandler: func() interface{} {
-				return NewCreateExpectedMachineHandler(dbSession, tc, scp, cfg)
+				return NewCreateExpectedMachineHandler(dbSession, scp, cfg)
 			},
 			setupContext: func(c echo.Context) {
 				c.Set("user", tenantUser)
@@ -1659,7 +1659,7 @@ func TestCreateExpectedMachinesHandler_Handle(t *testing.T) {
 
 	scp.IDClientMap[site.ID.String()] = mockTemporalClient
 
-	handler := NewCreateExpectedMachinesHandler(dbSession, nil, scp, cfg)
+	handler := NewCreateExpectedMachinesHandler(dbSession, scp, cfg)
 
 	// Helper function to create mock user
 	createMockUser := func(org string) *cdbm.User {
@@ -1877,7 +1877,7 @@ func TestCreateExpectedMachineHandler_BmcCredentialsForwardedToWorkflow(t *testi
 		Return(mockWorkflowRun, nil)
 	scp.IDClientMap[site.ID.String()] = mockTemporalClient
 
-	handler := NewCreateExpectedMachineHandler(dbSession, nil, scp, cfg)
+	handler := NewCreateExpectedMachineHandler(dbSession, scp, cfg)
 
 	// Build the request body as a raw JSON map using the field names defined in the
 	// OpenAPI spec ("defaultBmcUsername" / "defaultBmcPassword"), exactly as a curl
@@ -1973,7 +1973,7 @@ func TestUpdateExpectedMachineHandler_BmcCredentialsForwardedToWorkflow(t *testi
 		Return(mockWorkflowRun, nil)
 	scp.IDClientMap[site.ID.String()] = mockTemporalClient
 
-	handler := NewUpdateExpectedMachineHandler(dbSession, nil, scp, cfg)
+	handler := NewUpdateExpectedMachineHandler(dbSession, scp, cfg)
 
 	// Build the request body as a raw JSON map using the field names defined in the
 	// OpenAPI spec ("defaultBmcUsername" / "defaultBmcPassword"), exactly as a curl
@@ -2143,7 +2143,7 @@ func TestUpdateExpectedMachinesHandler_Handle(t *testing.T) {
 
 	scp.IDClientMap[site.ID.String()] = mockTemporalClient
 
-	handler := NewUpdateExpectedMachinesHandler(dbSession, nil, scp, cfg)
+	handler := NewUpdateExpectedMachinesHandler(dbSession, scp, cfg)
 
 	// Helper function to create mock user
 	createMockUser := func(org string) *cdbm.User {

--- a/api/pkg/api/handler/expectedpowershelf.go
+++ b/api/pkg/api/handler/expectedpowershelf.go
@@ -49,17 +49,15 @@ import (
 // CreateExpectedPowerShelfHandler is the API Handler for creating new ExpectedPowerShelf
 type CreateExpectedPowerShelfHandler struct {
 	dbSession  *cdb.Session
-	tc         tclient.Client
 	scp        *sc.ClientPool
 	cfg        *config.Config
 	tracerSpan *cutil.TracerSpan
 }
 
 // NewCreateExpectedPowerShelfHandler initializes and returns a new handler for creating ExpectedPowerShelf
-func NewCreateExpectedPowerShelfHandler(dbSession *cdb.Session, tc tclient.Client, scp *sc.ClientPool, cfg *config.Config) CreateExpectedPowerShelfHandler {
+func NewCreateExpectedPowerShelfHandler(dbSession *cdb.Session, scp *sc.ClientPool, cfg *config.Config) CreateExpectedPowerShelfHandler {
 	return CreateExpectedPowerShelfHandler{
 		dbSession:  dbSession,
-		tc:         tc,
 		scp:        scp,
 		cfg:        cfg,
 		tracerSpan: cutil.NewTracerSpan(),
@@ -304,16 +302,14 @@ func (cepsh CreateExpectedPowerShelfHandler) Handle(c echo.Context) error {
 // GetAllExpectedPowerShelfHandler is the API Handler for getting all ExpectedPowerShelves
 type GetAllExpectedPowerShelfHandler struct {
 	dbSession  *cdb.Session
-	tc         tclient.Client
 	cfg        *config.Config
 	tracerSpan *cutil.TracerSpan
 }
 
 // NewGetAllExpectedPowerShelfHandler initializes and returns a new handler for getting all ExpectedPowerShelves
-func NewGetAllExpectedPowerShelfHandler(dbSession *cdb.Session, tc tclient.Client, cfg *config.Config) GetAllExpectedPowerShelfHandler {
+func NewGetAllExpectedPowerShelfHandler(dbSession *cdb.Session, cfg *config.Config) GetAllExpectedPowerShelfHandler {
 	return GetAllExpectedPowerShelfHandler{
 		dbSession:  dbSession,
-		tc:         tc,
 		cfg:        cfg,
 		tracerSpan: cutil.NewTracerSpan(),
 	}
@@ -466,16 +462,14 @@ func (gaepsh GetAllExpectedPowerShelfHandler) Handle(c echo.Context) error {
 // GetExpectedPowerShelfHandler is the API Handler for retrieving ExpectedPowerShelf
 type GetExpectedPowerShelfHandler struct {
 	dbSession  *cdb.Session
-	tc         tclient.Client
 	cfg        *config.Config
 	tracerSpan *cutil.TracerSpan
 }
 
 // NewGetExpectedPowerShelfHandler initializes and returns a new handler to retrieve ExpectedPowerShelf
-func NewGetExpectedPowerShelfHandler(dbSession *cdb.Session, tc tclient.Client, cfg *config.Config) GetExpectedPowerShelfHandler {
+func NewGetExpectedPowerShelfHandler(dbSession *cdb.Session, cfg *config.Config) GetExpectedPowerShelfHandler {
 	return GetExpectedPowerShelfHandler{
 		dbSession:  dbSession,
-		tc:         tc,
 		cfg:        cfg,
 		tracerSpan: cutil.NewTracerSpan(),
 	}
@@ -570,17 +564,15 @@ func (gepsh GetExpectedPowerShelfHandler) Handle(c echo.Context) error {
 // UpdateExpectedPowerShelfHandler is the API Handler for updating a ExpectedPowerShelf
 type UpdateExpectedPowerShelfHandler struct {
 	dbSession  *cdb.Session
-	tc         tclient.Client
 	scp        *sc.ClientPool
 	cfg        *config.Config
 	tracerSpan *cutil.TracerSpan
 }
 
 // NewUpdateExpectedPowerShelfHandler initializes and returns a new handler for updating ExpectedPowerShelf
-func NewUpdateExpectedPowerShelfHandler(dbSession *cdb.Session, tc tclient.Client, scp *sc.ClientPool, cfg *config.Config) UpdateExpectedPowerShelfHandler {
+func NewUpdateExpectedPowerShelfHandler(dbSession *cdb.Session, scp *sc.ClientPool, cfg *config.Config) UpdateExpectedPowerShelfHandler {
 	return UpdateExpectedPowerShelfHandler{
 		dbSession:  dbSession,
-		tc:         tc,
 		scp:        scp,
 		cfg:        cfg,
 		tracerSpan: cutil.NewTracerSpan(),
@@ -823,17 +815,15 @@ func (uepsh UpdateExpectedPowerShelfHandler) Handle(c echo.Context) error {
 // DeleteExpectedPowerShelfHandler is the API Handler for deleting a ExpectedPowerShelf
 type DeleteExpectedPowerShelfHandler struct {
 	dbSession  *cdb.Session
-	tc         tclient.Client
 	scp        *sc.ClientPool
 	cfg        *config.Config
 	tracerSpan *cutil.TracerSpan
 }
 
 // NewDeleteExpectedPowerShelfHandler initializes and returns a new handler for deleting ExpectedPowerShelf
-func NewDeleteExpectedPowerShelfHandler(dbSession *cdb.Session, tc tclient.Client, scp *sc.ClientPool, cfg *config.Config) DeleteExpectedPowerShelfHandler {
+func NewDeleteExpectedPowerShelfHandler(dbSession *cdb.Session, scp *sc.ClientPool, cfg *config.Config) DeleteExpectedPowerShelfHandler {
 	return DeleteExpectedPowerShelfHandler{
 		dbSession:  dbSession,
-		tc:         tc,
 		scp:        scp,
 		cfg:        cfg,
 		tracerSpan: cutil.NewTracerSpan(),

--- a/api/pkg/api/handler/expectedpowershelf_test.go
+++ b/api/pkg/api/handler/expectedpowershelf_test.go
@@ -144,7 +144,7 @@ func TestCreateExpectedPowerShelfHandler_Handle(t *testing.T) {
 	mockTemporalClient.Mock.On("ExecuteWorkflow", mock.Anything, mock.Anything, "CreateExpectedPowerShelf", mock.Anything).Return(mockWorkflowRun, nil)
 	scp.IDClientMap[site.ID.String()] = mockTemporalClient
 
-	handler := NewCreateExpectedPowerShelfHandler(dbSession, nil, scp, cfg)
+	handler := NewCreateExpectedPowerShelfHandler(dbSession, scp, cfg)
 
 	createMockUser := func(org string) *cdbm.User {
 		return &cdbm.User{
@@ -309,7 +309,7 @@ func TestGetAllExpectedPowerShelfHandler_Handle(t *testing.T) {
 
 	ctx := context.Background()
 	cfg := &config.Config{}
-	handler := NewGetAllExpectedPowerShelfHandler(dbSession, nil, cfg)
+	handler := NewGetAllExpectedPowerShelfHandler(dbSession, cfg)
 
 	org := "test-org"
 	infraProv, site := testExpectedPowerShelfSetupTestData(t, dbSession, org)
@@ -494,7 +494,7 @@ func TestGetExpectedPowerShelfHandler_Handle(t *testing.T) {
 	ctx := context.Background()
 
 	cfg := &config.Config{}
-	handler := NewGetExpectedPowerShelfHandler(dbSession, nil, cfg)
+	handler := NewGetExpectedPowerShelfHandler(dbSession, cfg)
 
 	org := "test-org"
 	infraProv, site := testExpectedPowerShelfSetupTestData(t, dbSession, org)
@@ -698,7 +698,7 @@ func TestUpdateExpectedPowerShelfHandler_Handle(t *testing.T) {
 	mockTemporalClient.Mock.On("ExecuteWorkflow", mock.Anything, mock.Anything, "UpdateExpectedPowerShelf", mock.Anything).Return(mockWorkflowRun, nil)
 	scp.IDClientMap[site.ID.String()] = mockTemporalClient
 
-	handler := NewUpdateExpectedPowerShelfHandler(dbSession, nil, scp, cfg)
+	handler := NewUpdateExpectedPowerShelfHandler(dbSession, scp, cfg)
 
 	createMockUser := func(org string) *cdbm.User {
 		return &cdbm.User{
@@ -853,7 +853,7 @@ func TestDeleteExpectedPowerShelfHandler_Handle(t *testing.T) {
 	mockTemporalClient.Mock.On("ExecuteWorkflow", mock.Anything, mock.Anything, "DeleteExpectedPowerShelf", mock.Anything).Return(mockWorkflowRun, nil)
 	scp.IDClientMap[site.ID.String()] = mockTemporalClient
 
-	handler := NewDeleteExpectedPowerShelfHandler(dbSession, nil, scp, cfg)
+	handler := NewDeleteExpectedPowerShelfHandler(dbSession, scp, cfg)
 
 	createMockUser := func(org string) *cdbm.User {
 		return &cdbm.User{

--- a/api/pkg/api/handler/expectedswitch.go
+++ b/api/pkg/api/handler/expectedswitch.go
@@ -49,17 +49,15 @@ import (
 // CreateExpectedSwitchHandler is the API Handler for creating new ExpectedSwitch
 type CreateExpectedSwitchHandler struct {
 	dbSession  *cdb.Session
-	tc         tclient.Client
 	scp        *sc.ClientPool
 	cfg        *config.Config
 	tracerSpan *cutil.TracerSpan
 }
 
 // NewCreateExpectedSwitchHandler initializes and returns a new handler for creating ExpectedSwitch
-func NewCreateExpectedSwitchHandler(dbSession *cdb.Session, tc tclient.Client, scp *sc.ClientPool, cfg *config.Config) CreateExpectedSwitchHandler {
+func NewCreateExpectedSwitchHandler(dbSession *cdb.Session, scp *sc.ClientPool, cfg *config.Config) CreateExpectedSwitchHandler {
 	return CreateExpectedSwitchHandler{
 		dbSession:  dbSession,
-		tc:         tc,
 		scp:        scp,
 		cfg:        cfg,
 		tracerSpan: cutil.NewTracerSpan(),
@@ -307,16 +305,14 @@ func (cesh CreateExpectedSwitchHandler) Handle(c echo.Context) error {
 // GetAllExpectedSwitchHandler is the API Handler for getting all ExpectedSwitches
 type GetAllExpectedSwitchHandler struct {
 	dbSession  *cdb.Session
-	tc         tclient.Client
 	cfg        *config.Config
 	tracerSpan *cutil.TracerSpan
 }
 
 // NewGetAllExpectedSwitchHandler initializes and returns a new handler for getting all ExpectedSwitches
-func NewGetAllExpectedSwitchHandler(dbSession *cdb.Session, tc tclient.Client, cfg *config.Config) GetAllExpectedSwitchHandler {
+func NewGetAllExpectedSwitchHandler(dbSession *cdb.Session, cfg *config.Config) GetAllExpectedSwitchHandler {
 	return GetAllExpectedSwitchHandler{
 		dbSession:  dbSession,
-		tc:         tc,
 		cfg:        cfg,
 		tracerSpan: cutil.NewTracerSpan(),
 	}
@@ -469,16 +465,14 @@ func (gaesh GetAllExpectedSwitchHandler) Handle(c echo.Context) error {
 // GetExpectedSwitchHandler is the API Handler for retrieving ExpectedSwitch
 type GetExpectedSwitchHandler struct {
 	dbSession  *cdb.Session
-	tc         tclient.Client
 	cfg        *config.Config
 	tracerSpan *cutil.TracerSpan
 }
 
 // NewGetExpectedSwitchHandler initializes and returns a new handler to retrieve ExpectedSwitch
-func NewGetExpectedSwitchHandler(dbSession *cdb.Session, tc tclient.Client, cfg *config.Config) GetExpectedSwitchHandler {
+func NewGetExpectedSwitchHandler(dbSession *cdb.Session, cfg *config.Config) GetExpectedSwitchHandler {
 	return GetExpectedSwitchHandler{
 		dbSession:  dbSession,
-		tc:         tc,
 		cfg:        cfg,
 		tracerSpan: cutil.NewTracerSpan(),
 	}
@@ -573,17 +567,15 @@ func (gesh GetExpectedSwitchHandler) Handle(c echo.Context) error {
 // UpdateExpectedSwitchHandler is the API Handler for updating a ExpectedSwitch
 type UpdateExpectedSwitchHandler struct {
 	dbSession  *cdb.Session
-	tc         tclient.Client
 	scp        *sc.ClientPool
 	cfg        *config.Config
 	tracerSpan *cutil.TracerSpan
 }
 
 // NewUpdateExpectedSwitchHandler initializes and returns a new handler for updating ExpectedSwitch
-func NewUpdateExpectedSwitchHandler(dbSession *cdb.Session, tc tclient.Client, scp *sc.ClientPool, cfg *config.Config) UpdateExpectedSwitchHandler {
+func NewUpdateExpectedSwitchHandler(dbSession *cdb.Session, scp *sc.ClientPool, cfg *config.Config) UpdateExpectedSwitchHandler {
 	return UpdateExpectedSwitchHandler{
 		dbSession:  dbSession,
-		tc:         tc,
 		scp:        scp,
 		cfg:        cfg,
 		tracerSpan: cutil.NewTracerSpan(),
@@ -829,17 +821,15 @@ func (uesh UpdateExpectedSwitchHandler) Handle(c echo.Context) error {
 // DeleteExpectedSwitchHandler is the API Handler for deleting a ExpectedSwitch
 type DeleteExpectedSwitchHandler struct {
 	dbSession  *cdb.Session
-	tc         tclient.Client
 	scp        *sc.ClientPool
 	cfg        *config.Config
 	tracerSpan *cutil.TracerSpan
 }
 
 // NewDeleteExpectedSwitchHandler initializes and returns a new handler for deleting ExpectedSwitch
-func NewDeleteExpectedSwitchHandler(dbSession *cdb.Session, tc tclient.Client, scp *sc.ClientPool, cfg *config.Config) DeleteExpectedSwitchHandler {
+func NewDeleteExpectedSwitchHandler(dbSession *cdb.Session, scp *sc.ClientPool, cfg *config.Config) DeleteExpectedSwitchHandler {
 	return DeleteExpectedSwitchHandler{
 		dbSession:  dbSession,
-		tc:         tc,
 		scp:        scp,
 		cfg:        cfg,
 		tracerSpan: cutil.NewTracerSpan(),

--- a/api/pkg/api/handler/expectedswitch_test.go
+++ b/api/pkg/api/handler/expectedswitch_test.go
@@ -144,7 +144,7 @@ func TestCreateExpectedSwitchHandler_Handle(t *testing.T) {
 	mockTemporalClient.Mock.On("ExecuteWorkflow", mock.Anything, mock.Anything, "CreateExpectedSwitch", mock.Anything).Return(mockWorkflowRun, nil)
 	scp.IDClientMap[site.ID.String()] = mockTemporalClient
 
-	handler := NewCreateExpectedSwitchHandler(dbSession, nil, scp, cfg)
+	handler := NewCreateExpectedSwitchHandler(dbSession, scp, cfg)
 
 	createMockUser := func(org string) *cdbm.User {
 		return &cdbm.User{
@@ -308,7 +308,7 @@ func TestGetAllExpectedSwitchHandler_Handle(t *testing.T) {
 
 	ctx := context.Background()
 	cfg := &config.Config{}
-	handler := NewGetAllExpectedSwitchHandler(dbSession, nil, cfg)
+	handler := NewGetAllExpectedSwitchHandler(dbSession, cfg)
 
 	org := "test-org"
 	infraProv, site := testExpectedSwitchSetupTestData(t, dbSession, org)
@@ -493,7 +493,7 @@ func TestGetExpectedSwitchHandler_Handle(t *testing.T) {
 	ctx := context.Background()
 
 	cfg := &config.Config{}
-	handler := NewGetExpectedSwitchHandler(dbSession, nil, cfg)
+	handler := NewGetExpectedSwitchHandler(dbSession, cfg)
 
 	org := "test-org"
 	infraProv, site := testExpectedSwitchSetupTestData(t, dbSession, org)
@@ -697,7 +697,7 @@ func TestUpdateExpectedSwitchHandler_Handle(t *testing.T) {
 	mockTemporalClient.Mock.On("ExecuteWorkflow", mock.Anything, mock.Anything, "UpdateExpectedSwitch", mock.Anything).Return(mockWorkflowRun, nil)
 	scp.IDClientMap[site.ID.String()] = mockTemporalClient
 
-	handler := NewUpdateExpectedSwitchHandler(dbSession, nil, scp, cfg)
+	handler := NewUpdateExpectedSwitchHandler(dbSession, scp, cfg)
 
 	createMockUser := func(org string) *cdbm.User {
 		return &cdbm.User{
@@ -852,7 +852,7 @@ func TestDeleteExpectedSwitchHandler_Handle(t *testing.T) {
 	mockTemporalClient.Mock.On("ExecuteWorkflow", mock.Anything, mock.Anything, "DeleteExpectedSwitch", mock.Anything).Return(mockWorkflowRun, nil)
 	scp.IDClientMap[site.ID.String()] = mockTemporalClient
 
-	handler := NewDeleteExpectedSwitchHandler(dbSession, nil, scp, cfg)
+	handler := NewDeleteExpectedSwitchHandler(dbSession, scp, cfg)
 
 	createMockUser := func(org string) *cdbm.User {
 		return &cdbm.User{

--- a/api/pkg/api/routes.go
+++ b/api/pkg/api/routes.go
@@ -419,79 +419,79 @@ func NewAPIRoutes(dbSession *cdb.Session, tc tClient.Client, tnc tClient.Namespa
 		{
 			Path:    apiPathPrefix + "/expected-machine",
 			Method:  http.MethodPost,
-			Handler: apiHandler.NewCreateExpectedMachineHandler(dbSession, tc, scp, cfg),
+			Handler: apiHandler.NewCreateExpectedMachineHandler(dbSession, scp, cfg),
 		},
 		{
 			Path:    apiPathPrefix + "/expected-machine",
 			Method:  http.MethodGet,
-			Handler: apiHandler.NewGetAllExpectedMachineHandler(dbSession, tc, cfg),
+			Handler: apiHandler.NewGetAllExpectedMachineHandler(dbSession, cfg),
 		},
 		{
 			Path:    apiPathPrefix + "/expected-machine/:id",
 			Method:  http.MethodGet,
-			Handler: apiHandler.NewGetExpectedMachineHandler(dbSession, tc, cfg),
+			Handler: apiHandler.NewGetExpectedMachineHandler(dbSession, cfg),
 		},
 		{
 			Path:    apiPathPrefix + "/expected-machine/:id",
 			Method:  http.MethodPatch,
-			Handler: apiHandler.NewUpdateExpectedMachineHandler(dbSession, tc, scp, cfg),
+			Handler: apiHandler.NewUpdateExpectedMachineHandler(dbSession, scp, cfg),
 		},
 		{
 			Path:    apiPathPrefix + "/expected-machine/:id",
 			Method:  http.MethodDelete,
-			Handler: apiHandler.NewDeleteExpectedMachineHandler(dbSession, tc, scp, cfg),
+			Handler: apiHandler.NewDeleteExpectedMachineHandler(dbSession, scp, cfg),
 		},
 		// ExpectedPowerShelf endpoints
 		{
 			Path:    apiPathPrefix + "/expected-power-shelf",
 			Method:  http.MethodPost,
-			Handler: apiHandler.NewCreateExpectedPowerShelfHandler(dbSession, tc, scp, cfg),
+			Handler: apiHandler.NewCreateExpectedPowerShelfHandler(dbSession, scp, cfg),
 		},
 		{
 			Path:    apiPathPrefix + "/expected-power-shelf",
 			Method:  http.MethodGet,
-			Handler: apiHandler.NewGetAllExpectedPowerShelfHandler(dbSession, tc, cfg),
+			Handler: apiHandler.NewGetAllExpectedPowerShelfHandler(dbSession, cfg),
 		},
 		{
 			Path:    apiPathPrefix + "/expected-power-shelf/:id",
 			Method:  http.MethodGet,
-			Handler: apiHandler.NewGetExpectedPowerShelfHandler(dbSession, tc, cfg),
+			Handler: apiHandler.NewGetExpectedPowerShelfHandler(dbSession, cfg),
 		},
 		{
 			Path:    apiPathPrefix + "/expected-power-shelf/:id",
 			Method:  http.MethodPatch,
-			Handler: apiHandler.NewUpdateExpectedPowerShelfHandler(dbSession, tc, scp, cfg),
+			Handler: apiHandler.NewUpdateExpectedPowerShelfHandler(dbSession, scp, cfg),
 		},
 		{
 			Path:    apiPathPrefix + "/expected-power-shelf/:id",
 			Method:  http.MethodDelete,
-			Handler: apiHandler.NewDeleteExpectedPowerShelfHandler(dbSession, tc, scp, cfg),
+			Handler: apiHandler.NewDeleteExpectedPowerShelfHandler(dbSession, scp, cfg),
 		},
 		// ExpectedSwitch endpoints
 		{
 			Path:    apiPathPrefix + "/expected-switch",
 			Method:  http.MethodPost,
-			Handler: apiHandler.NewCreateExpectedSwitchHandler(dbSession, tc, scp, cfg),
+			Handler: apiHandler.NewCreateExpectedSwitchHandler(dbSession, scp, cfg),
 		},
 		{
 			Path:    apiPathPrefix + "/expected-switch",
 			Method:  http.MethodGet,
-			Handler: apiHandler.NewGetAllExpectedSwitchHandler(dbSession, tc, cfg),
+			Handler: apiHandler.NewGetAllExpectedSwitchHandler(dbSession, cfg),
 		},
 		{
 			Path:    apiPathPrefix + "/expected-switch/:id",
 			Method:  http.MethodGet,
-			Handler: apiHandler.NewGetExpectedSwitchHandler(dbSession, tc, cfg),
+			Handler: apiHandler.NewGetExpectedSwitchHandler(dbSession, cfg),
 		},
 		{
 			Path:    apiPathPrefix + "/expected-switch/:id",
 			Method:  http.MethodPatch,
-			Handler: apiHandler.NewUpdateExpectedSwitchHandler(dbSession, tc, scp, cfg),
+			Handler: apiHandler.NewUpdateExpectedSwitchHandler(dbSession, scp, cfg),
 		},
 		{
 			Path:    apiPathPrefix + "/expected-switch/:id",
 			Method:  http.MethodDelete,
-			Handler: apiHandler.NewDeleteExpectedSwitchHandler(dbSession, tc, scp, cfg),
+			Handler: apiHandler.NewDeleteExpectedSwitchHandler(dbSession, scp, cfg),
 		},
 		// Machine endpoints
 		{


### PR DESCRIPTION
## Description

Was poking around the `ExpectedMachine`, `ExpectedPowerShelf`, and `ExpectedSwitch` handlers looking for some cleanup, and noticed a bunch of `nil` args being passed around. Kept digging, and noticed every handler struct stores a `tc tclient.Client` and plumbs it through `New<...>Handler(...)`, but nothing actually reads it; the workflow client used at runtime comes from `scp.GetClientByID(site.ID)` (the per-Site `ClientPool`), not the stored `tc`. So, it's been unused on all 17 of these `Expected*` handlers.

Drops the field, the constructor parameter, and updates all `routes.go` and test call sites.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [x] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
