### PR TITLE
refactor: Introduce a CarbideAtomicClient.Forge() helper

### DIFF
--- a/site-workflow/pkg/activity/dpuextensionservice.go
+++ b/site-workflow/pkg/activity/dpuextensionservice.go
@@ -131,11 +131,10 @@ func (mdes *ManageDpuExtensionService) CreateDpuExtensionServiceOnSite(ctx conte
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mdes.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return nil, cclient.ErrClientNotConnected
+	forgeClient, err := mdes.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return nil, err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	createdDpuExtensionService, err := forgeClient.CreateDpuExtensionService(ctx, request)
 	if err != nil {
@@ -168,11 +167,10 @@ func (mdes *ManageDpuExtensionService) UpdateDpuExtensionServiceOnSite(ctx conte
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mdes.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return nil, cclient.ErrClientNotConnected
+	forgeClient, err := mdes.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return nil, err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	updatedDpuExtensionService, err := forgeClient.UpdateDpuExtensionService(ctx, request)
 	if err != nil {
@@ -205,11 +203,10 @@ func (mdes *ManageDpuExtensionService) DeleteDpuExtensionServiceOnSite(ctx conte
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mdes.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cclient.ErrClientNotConnected
+	forgeClient, err := mdes.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.DeleteDpuExtensionService(ctx, request)
 	if err != nil {
@@ -242,11 +239,10 @@ func (mdes *ManageDpuExtensionService) GetDpuExtensionServiceVersionsInfoOnSite(
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mdes.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return nil, cclient.ErrClientNotConnected
+	forgeClient, err := mdes.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return nil, err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	versionInfos, err := forgeClient.GetDpuExtensionServiceVersionsInfo(ctx, request)
 	if err != nil {

--- a/site-workflow/pkg/activity/expectedmachine.go
+++ b/site-workflow/pkg/activity/expectedmachine.go
@@ -63,11 +63,10 @@ func (memi *ManageExpectedMachineInventory) DiscoverExpectedMachineInventory(ctx
 	}
 
 	// Get Site Controller gRPC client
-	carbideClient := memi.carbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cclient.ErrClientNotConnected
+	forgeClient, err := memi.carbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	// Call GetAllExpectedMachines to get full list of ExpectedMachines on Site
 	emList, err := forgeClient.GetAllExpectedMachines(ctx, &emptypb.Empty{})
@@ -290,11 +289,10 @@ func (mem *ManageExpectedMachine) CreateExpectedMachineOnSite(ctx context.Contex
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mem.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cclient.ErrClientNotConnected
+	forgeClient, err := mem.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	// Call Forge gRPC endpoint
 	_, err = forgeClient.AddExpectedMachine(ctx, request)
@@ -330,11 +328,10 @@ func (mem *ManageExpectedMachine) UpdateExpectedMachineOnSite(ctx context.Contex
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mem.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cclient.ErrClientNotConnected
+	forgeClient, err := mem.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.UpdateExpectedMachine(ctx, request)
 	if err != nil {
@@ -367,11 +364,10 @@ func (mem *ManageExpectedMachine) DeleteExpectedMachineOnSite(ctx context.Contex
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mem.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cclient.ErrClientNotConnected
+	forgeClient, err := mem.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.DeleteExpectedMachine(ctx, request)
 	if err != nil {
@@ -404,11 +400,10 @@ func (mem *ManageExpectedMachine) CreateExpectedMachinesOnSite(ctx context.Conte
 	}
 
 	// Call Site Controller gRPC batch endpoint
-	carbideClient := mem.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return nil, cclient.ErrClientNotConnected
+	forgeClient, err := mem.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return nil, err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	// Call the batch CreateExpectedMachines endpoint
 	response, err := forgeClient.CreateExpectedMachines(ctx, request)
@@ -593,11 +588,10 @@ func (mem *ManageExpectedMachine) UpdateExpectedMachinesOnSite(ctx context.Conte
 	}
 
 	// Call Site Controller gRPC batch endpoint
-	carbideClient := mem.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return nil, cclient.ErrClientNotConnected
+	forgeClient, err := mem.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return nil, err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	// Call the batch UpdateExpectedMachines endpoint
 	response, err := forgeClient.UpdateExpectedMachines(ctx, request)

--- a/site-workflow/pkg/activity/expectedpowershelf.go
+++ b/site-workflow/pkg/activity/expectedpowershelf.go
@@ -63,11 +63,10 @@ func (mepsi *ManageExpectedPowerShelfInventory) DiscoverExpectedPowerShelfInvent
 	}
 
 	// Get Site Controller gRPC client
-	carbideClient := mepsi.carbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cclient.ErrClientNotConnected
+	forgeClient, err := mepsi.carbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	// Call GetAllExpectedPowerShelves to get full list of ExpectedPowerShelves on Site
 	epsList, err := forgeClient.GetAllExpectedPowerShelves(ctx, &emptypb.Empty{})
@@ -290,11 +289,10 @@ func (meps *ManageExpectedPowerShelf) CreateExpectedPowerShelfOnSite(ctx context
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := meps.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cclient.ErrClientNotConnected
+	forgeClient, err := meps.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	// Call Forge gRPC endpoint
 	_, err = forgeClient.AddExpectedPowerShelf(ctx, request)
@@ -330,11 +328,10 @@ func (meps *ManageExpectedPowerShelf) UpdateExpectedPowerShelfOnSite(ctx context
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := meps.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cclient.ErrClientNotConnected
+	forgeClient, err := meps.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.UpdateExpectedPowerShelf(ctx, request)
 	if err != nil {
@@ -464,11 +461,10 @@ func (meps *ManageExpectedPowerShelf) DeleteExpectedPowerShelfOnSite(ctx context
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := meps.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cclient.ErrClientNotConnected
+	forgeClient, err := meps.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.DeleteExpectedPowerShelf(ctx, request)
 	if err != nil {

--- a/site-workflow/pkg/activity/expectedswitch.go
+++ b/site-workflow/pkg/activity/expectedswitch.go
@@ -63,11 +63,10 @@ func (mesi *ManageExpectedSwitchInventory) DiscoverExpectedSwitchInventory(ctx c
 	}
 
 	// Get Site Controller gRPC client
-	carbideClient := mesi.carbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cclient.ErrClientNotConnected
+	forgeClient, err := mesi.carbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	// Call GetAllExpectedSwitches to get full list of ExpectedSwitches on Site
 	esList, err := forgeClient.GetAllExpectedSwitches(ctx, &emptypb.Empty{})
@@ -290,11 +289,10 @@ func (mes *ManageExpectedSwitch) CreateExpectedSwitchOnSite(ctx context.Context,
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mes.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cclient.ErrClientNotConnected
+	forgeClient, err := mes.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	// Call Forge gRPC endpoint
 	_, err = forgeClient.AddExpectedSwitch(ctx, request)
@@ -330,11 +328,10 @@ func (mes *ManageExpectedSwitch) UpdateExpectedSwitchOnSite(ctx context.Context,
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mes.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cclient.ErrClientNotConnected
+	forgeClient, err := mes.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.UpdateExpectedSwitch(ctx, request)
 	if err != nil {
@@ -459,11 +456,10 @@ func (mes *ManageExpectedSwitch) DeleteExpectedSwitchOnSite(ctx context.Context,
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mes.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cclient.ErrClientNotConnected
+	forgeClient, err := mes.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.DeleteExpectedSwitch(ctx, request)
 	if err != nil {

--- a/site-workflow/pkg/activity/ibpartition.go
+++ b/site-workflow/pkg/activity/ibpartition.go
@@ -144,12 +144,10 @@ func (mibp *ManageInfiniBandPartition) CreateInfiniBandPartitionOnSite(ctx conte
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mibp.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return client.ErrClientNotConnected
+	forgeClient, err := mibp.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.CreateIBPartition(ctx, request)
 	if err != nil {
@@ -183,12 +181,10 @@ func (mibp *ManageInfiniBandPartition) UpdateInfiniBandPartitionOnSite(ctx conte
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mibp.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return client.ErrClientNotConnected
+	forgeClient, err := mibp.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.UpdateIBPartition(ctx, request)
 	if err != nil {
@@ -221,12 +217,10 @@ func (mipb *ManageInfiniBandPartition) DeleteInfiniBandPartitionOnSite(ctx conte
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mipb.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return client.ErrClientNotConnected
+	forgeClient, err := mipb.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.DeleteIBPartition(ctx, request)
 	if err != nil {

--- a/site-workflow/pkg/activity/instance.go
+++ b/site-workflow/pkg/activity/instance.go
@@ -59,12 +59,10 @@ func (mm *ManageInstance) UpdateInstanceOnSite(ctx context.Context, request *cws
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mm.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mm.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.UpdateInstanceConfig(ctx, request)
 	if err != nil {
@@ -97,12 +95,10 @@ func (mm *ManageInstance) CreateInstanceOnSite(ctx context.Context, request *cws
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mm.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mm.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.AllocateInstance(ctx, request)
 	if err != nil {
@@ -141,12 +137,10 @@ func (mm *ManageInstance) CreateInstancesOnSite(ctx context.Context, request *cw
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mm.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mm.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.AllocateInstances(ctx, request)
 	if err != nil {
@@ -178,12 +172,10 @@ func (mm *ManageInstance) RebootInstanceOnSite(ctx context.Context, request *cws
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mm.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mm.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.InvokeInstancePower(ctx, request)
 	if err != nil {
@@ -216,12 +208,10 @@ func (mm *ManageInstance) DeleteInstanceOnSite(ctx context.Context, request *cws
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mm.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mm.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.ReleaseInstance(ctx, request)
 	if err != nil {

--- a/site-workflow/pkg/activity/instancetype.go
+++ b/site-workflow/pkg/activity/instancetype.go
@@ -60,11 +60,10 @@ func (mm *ManageInstanceType) CreateInstanceTypeOnSite(ctx context.Context, requ
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mm.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mm.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.CreateInstanceType(ctx, request)
 	if err != nil {
@@ -97,11 +96,10 @@ func (mm *ManageInstanceType) UpdateInstanceTypeOnSite(ctx context.Context, requ
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mm.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mm.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.UpdateInstanceType(ctx, request)
 	if err != nil {
@@ -134,11 +132,10 @@ func (mm *ManageInstanceType) DeleteInstanceTypeOnSite(ctx context.Context, requ
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mm.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mm.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.DeleteInstanceType(ctx, request)
 	if err != nil {
@@ -174,11 +171,10 @@ func (mm *ManageInstanceType) AssociateMachinesWithInstanceTypeOnSite(ctx contex
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mm.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mm.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.AssociateMachinesWithInstanceType(ctx, request)
 	if err != nil {
@@ -212,11 +208,10 @@ func (mm *ManageInstanceType) RemoveMachineInstanceTypeAssociationOnSite(ctx con
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mm.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mm.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.RemoveMachineInstanceTypeAssociation(ctx, request)
 	if err != nil {

--- a/site-workflow/pkg/activity/machine.go
+++ b/site-workflow/pkg/activity/machine.go
@@ -62,11 +62,10 @@ func (mm *ManageMachine) SetMachineMaintenanceOnSite(ctx context.Context, reques
 	}
 
 	// Call Site Controller gRPC endpoint to set SetMaintenance request
-	carbideClient := mm.carbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mm.carbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.SetMaintenance(ctx, request)
 	if err != nil {
@@ -99,11 +98,10 @@ func (mm *ManageMachine) UpdateMachineMetadataOnSite(ctx context.Context, reques
 	}
 
 	// Call Site Controller gRPC endpoint to update Machine metadata
-	carbideClient := mm.carbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mm.carbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.UpdateMachineMetadata(ctx, request)
 	if err != nil {
@@ -131,11 +129,10 @@ func (mm *ManageMachine) GetDpuMachinesByIDs(ctx context.Context, dpuMachineIDs 
 	}
 
 	// Call Site Controller gRPC endpoint to get DPU Machines by IDs
-	carbideClient := mm.carbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return nil, cClient.ErrClientNotConnected
+	forgeClient, err := mm.carbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return nil, err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	// Convert string IDs to MachineId objects
 	machineIDs := make([]*cwssaws.MachineId, 0, len(dpuMachineIDs))
@@ -209,11 +206,10 @@ func (mmi *ManageMachineInventory) CollectAndPublishMachineInventory(ctx context
 	}
 
 	// Call Site Controller gRPC endpoint to get available Machine IDs
-	carbideClient := mmi.carbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mmi.carbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	machineIDList, err := forgeClient.FindMachineIds(ctx, &cwssaws.MachineSearchConfig{})
 	if err != nil {

--- a/site-workflow/pkg/activity/machinevalidation.go
+++ b/site-workflow/pkg/activity/machinevalidation.go
@@ -61,12 +61,12 @@ func (mmv *ManageMachineValidation) EnableDisableMachineValidationTestOnSite(ctx
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mmv.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return client.ErrClientNotConnected
+	forgeClient, err := mmv.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
 
-	_, err = carbideClient.Carbide().MachineValidationTestEnableDisableTest(ctx, request)
+	_, err = forgeClient.MachineValidationTestEnableDisableTest(ctx, request)
 	if err != nil {
 		logger.Warn().Err(err).Msg("Failed to enable/disable machine validation test using Site Controller API")
 		return swe.WrapErr(err)
@@ -96,12 +96,12 @@ func (mmv *ManageMachineValidation) PersistValidationResultOnSite(ctx context.Co
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mmv.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return client.ErrClientNotConnected
+	forgeClient, err := mmv.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
 
-	_, err = carbideClient.Carbide().PersistValidationResult(ctx, request)
+	_, err = forgeClient.PersistValidationResult(ctx, request)
 	if err != nil {
 		logger.Warn().Err(err).Msg("Failed to persist validation results using Site Controller API")
 		return swe.WrapErr(err)
@@ -129,12 +129,12 @@ func (mmv *ManageMachineValidation) GetMachineValidationResultsFromSite(ctx cont
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mmv.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return nil, client.ErrClientNotConnected
+	forgeClient, err := mmv.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return nil, err
 	}
 
-	result, err := carbideClient.Carbide().GetMachineValidationResults(ctx, request)
+	result, err := forgeClient.GetMachineValidationResults(ctx, request)
 	if err != nil {
 		logger.Warn().Err(err).Msg("Failed to get machine validation results using Site Controller API")
 		return nil, swe.WrapErr(err)
@@ -164,12 +164,12 @@ func (mmv *ManageMachineValidation) GetMachineValidationRunsFromSite(ctx context
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mmv.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return nil, client.ErrClientNotConnected
+	forgeClient, err := mmv.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return nil, err
 	}
 
-	result, err := carbideClient.Carbide().GetMachineValidationRuns(ctx, request)
+	result, err := forgeClient.GetMachineValidationRuns(ctx, request)
 	if err != nil {
 		logger.Warn().Err(err).Msg("Failed to get machine validation runs using Site Controller API")
 		return nil, err
@@ -197,12 +197,12 @@ func (mmv *ManageMachineValidation) GetMachineValidationTestsFromSite(ctx contex
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mmv.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return nil, client.ErrClientNotConnected
+	forgeClient, err := mmv.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return nil, err
 	}
 
-	result, err := carbideClient.Carbide().GetMachineValidationTests(ctx, request)
+	result, err := forgeClient.GetMachineValidationTests(ctx, request)
 	if err != nil {
 		logger.Warn().Err(err).Msg("Failed to get machine validation tests using Site Controller API")
 		return nil, swe.WrapErr(err)
@@ -236,12 +236,12 @@ func (mmv *ManageMachineValidation) AddMachineValidationTestOnSite(ctx context.C
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mmv.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return nil, client.ErrClientNotConnected
+	forgeClient, err := mmv.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return nil, err
 	}
 
-	response, err := carbideClient.Carbide().AddMachineValidationTest(ctx, request)
+	response, err := forgeClient.AddMachineValidationTest(ctx, request)
 	if err != nil {
 		logger.Warn().Err(err).Msg("Failed to add machine validation test using Site Controller API")
 		return nil, swe.WrapErr(err)
@@ -275,12 +275,12 @@ func (mmv *ManageMachineValidation) UpdateMachineValidationTestOnSite(ctx contex
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mmv.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return client.ErrClientNotConnected
+	forgeClient, err := mmv.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
 
-	_, err = carbideClient.Carbide().UpdateMachineValidationTest(ctx, request)
+	_, err = forgeClient.UpdateMachineValidationTest(ctx, request)
 	if err != nil {
 		logger.Warn().Err(err).Msg("Failed to update machine validation test using Site Controller API")
 		return swe.WrapErr(err)
@@ -308,12 +308,12 @@ func (mmv *ManageMachineValidation) GetMachineValidationExternalConfigsFromSite(
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mmv.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return nil, client.ErrClientNotConnected
+	forgeClient, err := mmv.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return nil, err
 	}
 
-	result, err := carbideClient.Carbide().GetMachineValidationExternalConfigs(ctx, request)
+	result, err := forgeClient.GetMachineValidationExternalConfigs(ctx, request)
 	if err != nil {
 		logger.Warn().Err(err).Msg("Failed to get machine validation external configs using Site Controller API")
 		return nil, swe.WrapErr(err)
@@ -343,12 +343,12 @@ func (mmv *ManageMachineValidation) AddUpdateMachineValidationExternalConfigOnSi
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mmv.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return client.ErrClientNotConnected
+	forgeClient, err := mmv.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
 
-	_, err = carbideClient.Carbide().AddUpdateMachineValidationExternalConfig(ctx, request)
+	_, err = forgeClient.AddUpdateMachineValidationExternalConfig(ctx, request)
 	if err != nil {
 		logger.Warn().Err(err).Msg("Failed to add/update machine validation external config using Site Controller API")
 		return swe.WrapErr(err)
@@ -378,12 +378,12 @@ func (mmv *ManageMachineValidation) RemoveMachineValidationExternalConfigOnSite(
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mmv.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return client.ErrClientNotConnected
+	forgeClient, err := mmv.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
 
-	_, err = carbideClient.Carbide().RemoveMachineValidationExternalConfig(ctx, request)
+	_, err = forgeClient.RemoveMachineValidationExternalConfig(ctx, request)
 	if err != nil {
 		logger.Warn().Err(err).Msg("Failed to remove machine validation external config using Site Controller API")
 		return swe.WrapErr(err)

--- a/site-workflow/pkg/activity/networksecuritygroup.go
+++ b/site-workflow/pkg/activity/networksecuritygroup.go
@@ -64,11 +64,10 @@ func (mm *ManageNetworkSecurityGroup) CreateNetworkSecurityGroupOnSite(ctx conte
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mm.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mm.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.CreateNetworkSecurityGroup(ctx, request)
 	if err != nil {
@@ -104,11 +103,10 @@ func (mm *ManageNetworkSecurityGroup) UpdateNetworkSecurityGroupOnSite(ctx conte
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mm.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mm.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.UpdateNetworkSecurityGroup(ctx, request)
 	if err != nil {
@@ -144,11 +142,10 @@ func (mm *ManageNetworkSecurityGroup) DeleteNetworkSecurityGroupOnSite(ctx conte
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mm.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mm.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.DeleteNetworkSecurityGroup(ctx, request)
 	if err != nil {

--- a/site-workflow/pkg/activity/nvlinklogicalpartition.go
+++ b/site-workflow/pkg/activity/nvlinklogicalpartition.go
@@ -143,11 +143,10 @@ func (mnvllp *ManageNVLinkLogicalPartition) CreateNVLinkLogicalPartitionOnSite(c
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mnvllp.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return nil, cClient.ErrClientNotConnected
+	forgeClient, err := mnvllp.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return nil, err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	// Call Forge gRPC endpoint
 	nvLinkLogicalPartition, err := forgeClient.CreateNVLinkLogicalPartition(ctx, request)
@@ -186,11 +185,10 @@ func (mnvllp *ManageNVLinkLogicalPartition) UpdateNVLinkLogicalPartitionOnSite(c
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mnvllp.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mnvllp.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	// Call Forge gRPC endpoint
 	_, err = forgeClient.UpdateNVLinkLogicalPartition(ctx, request)
@@ -224,11 +222,10 @@ func (mnvllp *ManageNVLinkLogicalPartition) DeleteNVLinkLogicalPartitionOnSite(c
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mnvllp.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mnvllp.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.DeleteNVLinkLogicalPartition(ctx, request)
 	if err != nil {

--- a/site-workflow/pkg/activity/operatingsystem.go
+++ b/site-workflow/pkg/activity/operatingsystem.go
@@ -70,12 +70,10 @@ func (mos *ManageOperatingSystem) CreateOsImageOnSite(ctx context.Context, reque
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mos.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return client.ErrClientNotConnected
+	forgeClient, err := mos.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.CreateOsImage(ctx, request)
 	if err != nil {
@@ -112,11 +110,10 @@ func (mos *ManageOperatingSystem) UpdateOsImageOnSite(ctx context.Context, reque
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mos.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return client.ErrClientNotConnected
+	forgeClient, err := mos.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.UpdateOsImage(ctx, request)
 	if err != nil {
@@ -151,11 +148,10 @@ func (mos *ManageOperatingSystem) DeleteOsImageOnSite(ctx context.Context, reque
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mos.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return client.ErrClientNotConnected
+	forgeClient, err := mos.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.DeleteOsImage(ctx, request)
 	if err != nil {

--- a/site-workflow/pkg/activity/sshkeygroup.go
+++ b/site-workflow/pkg/activity/sshkeygroup.go
@@ -137,11 +137,10 @@ func (mmi *ManageSSHKeyGroup) CreateSSHKeyGroupOnSite(ctx context.Context, reque
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mmi.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return client.ErrClientNotConnected
+	forgeClient, err := mmi.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.CreateTenantKeyset(ctx, request)
 	if err != nil {
@@ -178,11 +177,10 @@ func (mmi *ManageSSHKeyGroup) UpdateSSHKeyGroupOnSite(ctx context.Context, reque
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mmi.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return client.ErrClientNotConnected
+	forgeClient, err := mmi.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.UpdateTenantKeyset(ctx, request)
 	if err != nil {
@@ -217,11 +215,10 @@ func (mmi *ManageSSHKeyGroup) DeleteSSHKeyGroupOnSite(ctx context.Context, reque
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mmi.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return client.ErrClientNotConnected
+	forgeClient, err := mmi.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.DeleteTenantKeyset(ctx, request)
 	if err != nil {

--- a/site-workflow/pkg/activity/subnet.go
+++ b/site-workflow/pkg/activity/subnet.go
@@ -74,11 +74,10 @@ func (mm *ManageSubnet) CreateSubnetOnSite(ctx context.Context, request *cwssaws
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mm.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mm.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.CreateNetworkSegment(ctx, request)
 	if err != nil {
@@ -114,11 +113,10 @@ func (mm *ManageSubnet) DeleteSubnetOnSite(ctx context.Context, request *cwssaws
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mm.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mm.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.DeleteNetworkSegment(ctx, request)
 	if err != nil {

--- a/site-workflow/pkg/activity/tenant.go
+++ b/site-workflow/pkg/activity/tenant.go
@@ -59,11 +59,10 @@ func (mt *ManageTenant) CreateTenantOnSite(ctx context.Context, request *cwssaws
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mt.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mt.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.CreateTenant(ctx, request)
 	if err != nil {
@@ -96,11 +95,10 @@ func (mt *ManageTenant) UpdateTenantOnSite(ctx context.Context, request *cwssaws
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mt.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mt.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.UpdateTenant(ctx, request)
 	if err != nil {

--- a/site-workflow/pkg/activity/vpc.go
+++ b/site-workflow/pkg/activity/vpc.go
@@ -168,11 +168,10 @@ func (mv *ManageVPC) CreateVpcOnSite(ctx context.Context, request *cwssaws.VpcCr
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mv.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mv.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.CreateVpc(ctx, request)
 	if err != nil {
@@ -208,11 +207,10 @@ func (mv *ManageVPC) UpdateVpcOnSite(ctx context.Context, request *cwssaws.VpcUp
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mv.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mv.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.UpdateVpc(ctx, request)
 	if err != nil {
@@ -247,11 +245,10 @@ func (mv *ManageVPC) DeleteVpcOnSite(ctx context.Context, request *cwssaws.VpcDe
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mv.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mv.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.DeleteVpc(ctx, request)
 	if err != nil {
@@ -285,11 +282,10 @@ func (mv *ManageVPC) UpdateVpcVirtualizationOnSite(ctx context.Context, request 
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mv.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mv.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.UpdateVpcVirtualization(ctx, request)
 	if err != nil {

--- a/site-workflow/pkg/activity/vpcpeering.go
+++ b/site-workflow/pkg/activity/vpcpeering.go
@@ -68,11 +68,10 @@ func (mvp *ManageVpcPeering) CreateVpcPeeringOnSite(ctx context.Context, request
 	}
 
 	// Call Site Controller API
-	carbideClient := mvp.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mvp.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.CreateVpcPeering(ctx, request)
 	if err != nil {
@@ -105,11 +104,10 @@ func (mvp *ManageVpcPeering) DeleteVpcPeeringOnSite(ctx context.Context, request
 	}
 
 	// Call Site Controller API
-	carbideClient := mvp.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return cClient.ErrClientNotConnected
+	forgeClient, err := mvp.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.DeleteVpcPeering(ctx, request)
 	if err != nil {

--- a/site-workflow/pkg/activity/vpcprefix.go
+++ b/site-workflow/pkg/activity/vpcprefix.go
@@ -64,11 +64,10 @@ func (mvp *ManageVpcPrefix) CreateVpcPrefixOnSite(ctx context.Context, request *
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mvp.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return client.ErrClientNotConnected
+	forgeClient, err := mvp.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.CreateVpcPrefix(ctx, request)
 	if err != nil {
@@ -101,11 +100,10 @@ func (mvp *ManageVpcPrefix) UpdateVpcPrefixOnSite(ctx context.Context, request *
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mvp.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return client.ErrClientNotConnected
+	forgeClient, err := mvp.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.UpdateVpcPrefix(ctx, request)
 	if err != nil {
@@ -138,11 +136,10 @@ func (mvp *ManageVpcPrefix) DeleteVpcPrefixOnSite(ctx context.Context, request *
 	}
 
 	// Call Site Controller gRPC endpoint
-	carbideClient := mvp.CarbideAtomicClient.GetClient()
-	if carbideClient == nil {
-		return client.ErrClientNotConnected
+	forgeClient, err := mvp.CarbideAtomicClient.GetForgeClient()
+	if err != nil {
+		return err
 	}
-	forgeClient := carbideClient.Carbide()
 
 	_, err = forgeClient.DeleteVpcPrefix(ctx, request)
 	if err != nil {

--- a/site-workflow/pkg/grpc/client/carbide_client.go
+++ b/site-workflow/pkg/grpc/client/carbide_client.go
@@ -289,6 +289,17 @@ func (cac *CarbideAtomicClient) GetClient() *CarbideClient {
 	return client
 }
 
+// GetForgeClient returns the underlying Forge gRPC client. Returns ErrClientNotConnected
+// if the client has not been initialized or is not currently connected.
+// Prefer this over GetClient() + manual nil-check + .Carbide() at call sites.
+func (cac *CarbideAtomicClient) GetForgeClient() (wflows.ForgeClient, error) {
+	client := cac.GetClient()
+	if client == nil {
+		return nil, ErrClientNotConnected
+	}
+	return client.Carbide(), nil
+}
+
 // CheckAndReloadCerts continuously monitors the TLS certificates for changes.
 // If a change is detected, it reinitializes the CarbideClient with the new certificates to ensure secure communication.
 func (cac *CarbideAtomicClient) CheckAndReloadCerts(initialClientCertMD5, initialServerCAMD5 []byte) {

--- a/site-workflow/pkg/grpc/client/carbide_client_test.go
+++ b/site-workflow/pkg/grpc/client/carbide_client_test.go
@@ -111,6 +111,29 @@ func TestCarbideAtomicClient_GetClient_ReturnsClientAfterSwap(t *testing.T) {
 	assert.Equal(t, testClient, cac.GetClient())
 }
 
+func TestCarbideAtomicClient_GetForgeClient_ReturnsErrWhenUninitialized(t *testing.T) {
+	cac := &CarbideAtomicClient{
+		value: &atomic.Value{},
+	}
+	// GetForgeClient should return ErrClientNotConnected when no client has been stored,
+	// rather than panicking on a nil-pointer deref.
+	forge, err := cac.GetForgeClient()
+	assert.Nil(t, forge)
+	assert.ErrorIs(t, err, ErrClientNotConnected)
+}
+
+func TestCarbideAtomicClient_GetForgeClient_ReturnsForgeAfterSwap(t *testing.T) {
+	cac := &CarbideAtomicClient{
+		value: &atomic.Value{},
+	}
+	// Once a CarbideClient is stored, GetForgeClient should succeed and delegate to
+	// (*CarbideClient).Carbide(). The underlying carbide field is zero-value
+	// in this test, so we just verify there's no error.
+	cac.value.Store(&CarbideClient{})
+	_, err := cac.GetForgeClient()
+	assert.NoError(t, err)
+}
+
 func TestCarbideAtomicClient_CheckCertificates(t *testing.T) {
 	// Generate files for MD5 hash testing
 	// clientCertBytes := []byte("new test cert file")


### PR DESCRIPTION
## Description

Follow-up to the `nil`-check fix from https://github.com/NVIDIA/infra-controller-rest/pull/458 that brought `PowerShelf`/`Switch` in line with `Machine` (and all other equivalent helpers). Since all of the other helpers do the exact same thing, it seemed like a nice idea to introduce a helper to simplify each call site, AND to make it so this specific `nil`-checking bug class goes away entirely (as in, if this existed already, I wouldn't have whoopsied before).

I'm calling it `.Forge()` since it maps to our `forgeClient` variable naming. I realize the name `Forge` is deprecated at this point, but for the purpose of visibily being easier to comprehend the diff here, I'm keeping it like this, and we can rename later, if that's ok!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [x] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [ ] **API** - API models or endpoints updated
- [x] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
