### PR TITLE
chore: Reuse pre-fetched Site in Expected Component GET handlers

### DIFF
--- a/api/pkg/api/handler/expectedmachine.go
+++ b/api/pkg/api/handler/expectedmachine.go
@@ -596,12 +596,15 @@ func (gemh GetExpectedMachineHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve Expected Machine due to DB error", nil)
 	}
 
-	// Get Site for the Expected Machine
-	siteDAO := cdbm.NewSiteDAO(gemh.dbSession)
-	site, err := siteDAO.GetByID(ctx, nil, expectedMachine.SiteID, nil, false)
-	if err != nil {
-		logger.Error().Err(err).Msg("error retrieving Site from DB")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve Site details for Expected Machine due to DB error", nil)
+	// Site is needed for the access check; reuse if loaded via includeRelation, else fetch.
+	site := expectedMachine.Site
+	if site == nil {
+		siteDAO := cdbm.NewSiteDAO(gemh.dbSession)
+		site, err = siteDAO.GetByID(ctx, nil, expectedMachine.SiteID, nil, false)
+		if err != nil {
+			logger.Error().Err(err).Msg("error retrieving Site from DB")
+			return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve Site details for Expected Machine due to DB error", nil)
+		}
 	}
 
 	// Validate ProviderTenantSite relationship and site state

--- a/api/pkg/api/handler/expectedpowershelf.go
+++ b/api/pkg/api/handler/expectedpowershelf.go
@@ -534,12 +534,15 @@ func (gepsh GetExpectedPowerShelfHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve Expected Power Shelf due to DB error", nil)
 	}
 
-	// Get Site for the Expected Power Shelf
-	siteDAO := cdbm.NewSiteDAO(gepsh.dbSession)
-	site, err := siteDAO.GetByID(ctx, nil, expectedPowerShelf.SiteID, nil, false)
-	if err != nil {
-		logger.Error().Err(err).Msg("error retrieving Site from DB")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve Site details for Expected Power Shelf due to DB error", nil)
+	// Site is needed for the access check; reuse if loaded via includeRelation, else fetch.
+	site := expectedPowerShelf.Site
+	if site == nil {
+		siteDAO := cdbm.NewSiteDAO(gepsh.dbSession)
+		site, err = siteDAO.GetByID(ctx, nil, expectedPowerShelf.SiteID, nil, false)
+		if err != nil {
+			logger.Error().Err(err).Msg("error retrieving Site from DB")
+			return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve Site details for Expected Power Shelf due to DB error", nil)
+		}
 	}
 
 	// Validate ProviderTenantSite relationship and site state

--- a/api/pkg/api/handler/expectedswitch.go
+++ b/api/pkg/api/handler/expectedswitch.go
@@ -537,12 +537,15 @@ func (gesh GetExpectedSwitchHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve Expected Switch due to DB error", nil)
 	}
 
-	// Get Site for the Expected Switch
-	siteDAO := cdbm.NewSiteDAO(gesh.dbSession)
-	site, err := siteDAO.GetByID(ctx, nil, expectedSwitch.SiteID, nil, false)
-	if err != nil {
-		logger.Error().Err(err).Msg("error retrieving Site from DB")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve Site details for Expected Switch due to DB error", nil)
+	// Site is needed for the access check; reuse if loaded via includeRelation, else fetch.
+	site := expectedSwitch.Site
+	if site == nil {
+		siteDAO := cdbm.NewSiteDAO(gesh.dbSession)
+		site, err = siteDAO.GetByID(ctx, nil, expectedSwitch.SiteID, nil, false)
+		if err != nil {
+			logger.Error().Err(err).Msg("error retrieving Site from DB")
+			return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve Site details for Expected Switch due to DB error", nil)
+		}
 	}
 
 	// Validate ProviderTenantSite relationship and site state


### PR DESCRIPTION
## Description

Continuing the cleanup across the `ExpectedMachine`, `ExpectedPowerShelf`, and `ExpectedSwitch` handlers. Each `Get` handler currently does an **extra** database call: it loads the entity with the caller's `qIncludeRelations`, and then issues a separate `siteDAO.GetByID` purely to satisfy the access check. When the caller already passed `?includeRelation=Site`, it turns into two queries for the same `Site` row.

`Update` and `Delete` already load `Site` as part of the entity `Get` and use `entity.Site` directly. This just teaches `Get` to do the same when it has the relation, falling back to the separate fetch otherwise. API behavior remains the same -- the response only includes `Site` when the caller asked for it.

**Note! We *could* go further and *always* join `Site`, dropping `siteDAO.GetByID` entirely. That'd match how `Update` and `Delete` *already* work, but `Get` responses would then always include `Site` whether the caller asked for it or not. Just a thought.**

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Chore** - Modification or removal of existing functionality (chore:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **API** - API models or endpoints updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->
None

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
None