### PR TITLE
fix: Introduce a GetRLAClient() helper

### DIFF
--- a/site-workflow/pkg/activity/rack.go
+++ b/site-workflow/pkg/activity/rack.go
@@ -61,11 +61,10 @@ func (mr *ManageRack) GetRack(ctx context.Context, request *rlav1.GetRackInfoByI
 	}
 
 	// Call RLA gRPC endpoint
-	rlaClient := mr.RlaAtomicClient.GetClient()
-	if rlaClient == nil {
-		return nil, cClient.ErrClientNotConnected
+	rla, err := mr.RlaAtomicClient.GetRLAClient()
+	if err != nil {
+		return nil, err
 	}
-	rla := rlaClient.Rla()
 
 	response, err := rla.GetRackInfoByID(ctx, request)
 	if err != nil {
@@ -89,11 +88,10 @@ func (mr *ManageRack) GetRacks(ctx context.Context, request *rlav1.GetListOfRack
 	}
 
 	// Call RLA gRPC endpoint
-	rlaClient := mr.RlaAtomicClient.GetClient()
-	if rlaClient == nil {
-		return nil, cClient.ErrClientNotConnected
+	rla, err := mr.RlaAtomicClient.GetRLAClient()
+	if err != nil {
+		return nil, err
 	}
-	rla := rlaClient.Rla()
 
 	response, err := rla.GetListOfRacks(ctx, request)
 	if err != nil {
@@ -125,11 +123,10 @@ func (mr *ManageRack) ValidateRackComponents(ctx context.Context, request *rlav1
 	}
 
 	// Call RLA gRPC endpoint
-	rlaClient := mr.RlaAtomicClient.GetClient()
-	if rlaClient == nil {
-		return nil, cClient.ErrClientNotConnected
+	rla, err := mr.RlaAtomicClient.GetRLAClient()
+	if err != nil {
+		return nil, err
 	}
-	rla := rlaClient.Rla()
 
 	response, err := rla.ValidateComponents(ctx, request)
 	if err != nil {
@@ -160,11 +157,10 @@ func (mr *ManageRack) PowerOnRack(ctx context.Context, request *rlav1.PowerOnRac
 	}
 
 	// Call RLA gRPC endpoint
-	rlaClient := mr.RlaAtomicClient.GetClient()
-	if rlaClient == nil {
-		return nil, cClient.ErrClientNotConnected
+	rla, err := mr.RlaAtomicClient.GetRLAClient()
+	if err != nil {
+		return nil, err
 	}
-	rla := rlaClient.Rla()
 
 	response, err := rla.PowerOnRack(ctx, request)
 	if err != nil {
@@ -195,11 +191,10 @@ func (mr *ManageRack) PowerOffRack(ctx context.Context, request *rlav1.PowerOffR
 	}
 
 	// Call RLA gRPC endpoint
-	rlaClient := mr.RlaAtomicClient.GetClient()
-	if rlaClient == nil {
-		return nil, cClient.ErrClientNotConnected
+	rla, err := mr.RlaAtomicClient.GetRLAClient()
+	if err != nil {
+		return nil, err
 	}
-	rla := rlaClient.Rla()
 
 	response, err := rla.PowerOffRack(ctx, request)
 	if err != nil {
@@ -230,11 +225,10 @@ func (mr *ManageRack) PowerResetRack(ctx context.Context, request *rlav1.PowerRe
 	}
 
 	// Call RLA gRPC endpoint
-	rlaClient := mr.RlaAtomicClient.GetClient()
-	if rlaClient == nil {
-		return nil, cClient.ErrClientNotConnected
+	rla, err := mr.RlaAtomicClient.GetRLAClient()
+	if err != nil {
+		return nil, err
 	}
-	rla := rlaClient.Rla()
 
 	response, err := rla.PowerResetRack(ctx, request)
 	if err != nil {
@@ -263,8 +257,10 @@ func (mr *ManageRack) BringUpRack(ctx context.Context, request *rlav1.BringUpRac
 		return nil, temporal.NewNonRetryableApplicationError(err.Error(), swe.ErrTypeInvalidRequest, err)
 	}
 
-	rlaClient := mr.RlaAtomicClient.GetClient()
-	rla := rlaClient.Rla()
+	rla, err := mr.RlaAtomicClient.GetRLAClient()
+	if err != nil {
+		return nil, err
+	}
 
 	response, err := rla.BringUpRack(ctx, request)
 	if err != nil {
@@ -295,11 +291,10 @@ func (mr *ManageRack) GetTaskByID(ctx context.Context, request *rlav1.GetTasksBy
 		return nil, temporal.NewNonRetryableApplicationError(err.Error(), swe.ErrTypeInvalidRequest, err)
 	}
 
-	rlaClient := mr.RlaAtomicClient.GetClient()
-	if rlaClient == nil {
-		return nil, cClient.ErrClientNotConnected
+	rla, err := mr.RlaAtomicClient.GetRLAClient()
+	if err != nil {
+		return nil, err
 	}
-	rla := rlaClient.Rla()
 
 	response, err := rla.GetTasksByIDs(ctx, request)
 	if err != nil {
@@ -328,11 +323,10 @@ func (mr *ManageRack) UpgradeFirmware(ctx context.Context, request *rlav1.Upgrad
 		return nil, temporal.NewNonRetryableApplicationError(err.Error(), swe.ErrTypeInvalidRequest, err)
 	}
 
-	rlaClient := mr.RlaAtomicClient.GetClient()
-	if rlaClient == nil {
-		return nil, cClient.ErrClientNotConnected
+	rla, err := mr.RlaAtomicClient.GetRLAClient()
+	if err != nil {
+		return nil, err
 	}
-	rla := rlaClient.Rla()
 
 	response, err := rla.UpgradeFirmware(ctx, request)
 	if err != nil {

--- a/site-workflow/pkg/activity/tray.go
+++ b/site-workflow/pkg/activity/tray.go
@@ -53,11 +53,10 @@ func (mt *ManageTray) GetTray(ctx context.Context, request *rlav1.GetComponentIn
 	}
 
 	// Call RLA gRPC endpoint
-	rlaClient := mt.RlaAtomicClient.GetClient()
-	if rlaClient == nil {
-		return nil, cClient.ErrClientNotConnected
+	rla, err := mt.RlaAtomicClient.GetRLAClient()
+	if err != nil {
+		return nil, err
 	}
-	rla := rlaClient.Rla()
 
 	response, err := rla.GetComponentInfoByID(ctx, request)
 	if err != nil {
@@ -81,11 +80,10 @@ func (mt *ManageTray) GetTrays(ctx context.Context, request *rlav1.GetComponents
 	}
 
 	// Call RLA gRPC endpoint
-	rlaClient := mt.RlaAtomicClient.GetClient()
-	if rlaClient == nil {
-		return nil, cClient.ErrClientNotConnected
+	rla, err := mt.RlaAtomicClient.GetRLAClient()
+	if err != nil {
+		return nil, err
 	}
-	rla := rlaClient.Rla()
 
 	response, err := rla.GetComponents(ctx, request)
 	if err != nil {

--- a/site-workflow/pkg/grpc/client/rla_client.go
+++ b/site-workflow/pkg/grpc/client/rla_client.go
@@ -289,6 +289,25 @@ func (rac *RlaAtomicClient) GetClient() *RlaClient {
 	return client
 }
 
+// GetRLAClient returns the underlying RLA gRPC client. Returns ErrClientNotConnected
+// if the client has not been initialized or is not currently connected.
+// Prefer this over GetClient() + manual nil-check + .Rla() at call sites.
+func (rac *RlaAtomicClient) GetRLAClient() (rlav1.RLAClient, error) {
+	client := rac.GetClient()
+	if client == nil {
+		return nil, ErrClientNotConnected
+	}
+	// It's true that NewRlaClient always populates the inner rla field, BUT,
+	// guard against zero-value RlaClient instances slipping in via direct
+	// construction. Without this, a misconstructed wrapper would yield (nil,
+	// nil) and break things.
+	rla := client.Rla()
+	if rla == nil {
+		return nil, ErrClientNotConnected
+	}
+	return rla, nil
+}
+
 // CheckAndReloadCerts continuously monitors the TLS certificates for changes.
 // If a change is detected, it reinitializes the RlaClient with the new certificates to ensure secure communication.
 func (rac *RlaAtomicClient) CheckAndReloadCerts(initialClientCertMD5, initialServerCAMD5 []byte) {

--- a/site-workflow/pkg/grpc/client/rla_client_test.go
+++ b/site-workflow/pkg/grpc/client/rla_client_test.go
@@ -20,9 +20,13 @@ package client
 import (
 	"crypto/md5"
 	"os"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+
+	rlav1 "github.com/NVIDIA/ncx-infra-controller-rest/workflow-schema/rla/protobuf/v1"
 )
 
 func TestRlaAtomicClient_GetInitialCertMD5(t *testing.T) {
@@ -86,6 +90,34 @@ func TestRlaAtomicClient_GetInitialCertMD5(t *testing.T) {
 			assert.Equal(t, tt.wantServerCAMD5, gotServerCAMD5)
 		})
 	}
+}
+
+func TestRlaAtomicClient_GetRLAClient_ReturnsErrWhenUninitialized(t *testing.T) {
+	rac := &RlaAtomicClient{
+		value: &atomic.Value{},
+	}
+	// GetRLAClient should return ErrClientNotConnected when no client has been stored,
+	// rather than panicking on a nil-pointer deref.
+	rla, err := rac.GetRLAClient()
+	assert.Nil(t, rla)
+	assert.ErrorIs(t, err, ErrClientNotConnected)
+}
+
+func TestRlaAtomicClient_GetRLAClient_ReturnsRLAAfterSwap(t *testing.T) {
+	rac := &RlaAtomicClient{
+		value: &atomic.Value{},
+	}
+	// Once a RlaClient with a populated rla field is stored, GetRLAClient
+	// should return that exact inner client. We construct a stub via
+	// rlav1.NewRLAClient(nil); it isn't usable for real RPCs but is a non-nil
+	// rlav1.RLAClient interface value, which is all we need to exercise the
+	// success path.
+	expected := rlav1.NewRLAClient((*grpc.ClientConn)(nil))
+	rac.value.Store(&RlaClient{rla: expected})
+	got, err := rac.GetRLAClient()
+	assert.NoError(t, err)
+	assert.NotNil(t, got)
+	assert.Equal(t, expected, got)
 }
 
 func TestRlaAtomicClient_CheckCertificates(t *testing.T) {


### PR DESCRIPTION
## Description

This mirrors the helper work done in https://github.com/NVIDIA/infra-controller-rest/pull/460 for a `.GetForgeClient()` helper, doing the same for RLA, for the same reasons: it simplifies the call sites, and removes a specific bug class entirely.

As a side effect, this also fixes a latent `nil` check bug  in `BringUpRack` (basically the exact reason https://github.com/NVIDIA/infra-controller-rest/pull/460 ended up becoming a thing -- because I had missed some `nil` checking for other handlers).

Small test included!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [x] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [ ] **API** - API models or endpoints updated
- [x] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
