### PR TITLE
chore: Define proto-builder helpers for ExpectedMachine/Switch/Powershelf API handlers

### DIFF
--- a/api/pkg/api/handler/expectedmachine.go
+++ b/api/pkg/api/handler/expectedmachine.go
@@ -93,6 +93,62 @@ func ValidateProviderOrTenantSiteAccess(ctx context.Context, logger zerolog.Logg
 	return hasAccess, nil
 }
 
+// expectedMachineToProto builds the workflow proto. BMC credentials and
+// labels are passed separately because they may come from the API request
+// rather than the DB record (BMC credentials aren't persisted at all).
+func expectedMachineToProto(em *cdbm.ExpectedMachine, defaultBmcUsername, defaultBmcPassword *string, labels map[string]string) *cwssaws.ExpectedMachine {
+	proto := &cwssaws.ExpectedMachine{
+		Id:                       &cwssaws.UUID{Value: em.ID.String()},
+		BmcMacAddress:            em.BmcMacAddress,
+		ChassisSerialNumber:      em.ChassisSerialNumber,
+		FallbackDpuSerialNumbers: em.FallbackDpuSerialNumbers,
+		SkuId:                    em.SkuID,
+	}
+
+	if em.RackID != nil {
+		proto.RackId = &cwssaws.RackId{Id: *em.RackID}
+	}
+	if em.Name != nil {
+		proto.Name = em.Name
+	}
+	if em.Manufacturer != nil {
+		proto.Manufacturer = em.Manufacturer
+	}
+	if em.Model != nil {
+		proto.Model = em.Model
+	}
+	if em.Description != nil {
+		proto.Description = em.Description
+	}
+	if em.FirmwareVersion != nil {
+		proto.FirmwareVersion = em.FirmwareVersion
+	}
+	if em.SlotID != nil {
+		proto.SlotId = em.SlotID
+	}
+	if em.TrayIdx != nil {
+		proto.TrayIdx = em.TrayIdx
+	}
+	if em.HostID != nil {
+		proto.HostId = em.HostID
+	}
+
+	if defaultBmcUsername != nil {
+		proto.BmcUsername = *defaultBmcUsername
+	}
+	if defaultBmcPassword != nil {
+		proto.BmcPassword = *defaultBmcPassword
+	}
+
+	if protoLabels := util.ProtobufLabelsFromAPILabels(labels); protoLabels != nil {
+		proto.Metadata = &cwssaws.Metadata{
+			Labels: protoLabels,
+		}
+	}
+
+	return proto
+}
+
 // ~~~~~ Create Handler ~~~~~ //
 
 // CreateExpectedMachineHandler is the API Handler for creating new ExpectedMachine
@@ -260,66 +316,12 @@ func (cemh CreateExpectedMachineHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to create Expected Machine due to DB error", nil)
 	}
 
-	// Build the create request for workflow
-	// BMC credentials come from API request since they're not stored in DB
-	createExpectedMachineRequest := &cwssaws.ExpectedMachine{
-		Id:                       &cwssaws.UUID{Value: expectedMachine.ID.String()},
-		BmcMacAddress:            expectedMachine.BmcMacAddress,
-		ChassisSerialNumber:      expectedMachine.ChassisSerialNumber,
-		FallbackDpuSerialNumbers: expectedMachine.FallbackDpuSerialNumbers,
-		SkuId:                    expectedMachine.SkuID,
-	}
-
-	if expectedMachine.RackID != nil {
-		createExpectedMachineRequest.RackId = &cwssaws.RackId{Id: *expectedMachine.RackID}
-	}
-
-	if expectedMachine.Name != nil {
-		createExpectedMachineRequest.Name = expectedMachine.Name
-	}
-
-	if expectedMachine.Manufacturer != nil {
-		createExpectedMachineRequest.Manufacturer = expectedMachine.Manufacturer
-	}
-
-	if expectedMachine.Model != nil {
-		createExpectedMachineRequest.Model = expectedMachine.Model
-	}
-
-	if expectedMachine.Description != nil {
-		createExpectedMachineRequest.Description = expectedMachine.Description
-	}
-
-	if expectedMachine.FirmwareVersion != nil {
-		createExpectedMachineRequest.FirmwareVersion = expectedMachine.FirmwareVersion
-	}
-
-	if expectedMachine.SlotID != nil {
-		createExpectedMachineRequest.SlotId = expectedMachine.SlotID
-	}
-
-	if expectedMachine.TrayIdx != nil {
-		createExpectedMachineRequest.TrayIdx = expectedMachine.TrayIdx
-	}
-
-	if expectedMachine.HostID != nil {
-		createExpectedMachineRequest.HostId = expectedMachine.HostID
-	}
-
-	if apiRequest.DefaultBmcUsername != nil {
-		createExpectedMachineRequest.BmcUsername = *apiRequest.DefaultBmcUsername
-	}
-
-	if apiRequest.DefaultBmcPassword != nil {
-		createExpectedMachineRequest.BmcPassword = *apiRequest.DefaultBmcPassword
-	}
-
-	protoLabels := util.ProtobufLabelsFromAPILabels(apiRequest.Labels)
-	if protoLabels != nil {
-		createExpectedMachineRequest.Metadata = &cwssaws.Metadata{
-			Labels: protoLabels,
-		}
-	}
+	createExpectedMachineRequest := expectedMachineToProto(
+		expectedMachine,
+		apiRequest.DefaultBmcUsername,
+		apiRequest.DefaultBmcPassword,
+		apiRequest.Labels,
+	)
 
 	logger.Info().Msg("triggering Expected Machine create workflow on Site")
 
@@ -785,66 +787,12 @@ func (uemh UpdateExpectedMachineHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to update Expected Machine due to DB error", nil)
 	}
 
-	// Build the update request for workflow
-	// BMC credentials come from API request since they're not stored in DB
-	updateExpectedMachineRequest := &cwssaws.ExpectedMachine{
-		Id:                       &cwssaws.UUID{Value: expectedMachine.ID.String()},
-		BmcMacAddress:            updatedExpectedMachine.BmcMacAddress,
-		ChassisSerialNumber:      updatedExpectedMachine.ChassisSerialNumber,
-		FallbackDpuSerialNumbers: updatedExpectedMachine.FallbackDpuSerialNumbers,
-		SkuId:                    updatedExpectedMachine.SkuID,
-	}
-
-	if updatedExpectedMachine.RackID != nil {
-		updateExpectedMachineRequest.RackId = &cwssaws.RackId{Id: *updatedExpectedMachine.RackID}
-	}
-
-	if updatedExpectedMachine.Name != nil {
-		updateExpectedMachineRequest.Name = updatedExpectedMachine.Name
-	}
-
-	if updatedExpectedMachine.Manufacturer != nil {
-		updateExpectedMachineRequest.Manufacturer = updatedExpectedMachine.Manufacturer
-	}
-
-	if updatedExpectedMachine.Model != nil {
-		updateExpectedMachineRequest.Model = updatedExpectedMachine.Model
-	}
-
-	if updatedExpectedMachine.Description != nil {
-		updateExpectedMachineRequest.Description = updatedExpectedMachine.Description
-	}
-
-	if updatedExpectedMachine.FirmwareVersion != nil {
-		updateExpectedMachineRequest.FirmwareVersion = updatedExpectedMachine.FirmwareVersion
-	}
-
-	if updatedExpectedMachine.SlotID != nil {
-		updateExpectedMachineRequest.SlotId = updatedExpectedMachine.SlotID
-	}
-
-	if updatedExpectedMachine.TrayIdx != nil {
-		updateExpectedMachineRequest.TrayIdx = updatedExpectedMachine.TrayIdx
-	}
-
-	if updatedExpectedMachine.HostID != nil {
-		updateExpectedMachineRequest.HostId = updatedExpectedMachine.HostID
-	}
-
-	if apiRequest.DefaultBmcUsername != nil {
-		updateExpectedMachineRequest.BmcUsername = *apiRequest.DefaultBmcUsername
-	}
-
-	if apiRequest.DefaultBmcPassword != nil {
-		updateExpectedMachineRequest.BmcPassword = *apiRequest.DefaultBmcPassword
-	}
-
-	protoLabels := util.ProtobufLabelsFromAPILabels(apiRequest.Labels)
-	if protoLabels != nil {
-		updateExpectedMachineRequest.Metadata = &cwssaws.Metadata{
-			Labels: protoLabels,
-		}
-	}
+	updateExpectedMachineRequest := expectedMachineToProto(
+		updatedExpectedMachine,
+		apiRequest.DefaultBmcUsername,
+		apiRequest.DefaultBmcPassword,
+		apiRequest.Labels,
+	)
 
 	logger.Info().Msg("triggering ExpectedMachine update workflow")
 

--- a/api/pkg/api/handler/expectedpowershelf.go
+++ b/api/pkg/api/handler/expectedpowershelf.go
@@ -44,6 +44,63 @@ import (
 	tclient "go.temporal.io/sdk/client"
 )
 
+// expectedPowerShelfToProto builds the workflow proto. BMC credentials and
+// labels are passed separately because they may come from the API request
+// rather than the DB record (BMC credentials aren't persisted at all).
+func expectedPowerShelfToProto(eps *cdbm.ExpectedPowerShelf, defaultBmcUsername, defaultBmcPassword *string, labels map[string]string) *cwssaws.ExpectedPowerShelf {
+	proto := &cwssaws.ExpectedPowerShelf{
+		ExpectedPowerShelfId: &cwssaws.UUID{Value: eps.ID.String()},
+		BmcMacAddress:        eps.BmcMacAddress,
+		ShelfSerialNumber:    eps.ShelfSerialNumber,
+	}
+
+	if eps.IpAddress != nil {
+		proto.BmcIpAddress = *eps.IpAddress
+	}
+	if eps.RackID != nil {
+		proto.RackId = &cwssaws.RackId{Id: *eps.RackID}
+	}
+	if eps.Name != nil {
+		proto.Name = eps.Name
+	}
+	if eps.Manufacturer != nil {
+		proto.Manufacturer = eps.Manufacturer
+	}
+	if eps.Model != nil {
+		proto.Model = eps.Model
+	}
+	if eps.Description != nil {
+		proto.Description = eps.Description
+	}
+	if eps.FirmwareVersion != nil {
+		proto.FirmwareVersion = eps.FirmwareVersion
+	}
+	if eps.SlotID != nil {
+		proto.SlotId = eps.SlotID
+	}
+	if eps.TrayIdx != nil {
+		proto.TrayIdx = eps.TrayIdx
+	}
+	if eps.HostID != nil {
+		proto.HostId = eps.HostID
+	}
+
+	if defaultBmcUsername != nil {
+		proto.BmcUsername = *defaultBmcUsername
+	}
+	if defaultBmcPassword != nil {
+		proto.BmcPassword = *defaultBmcPassword
+	}
+
+	if protoLabels := util.ProtobufLabelsFromAPILabels(labels); protoLabels != nil {
+		proto.Metadata = &cwssaws.Metadata{
+			Labels: protoLabels,
+		}
+	}
+
+	return proto
+}
+
 // ~~~~~ Create Handler ~~~~~ //
 
 // CreateExpectedPowerShelfHandler is the API Handler for creating new ExpectedPowerShelf
@@ -196,68 +253,12 @@ func (cepsh CreateExpectedPowerShelfHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to create Expected Power Shelf due to DB error", nil)
 	}
 
-	// Build the create request for workflow
-	// BMC credentials come from API request since they're not stored in DB
-	createExpectedPowerShelfRequest := &cwssaws.ExpectedPowerShelf{
-		ExpectedPowerShelfId: &cwssaws.UUID{Value: expectedPowerShelf.ID.String()},
-		BmcMacAddress:        expectedPowerShelf.BmcMacAddress,
-		ShelfSerialNumber:    expectedPowerShelf.ShelfSerialNumber,
-	}
-
-	if expectedPowerShelf.IpAddress != nil {
-		createExpectedPowerShelfRequest.BmcIpAddress = *expectedPowerShelf.IpAddress
-	}
-
-	if expectedPowerShelf.RackID != nil {
-		createExpectedPowerShelfRequest.RackId = &cwssaws.RackId{Id: *expectedPowerShelf.RackID}
-	}
-
-	if expectedPowerShelf.Name != nil {
-		createExpectedPowerShelfRequest.Name = expectedPowerShelf.Name
-	}
-
-	if expectedPowerShelf.Manufacturer != nil {
-		createExpectedPowerShelfRequest.Manufacturer = expectedPowerShelf.Manufacturer
-	}
-
-	if expectedPowerShelf.Model != nil {
-		createExpectedPowerShelfRequest.Model = expectedPowerShelf.Model
-	}
-
-	if expectedPowerShelf.Description != nil {
-		createExpectedPowerShelfRequest.Description = expectedPowerShelf.Description
-	}
-
-	if expectedPowerShelf.FirmwareVersion != nil {
-		createExpectedPowerShelfRequest.FirmwareVersion = expectedPowerShelf.FirmwareVersion
-	}
-
-	if expectedPowerShelf.SlotID != nil {
-		createExpectedPowerShelfRequest.SlotId = expectedPowerShelf.SlotID
-	}
-
-	if expectedPowerShelf.TrayIdx != nil {
-		createExpectedPowerShelfRequest.TrayIdx = expectedPowerShelf.TrayIdx
-	}
-
-	if expectedPowerShelf.HostID != nil {
-		createExpectedPowerShelfRequest.HostId = expectedPowerShelf.HostID
-	}
-
-	if apiRequest.DefaultBmcUsername != nil {
-		createExpectedPowerShelfRequest.BmcUsername = *apiRequest.DefaultBmcUsername
-	}
-
-	if apiRequest.DefaultBmcPassword != nil {
-		createExpectedPowerShelfRequest.BmcPassword = *apiRequest.DefaultBmcPassword
-	}
-
-	protoLabels := util.ProtobufLabelsFromAPILabels(apiRequest.Labels)
-	if protoLabels != nil {
-		createExpectedPowerShelfRequest.Metadata = &cwssaws.Metadata{
-			Labels: protoLabels,
-		}
-	}
+	createExpectedPowerShelfRequest := expectedPowerShelfToProto(
+		expectedPowerShelf,
+		apiRequest.DefaultBmcUsername,
+		apiRequest.DefaultBmcPassword,
+		apiRequest.Labels,
+	)
 
 	logger.Info().Msg("triggering Expected Power Shelf create workflow on Site")
 
@@ -708,68 +709,12 @@ func (uepsh UpdateExpectedPowerShelfHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to update Expected Power Shelf due to DB error", nil)
 	}
 
-	// Build the update request for workflow
-	// BMC credentials come from API request since they're not stored in DB
-	updateExpectedPowerShelfRequest := &cwssaws.ExpectedPowerShelf{
-		ExpectedPowerShelfId: &cwssaws.UUID{Value: expectedPowerShelf.ID.String()},
-		BmcMacAddress:        updatedExpectedPowerShelf.BmcMacAddress,
-		ShelfSerialNumber:    updatedExpectedPowerShelf.ShelfSerialNumber,
-	}
-
-	if updatedExpectedPowerShelf.IpAddress != nil {
-		updateExpectedPowerShelfRequest.BmcIpAddress = *updatedExpectedPowerShelf.IpAddress
-	}
-
-	if updatedExpectedPowerShelf.RackID != nil {
-		updateExpectedPowerShelfRequest.RackId = &cwssaws.RackId{Id: *updatedExpectedPowerShelf.RackID}
-	}
-
-	if updatedExpectedPowerShelf.Name != nil {
-		updateExpectedPowerShelfRequest.Name = updatedExpectedPowerShelf.Name
-	}
-
-	if updatedExpectedPowerShelf.Manufacturer != nil {
-		updateExpectedPowerShelfRequest.Manufacturer = updatedExpectedPowerShelf.Manufacturer
-	}
-
-	if updatedExpectedPowerShelf.Model != nil {
-		updateExpectedPowerShelfRequest.Model = updatedExpectedPowerShelf.Model
-	}
-
-	if updatedExpectedPowerShelf.Description != nil {
-		updateExpectedPowerShelfRequest.Description = updatedExpectedPowerShelf.Description
-	}
-
-	if updatedExpectedPowerShelf.FirmwareVersion != nil {
-		updateExpectedPowerShelfRequest.FirmwareVersion = updatedExpectedPowerShelf.FirmwareVersion
-	}
-
-	if updatedExpectedPowerShelf.SlotID != nil {
-		updateExpectedPowerShelfRequest.SlotId = updatedExpectedPowerShelf.SlotID
-	}
-
-	if updatedExpectedPowerShelf.TrayIdx != nil {
-		updateExpectedPowerShelfRequest.TrayIdx = updatedExpectedPowerShelf.TrayIdx
-	}
-
-	if updatedExpectedPowerShelf.HostID != nil {
-		updateExpectedPowerShelfRequest.HostId = updatedExpectedPowerShelf.HostID
-	}
-
-	if apiRequest.DefaultBmcUsername != nil {
-		updateExpectedPowerShelfRequest.BmcUsername = *apiRequest.DefaultBmcUsername
-	}
-
-	if apiRequest.DefaultBmcPassword != nil {
-		updateExpectedPowerShelfRequest.BmcPassword = *apiRequest.DefaultBmcPassword
-	}
-
-	protoLabels := util.ProtobufLabelsFromAPILabels(apiRequest.Labels)
-	if protoLabels != nil {
-		updateExpectedPowerShelfRequest.Metadata = &cwssaws.Metadata{
-			Labels: protoLabels,
-		}
-	}
+	updateExpectedPowerShelfRequest := expectedPowerShelfToProto(
+		updatedExpectedPowerShelf,
+		apiRequest.DefaultBmcUsername,
+		apiRequest.DefaultBmcPassword,
+		apiRequest.Labels,
+	)
 
 	logger.Info().Msg("triggering ExpectedPowerShelf update workflow")
 

--- a/api/pkg/api/handler/expectedswitch.go
+++ b/api/pkg/api/handler/expectedswitch.go
@@ -44,6 +44,66 @@ import (
 	tclient "go.temporal.io/sdk/client"
 )
 
+// expectedSwitchToProto builds the workflow proto. BMC and NVOS credentials
+// and labels are passed separately because they may come from the API request
+// rather than the DB record (credentials aren't persisted at all).
+func expectedSwitchToProto(es *cdbm.ExpectedSwitch, defaultBmcUsername, defaultBmcPassword, nvOsUsername, nvOsPassword *string, labels map[string]string) *cwssaws.ExpectedSwitch {
+	proto := &cwssaws.ExpectedSwitch{
+		ExpectedSwitchId:   &cwssaws.UUID{Value: es.ID.String()},
+		BmcMacAddress:      es.BmcMacAddress,
+		SwitchSerialNumber: es.SwitchSerialNumber,
+	}
+
+	if es.RackID != nil {
+		proto.RackId = &cwssaws.RackId{Id: *es.RackID}
+	}
+	if es.Name != nil {
+		proto.Name = es.Name
+	}
+	if es.Manufacturer != nil {
+		proto.Manufacturer = es.Manufacturer
+	}
+	if es.Model != nil {
+		proto.Model = es.Model
+	}
+	if es.Description != nil {
+		proto.Description = es.Description
+	}
+	if es.FirmwareVersion != nil {
+		proto.FirmwareVersion = es.FirmwareVersion
+	}
+	if es.SlotID != nil {
+		proto.SlotId = es.SlotID
+	}
+	if es.TrayIdx != nil {
+		proto.TrayIdx = es.TrayIdx
+	}
+	if es.HostID != nil {
+		proto.HostId = es.HostID
+	}
+
+	if defaultBmcUsername != nil {
+		proto.BmcUsername = *defaultBmcUsername
+	}
+	if defaultBmcPassword != nil {
+		proto.BmcPassword = *defaultBmcPassword
+	}
+	if nvOsUsername != nil {
+		proto.NvosUsername = nvOsUsername
+	}
+	if nvOsPassword != nil {
+		proto.NvosPassword = nvOsPassword
+	}
+
+	if protoLabels := util.ProtobufLabelsFromAPILabels(labels); protoLabels != nil {
+		proto.Metadata = &cwssaws.Metadata{
+			Labels: protoLabels,
+		}
+	}
+
+	return proto
+}
+
 // ~~~~~ Create Handler ~~~~~ //
 
 // CreateExpectedSwitchHandler is the API Handler for creating new ExpectedSwitch
@@ -195,72 +255,14 @@ func (cesh CreateExpectedSwitchHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to create Expected Switch due to DB error", nil)
 	}
 
-	// Build the create request for workflow
-	// NVOS credentials come from API request since they're not stored in DB
-	createExpectedSwitchRequest := &cwssaws.ExpectedSwitch{
-		ExpectedSwitchId:   &cwssaws.UUID{Value: expectedSwitch.ID.String()},
-		BmcMacAddress:      expectedSwitch.BmcMacAddress,
-		SwitchSerialNumber: expectedSwitch.SwitchSerialNumber,
-	}
-
-	if expectedSwitch.RackID != nil {
-		createExpectedSwitchRequest.RackId = &cwssaws.RackId{Id: *expectedSwitch.RackID}
-	}
-
-	if expectedSwitch.Name != nil {
-		createExpectedSwitchRequest.Name = expectedSwitch.Name
-	}
-
-	if expectedSwitch.Manufacturer != nil {
-		createExpectedSwitchRequest.Manufacturer = expectedSwitch.Manufacturer
-	}
-
-	if expectedSwitch.Model != nil {
-		createExpectedSwitchRequest.Model = expectedSwitch.Model
-	}
-
-	if expectedSwitch.Description != nil {
-		createExpectedSwitchRequest.Description = expectedSwitch.Description
-	}
-
-	if expectedSwitch.FirmwareVersion != nil {
-		createExpectedSwitchRequest.FirmwareVersion = expectedSwitch.FirmwareVersion
-	}
-
-	if expectedSwitch.SlotID != nil {
-		createExpectedSwitchRequest.SlotId = expectedSwitch.SlotID
-	}
-
-	if expectedSwitch.TrayIdx != nil {
-		createExpectedSwitchRequest.TrayIdx = expectedSwitch.TrayIdx
-	}
-
-	if expectedSwitch.HostID != nil {
-		createExpectedSwitchRequest.HostId = expectedSwitch.HostID
-	}
-
-	if apiRequest.DefaultBmcUsername != nil {
-		createExpectedSwitchRequest.BmcUsername = *apiRequest.DefaultBmcUsername
-	}
-
-	if apiRequest.DefaultBmcPassword != nil {
-		createExpectedSwitchRequest.BmcPassword = *apiRequest.DefaultBmcPassword
-	}
-
-	if apiRequest.NvOsUsername != nil {
-		createExpectedSwitchRequest.NvosUsername = apiRequest.NvOsUsername
-	}
-
-	if apiRequest.NvOsPassword != nil {
-		createExpectedSwitchRequest.NvosPassword = apiRequest.NvOsPassword
-	}
-
-	protoLabels := util.ProtobufLabelsFromAPILabels(apiRequest.Labels)
-	if protoLabels != nil {
-		createExpectedSwitchRequest.Metadata = &cwssaws.Metadata{
-			Labels: protoLabels,
-		}
-	}
+	createExpectedSwitchRequest := expectedSwitchToProto(
+		expectedSwitch,
+		apiRequest.DefaultBmcUsername,
+		apiRequest.DefaultBmcPassword,
+		apiRequest.NvOsUsername,
+		apiRequest.NvOsPassword,
+		apiRequest.Labels,
+	)
 
 	logger.Info().Msg("triggering Expected Switch create workflow on Site")
 
@@ -710,72 +712,14 @@ func (uesh UpdateExpectedSwitchHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to update Expected Switch due to DB error", nil)
 	}
 
-	// Build the update request for workflow
-	// NVOS credentials come from API request since they're not stored in DB
-	updateExpectedSwitchRequest := &cwssaws.ExpectedSwitch{
-		ExpectedSwitchId:   &cwssaws.UUID{Value: expectedSwitch.ID.String()},
-		BmcMacAddress:      updatedExpectedSwitch.BmcMacAddress,
-		SwitchSerialNumber: updatedExpectedSwitch.SwitchSerialNumber,
-	}
-
-	if updatedExpectedSwitch.RackID != nil {
-		updateExpectedSwitchRequest.RackId = &cwssaws.RackId{Id: *updatedExpectedSwitch.RackID}
-	}
-
-	if updatedExpectedSwitch.Name != nil {
-		updateExpectedSwitchRequest.Name = updatedExpectedSwitch.Name
-	}
-
-	if updatedExpectedSwitch.Manufacturer != nil {
-		updateExpectedSwitchRequest.Manufacturer = updatedExpectedSwitch.Manufacturer
-	}
-
-	if updatedExpectedSwitch.Model != nil {
-		updateExpectedSwitchRequest.Model = updatedExpectedSwitch.Model
-	}
-
-	if updatedExpectedSwitch.Description != nil {
-		updateExpectedSwitchRequest.Description = updatedExpectedSwitch.Description
-	}
-
-	if updatedExpectedSwitch.FirmwareVersion != nil {
-		updateExpectedSwitchRequest.FirmwareVersion = updatedExpectedSwitch.FirmwareVersion
-	}
-
-	if updatedExpectedSwitch.SlotID != nil {
-		updateExpectedSwitchRequest.SlotId = updatedExpectedSwitch.SlotID
-	}
-
-	if updatedExpectedSwitch.TrayIdx != nil {
-		updateExpectedSwitchRequest.TrayIdx = updatedExpectedSwitch.TrayIdx
-	}
-
-	if updatedExpectedSwitch.HostID != nil {
-		updateExpectedSwitchRequest.HostId = updatedExpectedSwitch.HostID
-	}
-
-	if apiRequest.DefaultBmcUsername != nil {
-		updateExpectedSwitchRequest.BmcUsername = *apiRequest.DefaultBmcUsername
-	}
-
-	if apiRequest.DefaultBmcPassword != nil {
-		updateExpectedSwitchRequest.BmcPassword = *apiRequest.DefaultBmcPassword
-	}
-
-	if apiRequest.NvOsUsername != nil {
-		updateExpectedSwitchRequest.NvosUsername = apiRequest.NvOsUsername
-	}
-
-	if apiRequest.NvOsPassword != nil {
-		updateExpectedSwitchRequest.NvosPassword = apiRequest.NvOsPassword
-	}
-
-	protoLabels := util.ProtobufLabelsFromAPILabels(apiRequest.Labels)
-	if protoLabels != nil {
-		updateExpectedSwitchRequest.Metadata = &cwssaws.Metadata{
-			Labels: protoLabels,
-		}
-	}
+	updateExpectedSwitchRequest := expectedSwitchToProto(
+		updatedExpectedSwitch,
+		apiRequest.DefaultBmcUsername,
+		apiRequest.DefaultBmcPassword,
+		apiRequest.NvOsUsername,
+		apiRequest.NvOsPassword,
+		apiRequest.Labels,
+	)
 
 	logger.Info().Msg("triggering ExpectedSwitch update workflow")
 


### PR DESCRIPTION
## Description

Continuing the `Expected*` cleanup. Each of the resources had 2x nearly-identical ~50-line copy-pasta-ish blocks that translated the DB record (plus BMC creds and labels from the API request) into the workflow proto. I mean it's my fault to begin with, since I was the one who did it, but hey, now I'm cleaning it up!

This pulls each resource's proto translation into a single private helper (`expectedMachineToProto`, `expectedPowerShelfToProto`, `expectedSwitchToProto`), kept next to its handlers. Each call site now collapses down to a four-line invocation. Any unique resource-specific behaviors are left in-tact (e.g. PowerShelf maps `IpAddress` to `BmcIpAddress`, Switch plumbing of `NvOs` credentials, Machine setting of `FallbackDpuSerialNumbers` and `SkuId`).

This is kind of the equivalent of a `From/TryFrom` implementation.

Note! The batch handlers (`CreateExpectedMachinesHandler`, `UpdateExpectedMachinesHandler`) still build their proto inline. I left alone here since they're not wired into routes. I'm planning on doing a separate, wider cleanup. There are actually a TON of places we can do this, but I wanted to do this smaller PR first as an example!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [x] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
