### PR TITLE
chore: Use existing protobuf API label-conversion helper across handlers

### DIFF
--- a/api/pkg/api/handler/infinibandpartition.go
+++ b/api/pkg/api/handler/infinibandpartition.go
@@ -36,6 +36,7 @@ import (
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/internal/config"
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/handler/util/common"
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/model"
+	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/model/util"
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/pagination"
 	sc "github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/client/site"
 	auth "github.com/NVIDIA/ncx-infra-controller-rest/auth/pkg/authorization"
@@ -283,19 +284,7 @@ func (cibph CreateInfiniBandPartitionHandler) Handle(c echo.Context) error {
 		metadata.Description = *ibp.Description
 	}
 
-	// Prepare labels for site controller
-	if len(ibp.Labels) > 0 {
-		var labels []*cwssaws.Label
-		for key, value := range ibp.Labels {
-			curVal := value
-			localLable := &cwssaws.Label{
-				Key:   key,
-				Value: &curVal,
-			}
-			labels = append(labels, localLable)
-		}
-		metadata.Labels = labels
-	}
+	metadata.Labels = util.ProtobufLabelsFromAPILabels(ibp.Labels)
 
 	createIBPRequest.Metadata = metadata
 
@@ -875,14 +864,7 @@ func (uibph UpdateInfiniBandPartitionHandler) Handle(c echo.Context) error {
 	if uipb.Description != nil {
 		metadata.Description = *uipb.Description
 	}
-	var clabels []*cwssaws.Label
-	if len(uipb.Labels) > 0 {
-		for key, value := range uipb.Labels {
-			curVal := value
-			clabels = append(clabels, &cwssaws.Label{Key: key, Value: &curVal})
-		}
-	}
-	metadata.Labels = clabels
+	metadata.Labels = util.ProtobufLabelsFromAPILabels(uipb.Labels)
 	updateIBPRequest.Metadata = metadata
 
 	workflowOptions := temporalClient.StartWorkflowOptions{

--- a/api/pkg/api/handler/instance.go
+++ b/api/pkg/api/handler/instance.go
@@ -41,6 +41,7 @@ import (
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/internal/config"
 	common "github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/handler/util/common"
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/model"
+	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/model/util"
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/pagination"
 	sc "github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/client/site"
 	auth "github.com/NVIDIA/ncx-infra-controller-rest/auth/pkg/authorization"
@@ -1518,14 +1519,7 @@ func (cih CreateInstanceHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
 	}
 
-	// Prepare the labels for the metadata of the carbide call.
-	createLabels := []*cwssaws.Label{}
-	for k, v := range instance.Labels {
-		createLabels = append(createLabels, &cwssaws.Label{
-			Key:   k,
-			Value: &v,
-		})
-	}
+	createLabels := util.ProtobufLabelsFromAPILabels(instance.Labels)
 
 	description := ""
 	if instance.Description != nil {
@@ -3213,14 +3207,7 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
 	}
 
-	// Prepare the labels for the metadata of the carbide call.
-	labels := []*cwssaws.Label{}
-	for k, v := range ui.Labels {
-		labels = append(labels, &cwssaws.Label{
-			Key:   k,
-			Value: &v,
-		})
-	}
+	labels := util.ProtobufLabelsFromAPILabels(ui.Labels)
 
 	description := ""
 	if ui.Description != nil {

--- a/api/pkg/api/handler/instancebatch.go
+++ b/api/pkg/api/handler/instancebatch.go
@@ -39,6 +39,7 @@ import (
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/internal/config"
 	common "github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/handler/util/common"
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/model"
+	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/model/util"
 	sc "github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/client/site"
 	auth "github.com/NVIDIA/ncx-infra-controller-rest/auth/pkg/authorization"
 	cutil "github.com/NVIDIA/ncx-infra-controller-rest/common/pkg/util"
@@ -1603,14 +1604,7 @@ func (bcih BatchCreateInstanceHandler) Handle(c echo.Context) error {
 	for _, data := range createdInstancesData {
 		instance := data.instance
 
-		// Prepare labels for metadata
-		createLabels := []*cwssaws.Label{}
-		for k, v := range instance.Labels {
-			createLabels = append(createLabels, &cwssaws.Label{
-				Key:   k,
-				Value: &v,
-			})
-		}
+		createLabels := util.ProtobufLabelsFromAPILabels(instance.Labels)
 
 		description := ""
 		if instance.Description != nil {

--- a/api/pkg/api/handler/instancetype.go
+++ b/api/pkg/api/handler/instancetype.go
@@ -49,6 +49,7 @@ import (
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/handler/util/common"
 	ch "github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/handler/util/common"
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/model"
+	mutil "github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/model/util"
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/pagination"
 	sc "github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/client/site"
 	auth "github.com/NVIDIA/ncx-infra-controller-rest/auth/pkg/authorization"
@@ -395,19 +396,7 @@ func (cith CreateInstanceTypeHandler) Handle(c echo.Context) error {
 		metadata.Description = *it.Description
 	}
 
-	// Prepare labels for site controller
-	if len(it.Labels) > 0 {
-		var labels []*cwssaws.Label
-		for key, value := range it.Labels {
-			curVal := value
-			localLable := &cwssaws.Label{
-				Key:   key,
-				Value: &curVal,
-			}
-			labels = append(labels, localLable)
-		}
-		metadata.Labels = labels
-	}
+	metadata.Labels = mutil.ProtobufLabelsFromAPILabels(it.Labels)
 
 	createInstanceTypeRequest.Metadata = metadata
 
@@ -1415,17 +1404,7 @@ func (uith UpdateInstanceTypeHandler) Handle(c echo.Context) error {
 		metadata.Description = *it.Description
 	}
 
-	// Prepare the labels for the metadata of the carbide call.
-	var labels []*cwssaws.Label
-	for key, value := range it.Labels {
-		curVal := value
-		localLable := &cwssaws.Label{
-			Key:   key,
-			Value: &curVal,
-		}
-		labels = append(labels, localLable)
-	}
-	metadata.Labels = labels
+	metadata.Labels = mutil.ProtobufLabelsFromAPILabels(it.Labels)
 
 	updateInstanceTypeRequest.Metadata = metadata
 

--- a/api/pkg/api/handler/machine.go
+++ b/api/pkg/api/handler/machine.go
@@ -52,6 +52,7 @@ import (
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/internal/config"
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/handler/util/common"
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/model"
+	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/model/util"
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/pagination"
 	auth "github.com/NVIDIA/ncx-infra-controller-rest/auth/pkg/authorization"
 	cutil "github.com/NVIDIA/ncx-infra-controller-rest/common/pkg/util"
@@ -1320,10 +1321,7 @@ func (umh UpdateMachineHandler) Handle(c echo.Context) error {
 			TaskQueue:                queue.SiteTaskQueue,
 		}
 
-		labels := []*cwssaws.Label{}
-		for key, value := range apiRequest.Labels {
-			labels = append(labels, &cwssaws.Label{Key: key, Value: cdb.GetStrPtr(value)})
-		}
+		labels := util.ProtobufLabelsFromAPILabels(apiRequest.Labels)
 
 		machineName := machine.ID
 		if machine.Metadata != nil && machine.Metadata.Metadata != nil {

--- a/api/pkg/api/handler/networksecuritygroup.go
+++ b/api/pkg/api/handler/networksecuritygroup.go
@@ -33,6 +33,7 @@ import (
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/internal/config"
 	common "github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/handler/util/common"
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/model"
+	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/model/util"
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/pagination"
 	sc "github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/client/site"
 	auth "github.com/NVIDIA/ncx-infra-controller-rest/auth/pkg/authorization"
@@ -271,14 +272,7 @@ func (cnsgh CreateNetworkSecurityGroupHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
 	}
 
-	// Prepare the labels for the metadata of the carbide call.
-	createLabels := []*cwssaws.Label{}
-	for k, v := range networkSecurityGroup.Labels {
-		createLabels = append(createLabels, &cwssaws.Label{
-			Key:   k,
-			Value: &v,
-		})
-	}
+	createLabels := util.ProtobufLabelsFromAPILabels(networkSecurityGroup.Labels)
 
 	description := ""
 	if networkSecurityGroup.Description != nil {
@@ -1253,14 +1247,7 @@ func (dnsgh UpdateNetworkSecurityGroupHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
 	}
 
-	// Prepare the labels for the metadata of the carbide call.
-	labels := []*cwssaws.Label{}
-	for k, v := range nsg.Labels {
-		labels = append(labels, &cwssaws.Label{
-			Key:   k,
-			Value: &v,
-		})
-	}
+	labels := util.ProtobufLabelsFromAPILabels(nsg.Labels)
 
 	description := ""
 	if nsg.Description != nil {

--- a/api/pkg/api/handler/vpc.go
+++ b/api/pkg/api/handler/vpc.go
@@ -43,6 +43,7 @@ import (
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/internal/config"
 	common "github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/handler/util/common"
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/model"
+	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/model/util"
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/pagination"
 	sc "github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/client/site"
 	auth "github.com/NVIDIA/ncx-infra-controller-rest/auth/pkg/authorization"
@@ -425,19 +426,7 @@ func (cvh CreateVPCHandler) Handle(c echo.Context) error {
 		metadata.Description = *vpc.Description
 	}
 
-	// Prepare labels for site controller
-	if len(vpc.Labels) > 0 {
-		var labels []*cwssaws.Label
-		for key, value := range vpc.Labels {
-			curVal := value
-			localLable := &cwssaws.Label{
-				Key:   key,
-				Value: &curVal,
-			}
-			labels = append(labels, localLable)
-		}
-		metadata.Labels = labels
-	}
+	metadata.Labels = util.ProtobufLabelsFromAPILabels(vpc.Labels)
 	createVpcRequest.Metadata = metadata
 
 	logger.Info().Msg("triggering VPC create workflow")
@@ -866,18 +855,7 @@ func (uvh UpdateVPCHandler) Handle(c echo.Context) error {
 		metadata.Description = *vpc.Description
 	}
 
-	// Prepare the labels
-	clabels := []*cwssaws.Label{}
-	for key, value := range vpc.Labels {
-		curVal := value
-		localLable := &cwssaws.Label{
-			Key:   key,
-			Value: &curVal,
-		}
-		clabels = append(clabels, localLable)
-	}
-
-	metadata.Labels = clabels
+	metadata.Labels = util.ProtobufLabelsFromAPILabels(vpc.Labels)
 	updateVpcRequest.Metadata = metadata
 
 	logger.Info().Msg("triggering VPC update workflow")


### PR DESCRIPTION
## Description

Following on from #451 (the `Expected*` proto-builder helpers), I noticed the only handlers calling `util.ProtobufLabelsFromAPILabels` were the `Expected*` handlers -- every other handler was manually doing the same conversion with a 5-7 line for-loop, some with slightly different ideas of how to do it.

This swaps each manual loop for a call to the existing helper. The helper handles `nil`/empty input identically (returns `nil` for `nil`, empty slice for empty map; both marshal the same on the wire), meaning the `if len > 0` guards just go away too.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [x] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
