### PR TITLE
refactor: Introduce db WithTx + migrate Expected handlers

### DIFF
--- a/api/pkg/api/handler/expectedmachine.go
+++ b/api/pkg/api/handler/expectedmachine.go
@@ -219,83 +219,64 @@ func (cemh CreateExpectedMachineHandler) Handle(c echo.Context) error {
 		})
 	}
 
-	// Start a db transaction
-	tx, err := cdb.BeginTx(ctx, cemh.dbSession, &sql.TxOptions{})
-	if err != nil {
-		logger.Error().Err(err).Msg("unable to start transaction")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to create Expected Machine due to DB transaction error", nil)
-	}
-	// this variable is used in cleanup actions to indicate if this transaction committed
-	txCommitted := false
-	defer common.RollbackTx(ctx, tx, &txCommitted)
+	expectedMachine, err := cdb.WithTxResult(ctx, cemh.dbSession, func(tx *cdb.Tx) (*cdbm.ExpectedMachine, error) {
+		// Note: DefaultBmcUsername and BmcPassword are not stored in DB, only passed to workflow
+		em, err := emDAO.Create(
+			ctx,
+			tx,
+			cdbm.ExpectedMachineCreateInput{
+				ExpectedMachineID:        uuid.New(),
+				SiteID:                   site.ID,
+				BmcMacAddress:            apiRequest.BmcMacAddress,
+				ChassisSerialNumber:      apiRequest.ChassisSerialNumber,
+				SkuID:                    apiRequest.SkuID,
+				FallbackDpuSerialNumbers: apiRequest.FallbackDPUSerialNumbers,
+				RackID:                   apiRequest.RackID,
+				Name:                     apiRequest.Name,
+				Manufacturer:             apiRequest.Manufacturer,
+				Model:                    apiRequest.Model,
+				Description:              apiRequest.Description,
+				FirmwareVersion:          apiRequest.FirmwareVersion,
+				SlotID:                   apiRequest.SlotID,
+				TrayIdx:                  apiRequest.TrayIdx,
+				HostID:                   apiRequest.HostID,
+				Labels:                   apiRequest.Labels,
+				CreatedBy:                dbUser.ID,
+			},
+		)
+		if err != nil {
+			logger.Error().Err(err).Msg("error creating ExpectedMachine record in DB")
+			return nil, cutil.NewAPIError(http.StatusInternalServerError, "Failed to create Expected Machine due to DB error", nil)
+		}
 
-	// Create the ExpectedMachine in DB
-	// Note: DefaultBmcUsername and BmcPassword are not stored in DB, only passed to workflow
-	expectedMachine, err := emDAO.Create(
-		ctx,
-		tx,
-		cdbm.ExpectedMachineCreateInput{
-			ExpectedMachineID:        uuid.New(),
-			SiteID:                   site.ID,
-			BmcMacAddress:            apiRequest.BmcMacAddress,
-			ChassisSerialNumber:      apiRequest.ChassisSerialNumber,
-			SkuID:                    apiRequest.SkuID,
-			FallbackDpuSerialNumbers: apiRequest.FallbackDPUSerialNumbers,
-			RackID:                   apiRequest.RackID,
-			Name:                     apiRequest.Name,
-			Manufacturer:             apiRequest.Manufacturer,
-			Model:                    apiRequest.Model,
-			Description:              apiRequest.Description,
-			FirmwareVersion:          apiRequest.FirmwareVersion,
-			SlotID:                   apiRequest.SlotID,
-			TrayIdx:                  apiRequest.TrayIdx,
-			HostID:                   apiRequest.HostID,
-			Labels:                   apiRequest.Labels,
-			CreatedBy:                dbUser.ID,
-		},
-	)
-	if err != nil {
-		logger.Error().Err(err).Msg("error creating ExpectedMachine record in DB")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to create Expected Machine due to DB error", nil)
-	}
+		createExpectedMachineRequest := em.ToProto(cdbm.ExpectedMachineCredentials{
+			Username: apiRequest.DefaultBmcUsername,
+			Password: apiRequest.DefaultBmcPassword,
+		})
 
-	createExpectedMachineRequest := expectedMachine.ToProto(cdbm.ExpectedMachineCredentials{
-		Username: apiRequest.DefaultBmcUsername,
-		Password: apiRequest.DefaultBmcPassword,
+		logger.Info().Msg("triggering Expected Machine create workflow on Site")
+
+		workflowOptions := tclient.StartWorkflowOptions{
+			ID:                       "expected-machine-create-" + em.ID.String(),
+			WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
+			TaskQueue:                queue.SiteTaskQueue,
+		}
+
+		stc, err := cemh.scp.GetClientByID(site.ID)
+		if err != nil {
+			logger.Error().Err(err).Msg("failed to retrieve Temporal client for Site")
+			return nil, cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
+		}
+
+		if apiErr := common.ExecuteSyncWorkflow(ctx, logger, stc, "CreateExpectedMachine", workflowOptions, createExpectedMachineRequest); apiErr != nil {
+			return nil, apiErr
+		}
+		return em, nil
 	})
-
-	logger.Info().Msg("triggering Expected Machine create workflow on Site")
-
-	// Create workflow options
-	workflowOptions := tclient.StartWorkflowOptions{
-		ID:                       "expected-machine-create-" + expectedMachine.ID.String(),
-		WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
-		TaskQueue:                queue.SiteTaskQueue,
-	}
-
-	// Get the temporal client for the site we are working with
-	stc, err := cemh.scp.GetClientByID(site.ID)
 	if err != nil {
-		logger.Error().Err(err).Msg("failed to retrieve Temporal client for Site")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
+		return common.HandleTxError(c, logger, err, "Failed to create Expected Machine due to DB transaction error")
 	}
 
-	// Run workflow
-	apiErr := common.ExecuteSyncWorkflow(ctx, logger, stc, "CreateExpectedMachine", workflowOptions, createExpectedMachineRequest)
-	if apiErr != nil {
-		return cutil.NewAPIErrorResponse(c, apiErr.Code, apiErr.Message, apiErr.Data)
-	}
-
-	// Commit transaction
-	err = tx.Commit()
-	if err != nil {
-		logger.Error().Err(err).Msg("error committing ExpectedMachine transaction to DB")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to create Expected Machine due to DB transaction error", nil)
-	}
-	// Set committed so, deferred cleanup functions will do nothing
-	txCommitted = true
-
-	// Create response
 	apiExpectedMachine := model.NewAPIExpectedMachine(expectedMachine)
 
 	logger.Info().Msg("finishing API handler")
@@ -692,82 +673,62 @@ func (uemh UpdateExpectedMachineHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusForbidden, "Current org is not associated with the Site of the Expected Machine", nil)
 	}
 
-	// Start a db tx
-	tx, err := cdb.BeginTx(ctx, uemh.dbSession, &sql.TxOptions{})
-	if err != nil {
-		logger.Error().Err(err).Msg("unable to start transaction")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to update Expected Machine due to DB transaction error", nil)
-	}
-	// this variable is used in cleanup actions to indicate if this transaction committed
-	txCommitted := false
-	defer common.RollbackTx(ctx, tx, &txCommitted)
+	updatedExpectedMachine, err := cdb.WithTxResult(ctx, uemh.dbSession, func(tx *cdb.Tx) (*cdbm.ExpectedMachine, error) {
+		// Note: DefaultBmcUsername and BmcPassword are not stored in DB, only passed to workflow
+		em, err := emDAO.Update(
+			ctx,
+			tx,
+			cdbm.ExpectedMachineUpdateInput{
+				ExpectedMachineID:        expectedMachine.ID,
+				BmcMacAddress:            apiRequest.BmcMacAddress,
+				ChassisSerialNumber:      apiRequest.ChassisSerialNumber,
+				SkuID:                    apiRequest.SkuID,
+				FallbackDpuSerialNumbers: apiRequest.FallbackDPUSerialNumbers,
+				RackID:                   apiRequest.RackID,
+				Name:                     apiRequest.Name,
+				Manufacturer:             apiRequest.Manufacturer,
+				Model:                    apiRequest.Model,
+				Description:              apiRequest.Description,
+				FirmwareVersion:          apiRequest.FirmwareVersion,
+				SlotID:                   apiRequest.SlotID,
+				TrayIdx:                  apiRequest.TrayIdx,
+				HostID:                   apiRequest.HostID,
+				Labels:                   apiRequest.Labels,
+			},
+		)
+		if err != nil {
+			logger.Error().Err(err).Msg("failed to update ExpectedMachine record in DB")
+			return nil, cutil.NewAPIError(http.StatusInternalServerError, "Failed to update Expected Machine due to DB error", nil)
+		}
 
-	// Update ExpectedMachine in DB
-	// Note: DefaultBmcUsername and BmcPassword are not stored in DB, only passed to workflow
+		updateExpectedMachineRequest := em.ToProto(cdbm.ExpectedMachineCredentials{
+			Username: apiRequest.DefaultBmcUsername,
+			Password: apiRequest.DefaultBmcPassword,
+		})
 
-	updatedExpectedMachine, err := emDAO.Update(
-		ctx,
-		tx,
-		cdbm.ExpectedMachineUpdateInput{
-			ExpectedMachineID:        expectedMachine.ID,
-			BmcMacAddress:            apiRequest.BmcMacAddress,
-			ChassisSerialNumber:      apiRequest.ChassisSerialNumber,
-			SkuID:                    apiRequest.SkuID,
-			FallbackDpuSerialNumbers: apiRequest.FallbackDPUSerialNumbers,
-			RackID:                   apiRequest.RackID,
-			Name:                     apiRequest.Name,
-			Manufacturer:             apiRequest.Manufacturer,
-			Model:                    apiRequest.Model,
-			Description:              apiRequest.Description,
-			FirmwareVersion:          apiRequest.FirmwareVersion,
-			SlotID:                   apiRequest.SlotID,
-			TrayIdx:                  apiRequest.TrayIdx,
-			HostID:                   apiRequest.HostID,
-			Labels:                   apiRequest.Labels,
-		},
-	)
-	if err != nil {
-		logger.Error().Err(err).Msg("failed to update ExpectedMachine record in DB")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to update Expected Machine due to DB error", nil)
-	}
+		logger.Info().Msg("triggering ExpectedMachine update workflow")
 
-	updateExpectedMachineRequest := updatedExpectedMachine.ToProto(cdbm.ExpectedMachineCredentials{
-		Username: apiRequest.DefaultBmcUsername,
-		Password: apiRequest.DefaultBmcPassword,
+		workflowOptions := tclient.StartWorkflowOptions{
+			ID:                       "expected-machine-update-" + expectedMachine.ID.String(),
+			WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
+			TaskQueue:                queue.SiteTaskQueue,
+		}
+
+		stc, err := uemh.scp.GetClientByID(site.ID)
+		if err != nil {
+			logger.Error().Err(err).Msg("failed to retrieve Temporal client for Site")
+			return nil, cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
+		}
+
+		if apiErr := common.ExecuteSyncWorkflow(ctx, logger, stc, "UpdateExpectedMachine", workflowOptions, updateExpectedMachineRequest); apiErr != nil {
+			return nil, apiErr
+		}
+		return em, nil
 	})
-
-	logger.Info().Msg("triggering ExpectedMachine update workflow")
-
-	// Create workflow options
-	workflowOptions := tclient.StartWorkflowOptions{
-		ID:                       "expected-machine-update-" + expectedMachine.ID.String(),
-		WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
-		TaskQueue:                queue.SiteTaskQueue,
-	}
-
-	// Get the Temporal client for the site we are working with
-	stc, err := uemh.scp.GetClientByID(site.ID)
 	if err != nil {
-		logger.Error().Err(err).Msg("failed to retrieve Temporal client for Site")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
+		return common.HandleTxError(c, logger, err, "Failed to update Expected Machine due to DB transaction error")
 	}
 
-	// Run workflow
-	apiErr := common.ExecuteSyncWorkflow(ctx, logger, stc, "UpdateExpectedMachine", workflowOptions, updateExpectedMachineRequest)
-	if apiErr != nil {
-		return cutil.NewAPIErrorResponse(c, apiErr.Code, apiErr.Message, apiErr.Data)
-	}
-
-	// Commit transaction
-	err = tx.Commit()
-	if err != nil {
-		logger.Error().Err(err).Msg("error committing ExpectedMachine update transaction to DB")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to update ExpectedMachine", nil)
-	}
-	// Set committed so, deferred cleanup functions will do nothing
-	txCommitted = true
-
-	// Create response
 	apiExpectedMachine := model.NewAPIExpectedMachine(updatedExpectedMachine)
 
 	logger.Info().Msg("finishing API handler")
@@ -860,58 +821,38 @@ func (demh DeleteExpectedMachineHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusForbidden, "Current org is not associated with the Site of the Expected Machine", nil)
 	}
 
-	// Start a db tx
-	tx, err := cdb.BeginTx(ctx, demh.dbSession, &sql.TxOptions{})
+	err = cdb.WithTx(ctx, demh.dbSession, func(tx *cdb.Tx) error {
+		if err := emDAO.Delete(ctx, tx, expectedMachine.ID); err != nil {
+			logger.Error().Err(err).Msg("unable to delete ExpectedMachine record from DB")
+			return cutil.NewAPIError(http.StatusInternalServerError, "Failed to delete Expected Machine due to DB error", nil)
+		}
+
+		deleteExpectedMachineRequest := &cwssaws.ExpectedMachineRequest{
+			Id: &cwssaws.UUID{Value: expectedMachine.ID.String()},
+		}
+
+		logger.Info().Msg("triggering ExpectedMachine delete workflow")
+
+		workflowOptions := tclient.StartWorkflowOptions{
+			ID:                       "expected-machine-delete-" + expectedMachine.ID.String(),
+			WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
+			TaskQueue:                queue.SiteTaskQueue,
+		}
+
+		stc, err := demh.scp.GetClientByID(site.ID)
+		if err != nil {
+			logger.Error().Err(err).Msg("failed to retrieve Temporal client for Site")
+			return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
+		}
+
+		if apiErr := common.ExecuteSyncWorkflow(ctx, logger, stc, "DeleteExpectedMachine", workflowOptions, deleteExpectedMachineRequest); apiErr != nil {
+			return apiErr
+		}
+		return nil
+	})
 	if err != nil {
-		logger.Error().Err(err).Msg("unable to start transaction")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to delete Expected Machine due to DB error", nil)
+		return common.HandleTxError(c, logger, err, "Failed to delete Expected Machine due to DB transaction error")
 	}
-	// this variable is used in cleanup actions to indicate if this transaction committed
-	txCommitted := false
-	defer common.RollbackTx(ctx, tx, &txCommitted)
-
-	// Delete ExpectedMachine from DB
-	err = emDAO.Delete(ctx, tx, expectedMachine.ID)
-	if err != nil {
-		logger.Error().Err(err).Msg("unable to delete ExpectedMachine record from DB")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to delete Expected Machine due to DB error", nil)
-	}
-
-	// Build the delete request for workflow
-	deleteExpectedMachineRequest := &cwssaws.ExpectedMachineRequest{
-		Id: &cwssaws.UUID{Value: expectedMachine.ID.String()},
-	}
-
-	logger.Info().Msg("triggering ExpectedMachine delete workflow")
-
-	// Create workflow options
-	workflowOptions := tclient.StartWorkflowOptions{
-		ID:                       "expected-machine-delete-" + expectedMachine.ID.String(),
-		WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
-		TaskQueue:                queue.SiteTaskQueue,
-	}
-
-	// Get the temporal client for the site we are working with
-	stc, err := demh.scp.GetClientByID(site.ID)
-	if err != nil {
-		logger.Error().Err(err).Msg("failed to retrieve Temporal client for Site")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
-	}
-
-	// Run workflow
-	apiErr := common.ExecuteSyncWorkflow(ctx, logger, stc, "DeleteExpectedMachine", workflowOptions, deleteExpectedMachineRequest)
-	if apiErr != nil {
-		return cutil.NewAPIErrorResponse(c, apiErr.Code, apiErr.Message, apiErr.Data)
-	}
-
-	// Commit transaction
-	err = tx.Commit()
-	if err != nil {
-		logger.Error().Err(err).Msg("error committing ExpectedMachine delete transaction to DB")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to delete Expected Machine due to DB transaction error", nil)
-	}
-	// Set committed so, deferred cleanup functions will do nothing
-	txCommitted = true
 
 	logger.Info().Msg("finishing API handler")
 

--- a/api/pkg/api/handler/expectedpowershelf.go
+++ b/api/pkg/api/handler/expectedpowershelf.go
@@ -18,7 +18,6 @@
 package handler
 
 import (
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -156,82 +155,63 @@ func (cepsh CreateExpectedPowerShelfHandler) Handle(c echo.Context) error {
 		})
 	}
 
-	// Start a db transaction
-	tx, err := cdb.BeginTx(ctx, cepsh.dbSession, &sql.TxOptions{})
-	if err != nil {
-		logger.Error().Err(err).Msg("unable to start transaction")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to create Expected Power Shelf due to DB transaction error", nil)
-	}
-	// this variable is used in cleanup actions to indicate if this transaction committed
-	txCommitted := false
-	defer common.RollbackTx(ctx, tx, &txCommitted)
+	expectedPowerShelf, err := cdb.WithTxResult(ctx, cepsh.dbSession, func(tx *cdb.Tx) (*cdbm.ExpectedPowerShelf, error) {
+		// Note: DefaultBmcUsername and BmcPassword are not stored in DB, only passed to workflow
+		eps, err := epsDAO.Create(
+			ctx,
+			tx,
+			cdbm.ExpectedPowerShelfCreateInput{
+				ExpectedPowerShelfID: uuid.New(),
+				SiteID:               site.ID,
+				BmcMacAddress:        apiRequest.BmcMacAddress,
+				ShelfSerialNumber:    apiRequest.ShelfSerialNumber,
+				IpAddress:            apiRequest.IpAddress,
+				RackID:               apiRequest.RackID,
+				Name:                 apiRequest.Name,
+				Manufacturer:         apiRequest.Manufacturer,
+				Model:                apiRequest.Model,
+				Description:          apiRequest.Description,
+				FirmwareVersion:      apiRequest.FirmwareVersion,
+				SlotID:               apiRequest.SlotID,
+				TrayIdx:              apiRequest.TrayIdx,
+				HostID:               apiRequest.HostID,
+				Labels:               apiRequest.Labels,
+				CreatedBy:            dbUser.ID,
+			},
+		)
+		if err != nil {
+			logger.Error().Err(err).Msg("error creating ExpectedPowerShelf record in DB")
+			return nil, cutil.NewAPIError(http.StatusInternalServerError, "Failed to create Expected Power Shelf due to DB error", nil)
+		}
 
-	// Create the ExpectedPowerShelf in DB
-	// Note: DefaultBmcUsername and BmcPassword are not stored in DB, only passed to workflow
-	expectedPowerShelf, err := epsDAO.Create(
-		ctx,
-		tx,
-		cdbm.ExpectedPowerShelfCreateInput{
-			ExpectedPowerShelfID: uuid.New(),
-			SiteID:               site.ID,
-			BmcMacAddress:        apiRequest.BmcMacAddress,
-			ShelfSerialNumber:    apiRequest.ShelfSerialNumber,
-			IpAddress:            apiRequest.IpAddress,
-			RackID:               apiRequest.RackID,
-			Name:                 apiRequest.Name,
-			Manufacturer:         apiRequest.Manufacturer,
-			Model:                apiRequest.Model,
-			Description:          apiRequest.Description,
-			FirmwareVersion:      apiRequest.FirmwareVersion,
-			SlotID:               apiRequest.SlotID,
-			TrayIdx:              apiRequest.TrayIdx,
-			HostID:               apiRequest.HostID,
-			Labels:               apiRequest.Labels,
-			CreatedBy:            dbUser.ID,
-		},
-	)
-	if err != nil {
-		logger.Error().Err(err).Msg("error creating ExpectedPowerShelf record in DB")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to create Expected Power Shelf due to DB error", nil)
-	}
+		createExpectedPowerShelfRequest := eps.ToProto(cdbm.ExpectedPowerShelfCredentials{
+			Username: apiRequest.DefaultBmcUsername,
+			Password: apiRequest.DefaultBmcPassword,
+		})
 
-	createExpectedPowerShelfRequest := expectedPowerShelf.ToProto(cdbm.ExpectedPowerShelfCredentials{
-		Username: apiRequest.DefaultBmcUsername,
-		Password: apiRequest.DefaultBmcPassword,
+		logger.Info().Msg("triggering Expected Power Shelf create workflow on Site")
+
+		workflowOptions := tclient.StartWorkflowOptions{
+			ID:                       "expected-power-shelf-create-" + eps.ID.String(),
+			WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
+			TaskQueue:                queue.SiteTaskQueue,
+		}
+
+		stc, err := cepsh.scp.GetClientByID(site.ID)
+		if err != nil {
+			logger.Error().Err(err).Msg("failed to retrieve Temporal client for Site")
+			return nil, cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
+		}
+
+		if apiErr := common.ExecuteSyncWorkflow(ctx, logger, stc, "CreateExpectedPowerShelf", workflowOptions, createExpectedPowerShelfRequest); apiErr != nil {
+			return nil, apiErr
+		}
+		return eps, nil
 	})
-
-	logger.Info().Msg("triggering Expected Power Shelf create workflow on Site")
-
-	// Create workflow options
-	workflowOptions := tclient.StartWorkflowOptions{
-		ID:                       "expected-power-shelf-create-" + expectedPowerShelf.ID.String(),
-		WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
-		TaskQueue:                queue.SiteTaskQueue,
-	}
-
-	// Get the temporal client for the site we are working with
-	stc, err := cepsh.scp.GetClientByID(site.ID)
 	if err != nil {
-		logger.Error().Err(err).Msg("failed to retrieve Temporal client for Site")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
+		return common.HandleTxError(c, logger, err, "Failed to create Expected Power Shelf due to DB transaction error")
 	}
 
-	// Run workflow
-	apiErr := common.ExecuteSyncWorkflow(ctx, logger, stc, "CreateExpectedPowerShelf", workflowOptions, createExpectedPowerShelfRequest)
-	if apiErr != nil {
-		return cutil.NewAPIErrorResponse(c, apiErr.Code, apiErr.Message, apiErr.Data)
-	}
-
-	// Commit transaction
-	err = tx.Commit()
-	if err != nil {
-		logger.Error().Err(err).Msg("error committing ExpectedPowerShelf transaction to DB")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to create Expected Power Shelf due to DB transaction error", nil)
-	}
-	// Set committed so, deferred cleanup functions will do nothing
-	txCommitted = true
-
-	// Create response
 	apiExpectedPowerShelf := model.NewAPIExpectedPowerShelf(expectedPowerShelf)
 
 	logger.Info().Msg("finishing API handler")
@@ -614,81 +594,61 @@ func (uepsh UpdateExpectedPowerShelfHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusForbidden, "Current org is not associated with the Site of the Expected Power Shelf", nil)
 	}
 
-	// Start a db tx
-	tx, err := cdb.BeginTx(ctx, uepsh.dbSession, &sql.TxOptions{})
-	if err != nil {
-		logger.Error().Err(err).Msg("unable to start transaction")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to update Expected Power Shelf due to DB transaction error", nil)
-	}
-	// this variable is used in cleanup actions to indicate if this transaction committed
-	txCommitted := false
-	defer common.RollbackTx(ctx, tx, &txCommitted)
+	updatedExpectedPowerShelf, err := cdb.WithTxResult(ctx, uepsh.dbSession, func(tx *cdb.Tx) (*cdbm.ExpectedPowerShelf, error) {
+		// Note: DefaultBmcUsername and BmcPassword are not stored in DB, only passed to workflow
+		eps, err := epsDAO.Update(
+			ctx,
+			tx,
+			cdbm.ExpectedPowerShelfUpdateInput{
+				ExpectedPowerShelfID: expectedPowerShelf.ID,
+				BmcMacAddress:        apiRequest.BmcMacAddress,
+				ShelfSerialNumber:    apiRequest.ShelfSerialNumber,
+				IpAddress:            apiRequest.IpAddress,
+				RackID:               apiRequest.RackID,
+				Name:                 apiRequest.Name,
+				Manufacturer:         apiRequest.Manufacturer,
+				Model:                apiRequest.Model,
+				Description:          apiRequest.Description,
+				FirmwareVersion:      apiRequest.FirmwareVersion,
+				SlotID:               apiRequest.SlotID,
+				TrayIdx:              apiRequest.TrayIdx,
+				HostID:               apiRequest.HostID,
+				Labels:               apiRequest.Labels,
+			},
+		)
+		if err != nil {
+			logger.Error().Err(err).Msg("failed to update ExpectedPowerShelf record in DB")
+			return nil, cutil.NewAPIError(http.StatusInternalServerError, "Failed to update Expected Power Shelf due to DB error", nil)
+		}
 
-	// Update ExpectedPowerShelf in DB
-	// Note: DefaultBmcUsername and BmcPassword are not stored in DB, only passed to workflow
+		updateExpectedPowerShelfRequest := eps.ToProto(cdbm.ExpectedPowerShelfCredentials{
+			Username: apiRequest.DefaultBmcUsername,
+			Password: apiRequest.DefaultBmcPassword,
+		})
 
-	updatedExpectedPowerShelf, err := epsDAO.Update(
-		ctx,
-		tx,
-		cdbm.ExpectedPowerShelfUpdateInput{
-			ExpectedPowerShelfID: expectedPowerShelf.ID,
-			BmcMacAddress:        apiRequest.BmcMacAddress,
-			ShelfSerialNumber:    apiRequest.ShelfSerialNumber,
-			IpAddress:            apiRequest.IpAddress,
-			RackID:               apiRequest.RackID,
-			Name:                 apiRequest.Name,
-			Manufacturer:         apiRequest.Manufacturer,
-			Model:                apiRequest.Model,
-			Description:          apiRequest.Description,
-			FirmwareVersion:      apiRequest.FirmwareVersion,
-			SlotID:               apiRequest.SlotID,
-			TrayIdx:              apiRequest.TrayIdx,
-			HostID:               apiRequest.HostID,
-			Labels:               apiRequest.Labels,
-		},
-	)
-	if err != nil {
-		logger.Error().Err(err).Msg("failed to update ExpectedPowerShelf record in DB")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to update Expected Power Shelf due to DB error", nil)
-	}
+		logger.Info().Msg("triggering ExpectedPowerShelf update workflow")
 
-	updateExpectedPowerShelfRequest := updatedExpectedPowerShelf.ToProto(cdbm.ExpectedPowerShelfCredentials{
-		Username: apiRequest.DefaultBmcUsername,
-		Password: apiRequest.DefaultBmcPassword,
+		workflowOptions := tclient.StartWorkflowOptions{
+			ID:                       "expected-power-shelf-update-" + expectedPowerShelf.ID.String(),
+			WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
+			TaskQueue:                queue.SiteTaskQueue,
+		}
+
+		stc, err := uepsh.scp.GetClientByID(site.ID)
+		if err != nil {
+			logger.Error().Err(err).Msg("failed to retrieve Temporal client for Site")
+			return nil, cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
+		}
+
+		if apiErr := common.ExecuteSyncWorkflow(ctx, logger, stc, "UpdateExpectedPowerShelf", workflowOptions, updateExpectedPowerShelfRequest); apiErr != nil {
+			return nil, apiErr
+		}
+		return eps, nil
 	})
-
-	logger.Info().Msg("triggering ExpectedPowerShelf update workflow")
-
-	// Create workflow options
-	workflowOptions := tclient.StartWorkflowOptions{
-		ID:                       "expected-power-shelf-update-" + expectedPowerShelf.ID.String(),
-		WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
-		TaskQueue:                queue.SiteTaskQueue,
-	}
-
-	// Get the Temporal client for the site we are working with
-	stc, err := uepsh.scp.GetClientByID(site.ID)
 	if err != nil {
-		logger.Error().Err(err).Msg("failed to retrieve Temporal client for Site")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
+		return common.HandleTxError(c, logger, err, "Failed to update Expected Power Shelf due to DB transaction error")
 	}
 
-	// Run workflow
-	apiErr := common.ExecuteSyncWorkflow(ctx, logger, stc, "UpdateExpectedPowerShelf", workflowOptions, updateExpectedPowerShelfRequest)
-	if apiErr != nil {
-		return cutil.NewAPIErrorResponse(c, apiErr.Code, apiErr.Message, apiErr.Data)
-	}
-
-	// Commit transaction
-	err = tx.Commit()
-	if err != nil {
-		logger.Error().Err(err).Msg("error committing ExpectedPowerShelf update transaction to DB")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to update ExpectedPowerShelf", nil)
-	}
-	// Set committed so, deferred cleanup functions will do nothing
-	txCommitted = true
-
-	// Create response
 	apiExpectedPowerShelf := model.NewAPIExpectedPowerShelf(updatedExpectedPowerShelf)
 
 	logger.Info().Msg("finishing API handler")
@@ -781,59 +741,39 @@ func (depsh DeleteExpectedPowerShelfHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusForbidden, "Current org is not associated with the Site of the Expected Power Shelf", nil)
 	}
 
-	// Start a db tx
-	tx, err := cdb.BeginTx(ctx, depsh.dbSession, &sql.TxOptions{})
+	err = cdb.WithTx(ctx, depsh.dbSession, func(tx *cdb.Tx) error {
+		if err := epsDAO.Delete(ctx, tx, expectedPowerShelf.ID); err != nil {
+			logger.Error().Err(err).Msg("unable to delete ExpectedPowerShelf record from DB")
+			return cutil.NewAPIError(http.StatusInternalServerError, "Failed to delete Expected Power Shelf due to DB error", nil)
+		}
+
+		deleteExpectedPowerShelfRequest := &cwssaws.ExpectedPowerShelfRequest{
+			ExpectedPowerShelfId: &cwssaws.UUID{Value: expectedPowerShelf.ID.String()},
+			BmcMacAddress:        expectedPowerShelf.BmcMacAddress,
+		}
+
+		logger.Info().Msg("triggering ExpectedPowerShelf delete workflow")
+
+		workflowOptions := tclient.StartWorkflowOptions{
+			ID:                       "expected-power-shelf-delete-" + expectedPowerShelf.ID.String(),
+			WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
+			TaskQueue:                queue.SiteTaskQueue,
+		}
+
+		stc, err := depsh.scp.GetClientByID(site.ID)
+		if err != nil {
+			logger.Error().Err(err).Msg("failed to retrieve Temporal client for Site")
+			return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
+		}
+
+		if apiErr := common.ExecuteSyncWorkflow(ctx, logger, stc, "DeleteExpectedPowerShelf", workflowOptions, deleteExpectedPowerShelfRequest); apiErr != nil {
+			return apiErr
+		}
+		return nil
+	})
 	if err != nil {
-		logger.Error().Err(err).Msg("unable to start transaction")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to delete Expected Power Shelf due to DB error", nil)
+		return common.HandleTxError(c, logger, err, "Failed to delete Expected Power Shelf due to DB transaction error")
 	}
-	// this variable is used in cleanup actions to indicate if this transaction committed
-	txCommitted := false
-	defer common.RollbackTx(ctx, tx, &txCommitted)
-
-	// Delete ExpectedPowerShelf from DB
-	err = epsDAO.Delete(ctx, tx, expectedPowerShelf.ID)
-	if err != nil {
-		logger.Error().Err(err).Msg("unable to delete ExpectedPowerShelf record from DB")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to delete Expected Power Shelf due to DB error", nil)
-	}
-
-	// Build the delete request for workflow
-	deleteExpectedPowerShelfRequest := &cwssaws.ExpectedPowerShelfRequest{
-		ExpectedPowerShelfId: &cwssaws.UUID{Value: expectedPowerShelf.ID.String()},
-		BmcMacAddress:        expectedPowerShelf.BmcMacAddress,
-	}
-
-	logger.Info().Msg("triggering ExpectedPowerShelf delete workflow")
-
-	// Create workflow options
-	workflowOptions := tclient.StartWorkflowOptions{
-		ID:                       "expected-power-shelf-delete-" + expectedPowerShelf.ID.String(),
-		WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
-		TaskQueue:                queue.SiteTaskQueue,
-	}
-
-	// Get the temporal client for the site we are working with
-	stc, err := depsh.scp.GetClientByID(site.ID)
-	if err != nil {
-		logger.Error().Err(err).Msg("failed to retrieve Temporal client for Site")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
-	}
-
-	// Run workflow
-	apiErr := common.ExecuteSyncWorkflow(ctx, logger, stc, "DeleteExpectedPowerShelf", workflowOptions, deleteExpectedPowerShelfRequest)
-	if apiErr != nil {
-		return cutil.NewAPIErrorResponse(c, apiErr.Code, apiErr.Message, apiErr.Data)
-	}
-
-	// Commit transaction
-	err = tx.Commit()
-	if err != nil {
-		logger.Error().Err(err).Msg("error committing ExpectedPowerShelf delete transaction to DB")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to delete Expected Power Shelf due to DB transaction error", nil)
-	}
-	// Set committed so, deferred cleanup functions will do nothing
-	txCommitted = true
 
 	logger.Info().Msg("finishing API handler")
 

--- a/api/pkg/api/handler/expectedswitch.go
+++ b/api/pkg/api/handler/expectedswitch.go
@@ -18,7 +18,6 @@
 package handler
 
 import (
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -156,83 +155,64 @@ func (cesh CreateExpectedSwitchHandler) Handle(c echo.Context) error {
 		})
 	}
 
-	// Start a db transaction
-	tx, err := cdb.BeginTx(ctx, cesh.dbSession, &sql.TxOptions{})
-	if err != nil {
-		logger.Error().Err(err).Msg("unable to start transaction")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to create Expected Switch due to DB transaction error", nil)
-	}
-	// this variable is used in cleanup actions to indicate if this transaction committed
-	txCommitted := false
-	defer common.RollbackTx(ctx, tx, &txCommitted)
+	expectedSwitch, err := cdb.WithTxResult(ctx, cesh.dbSession, func(tx *cdb.Tx) (*cdbm.ExpectedSwitch, error) {
+		// Note: NvOsUsername and NvOsPassword are not stored in DB, only passed to workflow
+		es, err := esDAO.Create(
+			ctx,
+			tx,
+			cdbm.ExpectedSwitchCreateInput{
+				ExpectedSwitchID:   uuid.New(),
+				SiteID:             site.ID,
+				BmcMacAddress:      apiRequest.BmcMacAddress,
+				SwitchSerialNumber: apiRequest.SwitchSerialNumber,
+				RackID:             apiRequest.RackID,
+				Name:               apiRequest.Name,
+				Manufacturer:       apiRequest.Manufacturer,
+				Model:              apiRequest.Model,
+				Description:        apiRequest.Description,
+				FirmwareVersion:    apiRequest.FirmwareVersion,
+				SlotID:             apiRequest.SlotID,
+				TrayIdx:            apiRequest.TrayIdx,
+				HostID:             apiRequest.HostID,
+				Labels:             apiRequest.Labels,
+				CreatedBy:          dbUser.ID,
+			},
+		)
+		if err != nil {
+			logger.Error().Err(err).Msg("error creating ExpectedSwitch record in DB")
+			return nil, cutil.NewAPIError(http.StatusInternalServerError, "Failed to create Expected Switch due to DB error", nil)
+		}
 
-	// Create the ExpectedSwitch in DB
-	// Note: NvOsUsername and NvOsPassword are not stored in DB, only passed to workflow
-	expectedSwitch, err := esDAO.Create(
-		ctx,
-		tx,
-		cdbm.ExpectedSwitchCreateInput{
-			ExpectedSwitchID:   uuid.New(),
-			SiteID:             site.ID,
-			BmcMacAddress:      apiRequest.BmcMacAddress,
-			SwitchSerialNumber: apiRequest.SwitchSerialNumber,
-			RackID:             apiRequest.RackID,
-			Name:               apiRequest.Name,
-			Manufacturer:       apiRequest.Manufacturer,
-			Model:              apiRequest.Model,
-			Description:        apiRequest.Description,
-			FirmwareVersion:    apiRequest.FirmwareVersion,
-			SlotID:             apiRequest.SlotID,
-			TrayIdx:            apiRequest.TrayIdx,
-			HostID:             apiRequest.HostID,
-			Labels:             apiRequest.Labels,
-			CreatedBy:          dbUser.ID,
-		},
-	)
-	if err != nil {
-		logger.Error().Err(err).Msg("error creating ExpectedSwitch record in DB")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to create Expected Switch due to DB error", nil)
-	}
+		createExpectedSwitchRequest := es.ToProto(cdbm.ExpectedSwitchCredentials{
+			BmcUsername:  apiRequest.DefaultBmcUsername,
+			BmcPassword:  apiRequest.DefaultBmcPassword,
+			NvosUsername: apiRequest.NvOsUsername,
+			NvosPassword: apiRequest.NvOsPassword,
+		})
 
-	createExpectedSwitchRequest := expectedSwitch.ToProto(cdbm.ExpectedSwitchCredentials{
-		BmcUsername:  apiRequest.DefaultBmcUsername,
-		BmcPassword:  apiRequest.DefaultBmcPassword,
-		NvosUsername: apiRequest.NvOsUsername,
-		NvosPassword: apiRequest.NvOsPassword,
+		logger.Info().Msg("triggering Expected Switch create workflow on Site")
+
+		workflowOptions := tclient.StartWorkflowOptions{
+			ID:                       "expected-switch-create-" + es.ID.String(),
+			WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
+			TaskQueue:                queue.SiteTaskQueue,
+		}
+
+		stc, err := cesh.scp.GetClientByID(site.ID)
+		if err != nil {
+			logger.Error().Err(err).Msg("failed to retrieve Temporal client for Site")
+			return nil, cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
+		}
+
+		if apiErr := common.ExecuteSyncWorkflow(ctx, logger, stc, "CreateExpectedSwitch", workflowOptions, createExpectedSwitchRequest); apiErr != nil {
+			return nil, apiErr
+		}
+		return es, nil
 	})
-
-	logger.Info().Msg("triggering Expected Switch create workflow on Site")
-
-	// Create workflow options
-	workflowOptions := tclient.StartWorkflowOptions{
-		ID:                       "expected-switch-create-" + expectedSwitch.ID.String(),
-		WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
-		TaskQueue:                queue.SiteTaskQueue,
-	}
-
-	// Get the temporal client for the site we are working with
-	stc, err := cesh.scp.GetClientByID(site.ID)
 	if err != nil {
-		logger.Error().Err(err).Msg("failed to retrieve Temporal client for Site")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
+		return common.HandleTxError(c, logger, err, "Failed to create Expected Switch due to DB transaction error")
 	}
 
-	// Run workflow
-	apiErr := common.ExecuteSyncWorkflow(ctx, logger, stc, "CreateExpectedSwitch", workflowOptions, createExpectedSwitchRequest)
-	if apiErr != nil {
-		return cutil.NewAPIErrorResponse(c, apiErr.Code, apiErr.Message, apiErr.Data)
-	}
-
-	// Commit transaction
-	err = tx.Commit()
-	if err != nil {
-		logger.Error().Err(err).Msg("error committing ExpectedSwitch transaction to DB")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to create Expected Switch due to DB transaction error", nil)
-	}
-	// Set committed so, deferred cleanup functions will do nothing
-	txCommitted = true
-
-	// Create response
 	apiExpectedSwitch := model.NewAPIExpectedSwitch(expectedSwitch)
 
 	logger.Info().Msg("finishing API handler")
@@ -615,82 +595,62 @@ func (uesh UpdateExpectedSwitchHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusForbidden, "Current org is not associated with the Site of the Expected Switch", nil)
 	}
 
-	// Start a db tx
-	tx, err := cdb.BeginTx(ctx, uesh.dbSession, &sql.TxOptions{})
-	if err != nil {
-		logger.Error().Err(err).Msg("unable to start transaction")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to update Expected Switch due to DB transaction error", nil)
-	}
-	// this variable is used in cleanup actions to indicate if this transaction committed
-	txCommitted := false
-	defer common.RollbackTx(ctx, tx, &txCommitted)
+	updatedExpectedSwitch, err := cdb.WithTxResult(ctx, uesh.dbSession, func(tx *cdb.Tx) (*cdbm.ExpectedSwitch, error) {
+		// Note: NvOsUsername and NvOsPassword are not stored in DB, only passed to workflow
+		es, err := esDAO.Update(
+			ctx,
+			tx,
+			cdbm.ExpectedSwitchUpdateInput{
+				ExpectedSwitchID:   expectedSwitch.ID,
+				BmcMacAddress:      apiRequest.BmcMacAddress,
+				SwitchSerialNumber: apiRequest.SwitchSerialNumber,
+				RackID:             apiRequest.RackID,
+				Name:               apiRequest.Name,
+				Manufacturer:       apiRequest.Manufacturer,
+				Model:              apiRequest.Model,
+				Description:        apiRequest.Description,
+				FirmwareVersion:    apiRequest.FirmwareVersion,
+				SlotID:             apiRequest.SlotID,
+				TrayIdx:            apiRequest.TrayIdx,
+				HostID:             apiRequest.HostID,
+				Labels:             apiRequest.Labels,
+			},
+		)
+		if err != nil {
+			logger.Error().Err(err).Msg("failed to update ExpectedSwitch record in DB")
+			return nil, cutil.NewAPIError(http.StatusInternalServerError, "Failed to update Expected Switch due to DB error", nil)
+		}
 
-	// Update ExpectedSwitch in DB
-	// Note: NvOsUsername and NvOsPassword are not stored in DB, only passed to workflow
+		updateExpectedSwitchRequest := es.ToProto(cdbm.ExpectedSwitchCredentials{
+			BmcUsername:  apiRequest.DefaultBmcUsername,
+			BmcPassword:  apiRequest.DefaultBmcPassword,
+			NvosUsername: apiRequest.NvOsUsername,
+			NvosPassword: apiRequest.NvOsPassword,
+		})
 
-	updatedExpectedSwitch, err := esDAO.Update(
-		ctx,
-		tx,
-		cdbm.ExpectedSwitchUpdateInput{
-			ExpectedSwitchID:   expectedSwitch.ID,
-			BmcMacAddress:      apiRequest.BmcMacAddress,
-			SwitchSerialNumber: apiRequest.SwitchSerialNumber,
-			RackID:             apiRequest.RackID,
-			Name:               apiRequest.Name,
-			Manufacturer:       apiRequest.Manufacturer,
-			Model:              apiRequest.Model,
-			Description:        apiRequest.Description,
-			FirmwareVersion:    apiRequest.FirmwareVersion,
-			SlotID:             apiRequest.SlotID,
-			TrayIdx:            apiRequest.TrayIdx,
-			HostID:             apiRequest.HostID,
-			Labels:             apiRequest.Labels,
-		},
-	)
-	if err != nil {
-		logger.Error().Err(err).Msg("failed to update ExpectedSwitch record in DB")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to update Expected Switch due to DB error", nil)
-	}
+		logger.Info().Msg("triggering ExpectedSwitch update workflow")
 
-	updateExpectedSwitchRequest := updatedExpectedSwitch.ToProto(cdbm.ExpectedSwitchCredentials{
-		BmcUsername:  apiRequest.DefaultBmcUsername,
-		BmcPassword:  apiRequest.DefaultBmcPassword,
-		NvosUsername: apiRequest.NvOsUsername,
-		NvosPassword: apiRequest.NvOsPassword,
+		workflowOptions := tclient.StartWorkflowOptions{
+			ID:                       "expected-switch-update-" + expectedSwitch.ID.String(),
+			WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
+			TaskQueue:                queue.SiteTaskQueue,
+		}
+
+		stc, err := uesh.scp.GetClientByID(site.ID)
+		if err != nil {
+			logger.Error().Err(err).Msg("failed to retrieve Temporal client for Site")
+			return nil, cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
+		}
+
+		if apiErr := common.ExecuteSyncWorkflow(ctx, logger, stc, "UpdateExpectedSwitch", workflowOptions, updateExpectedSwitchRequest); apiErr != nil {
+			return nil, apiErr
+		}
+		return es, nil
 	})
-
-	logger.Info().Msg("triggering ExpectedSwitch update workflow")
-
-	// Create workflow options
-	workflowOptions := tclient.StartWorkflowOptions{
-		ID:                       "expected-switch-update-" + expectedSwitch.ID.String(),
-		WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
-		TaskQueue:                queue.SiteTaskQueue,
-	}
-
-	// Get the Temporal client for the site we are working with
-	stc, err := uesh.scp.GetClientByID(site.ID)
 	if err != nil {
-		logger.Error().Err(err).Msg("failed to retrieve Temporal client for Site")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
+		return common.HandleTxError(c, logger, err, "Failed to update Expected Switch due to DB transaction error")
 	}
 
-	// Run workflow
-	apiErr := common.ExecuteSyncWorkflow(ctx, logger, stc, "UpdateExpectedSwitch", workflowOptions, updateExpectedSwitchRequest)
-	if apiErr != nil {
-		return cutil.NewAPIErrorResponse(c, apiErr.Code, apiErr.Message, apiErr.Data)
-	}
-
-	// Commit transaction
-	err = tx.Commit()
-	if err != nil {
-		logger.Error().Err(err).Msg("error committing ExpectedSwitch update transaction to DB")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to update ExpectedSwitch", nil)
-	}
-	// Set committed so, deferred cleanup functions will do nothing
-	txCommitted = true
-
-	// Create response
 	apiExpectedSwitch := model.NewAPIExpectedSwitch(updatedExpectedSwitch)
 
 	logger.Info().Msg("finishing API handler")
@@ -783,59 +743,39 @@ func (desh DeleteExpectedSwitchHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusForbidden, "Current org is not associated with the Site of the Expected Switch", nil)
 	}
 
-	// Start a db tx
-	tx, err := cdb.BeginTx(ctx, desh.dbSession, &sql.TxOptions{})
+	err = cdb.WithTx(ctx, desh.dbSession, func(tx *cdb.Tx) error {
+		if err := esDAO.Delete(ctx, tx, expectedSwitch.ID); err != nil {
+			logger.Error().Err(err).Msg("unable to delete ExpectedSwitch record from DB")
+			return cutil.NewAPIError(http.StatusInternalServerError, "Failed to delete Expected Switch due to DB error", nil)
+		}
+
+		deleteExpectedSwitchRequest := &cwssaws.ExpectedSwitchRequest{
+			ExpectedSwitchId: &cwssaws.UUID{Value: expectedSwitch.ID.String()},
+			BmcMacAddress:    expectedSwitch.BmcMacAddress,
+		}
+
+		logger.Info().Msg("triggering ExpectedSwitch delete workflow")
+
+		workflowOptions := tclient.StartWorkflowOptions{
+			ID:                       "expected-switch-delete-" + expectedSwitch.ID.String(),
+			WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
+			TaskQueue:                queue.SiteTaskQueue,
+		}
+
+		stc, err := desh.scp.GetClientByID(site.ID)
+		if err != nil {
+			logger.Error().Err(err).Msg("failed to retrieve Temporal client for Site")
+			return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
+		}
+
+		if apiErr := common.ExecuteSyncWorkflow(ctx, logger, stc, "DeleteExpectedSwitch", workflowOptions, deleteExpectedSwitchRequest); apiErr != nil {
+			return apiErr
+		}
+		return nil
+	})
 	if err != nil {
-		logger.Error().Err(err).Msg("unable to start transaction")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to delete Expected Switch due to DB error", nil)
+		return common.HandleTxError(c, logger, err, "Failed to delete Expected Switch due to DB transaction error")
 	}
-	// this variable is used in cleanup actions to indicate if this transaction committed
-	txCommitted := false
-	defer common.RollbackTx(ctx, tx, &txCommitted)
-
-	// Delete ExpectedSwitch from DB
-	err = esDAO.Delete(ctx, tx, expectedSwitch.ID)
-	if err != nil {
-		logger.Error().Err(err).Msg("unable to delete ExpectedSwitch record from DB")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to delete Expected Switch due to DB error", nil)
-	}
-
-	// Build the delete request for workflow
-	deleteExpectedSwitchRequest := &cwssaws.ExpectedSwitchRequest{
-		ExpectedSwitchId: &cwssaws.UUID{Value: expectedSwitch.ID.String()},
-		BmcMacAddress:    expectedSwitch.BmcMacAddress,
-	}
-
-	logger.Info().Msg("triggering ExpectedSwitch delete workflow")
-
-	// Create workflow options
-	workflowOptions := tclient.StartWorkflowOptions{
-		ID:                       "expected-switch-delete-" + expectedSwitch.ID.String(),
-		WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
-		TaskQueue:                queue.SiteTaskQueue,
-	}
-
-	// Get the temporal client for the site we are working with
-	stc, err := desh.scp.GetClientByID(site.ID)
-	if err != nil {
-		logger.Error().Err(err).Msg("failed to retrieve Temporal client for Site")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
-	}
-
-	// Run workflow
-	apiErr := common.ExecuteSyncWorkflow(ctx, logger, stc, "DeleteExpectedSwitch", workflowOptions, deleteExpectedSwitchRequest)
-	if apiErr != nil {
-		return cutil.NewAPIErrorResponse(c, apiErr.Code, apiErr.Message, apiErr.Data)
-	}
-
-	// Commit transaction
-	err = tx.Commit()
-	if err != nil {
-		logger.Error().Err(err).Msg("error committing ExpectedSwitch delete transaction to DB")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to delete Expected Switch due to DB transaction error", nil)
-	}
-	// Set committed so, deferred cleanup functions will do nothing
-	txCommitted = true
 
 	logger.Info().Msg("finishing API handler")
 

--- a/api/pkg/api/handler/util/common/common.go
+++ b/api/pkg/api/handler/util/common/common.go
@@ -606,6 +606,30 @@ func RollbackTx(ctx context.Context, tx *cdb.Tx, committed *bool) {
 	}
 }
 
+// HandleTxError translates an error returned by cdb.WithTx / cdb.WithTxResult
+// into an Echo API response. The lookups happen in this order:
+//  1. If the error wraps a *cutil.APIError (the closure chose its own
+//     Code/Message/Data), those are preserved.
+//  2. If the error is cdb.ErrTransactionInitiation or cdb.ErrTransactionCommit,
+//     a 500 is returned with a message that names the transaction phase.
+//  3. Otherwise the caller-supplied fallback message is used with a 500.
+func HandleTxError(c echo.Context, logger zerolog.Logger, err error, fallback string) error {
+	var apiErr *cutil.APIError
+	if errors.As(err, &apiErr) {
+		return cutil.NewAPIErrorResponse(c, apiErr.Code, apiErr.Message, apiErr.Data)
+	}
+	if errors.Is(err, cdb.ErrTransactionInitiation) {
+		logger.Error().Err(err).Msg("DB transaction initiation failed")
+		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to complete request, DB transaction initiation error", nil)
+	}
+	if errors.Is(err, cdb.ErrTransactionCommit) {
+		logger.Error().Err(err).Msg("DB transaction commit failed")
+		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to complete request, DB transaction commit error", nil)
+	}
+	logger.Error().Err(err).Msg(fallback)
+	return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, fallback, nil)
+}
+
 // GetAndValidateQueryRelations is a utility function to get and validate the query parameters for include relations get/getall request
 func GetAndValidateQueryRelations(qParams url.Values, relatedEntities map[string]bool) ([]string, string) {
 	qIncludeRelations := qParams["includeRelation"]

--- a/common/pkg/util/api.go
+++ b/common/pkg/util/api.go
@@ -53,6 +53,13 @@ type APIError struct {
 	Data    error  `json:"data"`
 }
 
+// Error implements the error interface so *APIError can flow through error
+// channels (e.g., closures returned by WithTx). Use NewAPIErrorResponse to
+// turn one into an Echo response at the API boundary.
+func (a *APIError) Error() string {
+	return a.Message
+}
+
 // NewAPIError returns an API error given appropriate params
 func NewAPIError(code int, message string, data error) *APIError {
 	return &APIError{

--- a/db/pkg/db/error.go
+++ b/db/pkg/db/error.go
@@ -42,4 +42,13 @@ var (
 	ErrInvalidPort = errors.New("failed to parse DB_PORT")
 	// ErrInvalidCredential indicates the credential is not valid.
 	ErrInvalidCredential = errors.New("invalid credential")
+
+	// ErrTransactionInitiation is returned by WithTx*/WithTxResult* when the
+	// underlying BeginTx call fails. HandleTxError detects this sentinel via
+	// errors.Is and renders a user-facing message about transaction initiation.
+	ErrTransactionInitiation = errors.New("DB transaction initiation error")
+	// ErrTransactionCommit is returned by WithTx*/WithTxResult* when the
+	// underlying tx.Commit call fails. HandleTxError detects this sentinel via
+	// errors.Is and renders a user-facing message about transaction commit.
+	ErrTransactionCommit = errors.New("DB transaction commit error")
 )

--- a/db/pkg/db/tx.go
+++ b/db/pkg/db/tx.go
@@ -74,6 +74,77 @@ func RollbackTx(ctx context.Context, tx *Tx, committed *bool) {
 	}
 }
 
+// WithTx runs fn inside a database transaction. If fn returns nil, the
+// transaction is committed; if fn returns an error, the transaction is rolled
+// back. Callers don't have to manage Begin/Commit/Rollback or a "did we
+// commit?" flag manually.
+//
+// Use this in preference to BeginTx + manual RollbackTx + tx.Commit() at call
+// sites. See WithTxOpts for non-default tx options.
+func WithTx(ctx context.Context, dbSession *Session, fn func(tx *Tx) error) error {
+	return WithTxOpts(ctx, dbSession, &sql.TxOptions{}, fn)
+}
+
+// WithTxOpts is the variant of WithTx that lets callers pass non-default
+// sql.TxOptions (e.g., a specific isolation level).
+func WithTxOpts(ctx context.Context, dbSession *Session, opts *sql.TxOptions, fn func(tx *Tx) error) error {
+	tx, err := BeginTx(ctx, dbSession, opts)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrTransactionInitiation, err)
+	}
+	// If fn panics, ensure the tx is rolled back so we don't leak an open
+	// transaction (and any locks it holds) until the connection drops.
+	// The original panic is re-raised after rollback.
+	defer func() {
+		if p := recover(); p != nil {
+			_ = tx.Rollback()
+			panic(p)
+		}
+	}()
+	if err := fn(tx); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("%w: %w", ErrTransactionCommit, err)
+	}
+	return nil
+}
+
+// WithTxResult is the value-returning variant of WithTx. The closure can
+// return a result of any type; it's only returned to the caller if the
+// transaction committed successfully.
+func WithTxResult[T any](ctx context.Context, dbSession *Session, fn func(tx *Tx) (T, error)) (T, error) {
+	return WithTxResultOpts(ctx, dbSession, &sql.TxOptions{}, fn)
+}
+
+// WithTxResultOpts is the value-returning variant of WithTxOpts.
+func WithTxResultOpts[T any](ctx context.Context, dbSession *Session, opts *sql.TxOptions, fn func(tx *Tx) (T, error)) (T, error) {
+	var zero T
+	tx, err := BeginTx(ctx, dbSession, opts)
+	if err != nil {
+		return zero, fmt.Errorf("begin tx: %w", err)
+	}
+	// If fn panics, ensure the tx is rolled back so we don't leak an open
+	// transaction (and any locks it holds) until the connection drops.
+	// The original panic is re-raised after rollback.
+	defer func() {
+		if p := recover(); p != nil {
+			_ = tx.Rollback()
+			panic(p)
+		}
+	}()
+	result, err := fn(tx)
+	if err != nil {
+		_ = tx.Rollback()
+		return zero, err
+	}
+	if err := tx.Commit(); err != nil {
+		return zero, fmt.Errorf("commit tx: %w", err)
+	}
+	return result, nil
+}
+
 // Commit wraps bun's Commit
 func (tx *Tx) Commit() error {
 	return tx.tx.Commit()

--- a/db/pkg/db/tx_test.go
+++ b/db/pkg/db/tx_test.go
@@ -20,12 +20,14 @@ package db
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/extra/bundebug"
 )
@@ -376,6 +378,155 @@ func TestTxTryAcquireAdvisoryLock(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWithTx_CommitsOnSuccess(t *testing.T) {
+	dbSession := testTxGetTestSession(t)
+	defer dbSession.Close()
+	testTxSetupSchema(t, dbSession)
+	ctx := context.Background()
+
+	name := "withtx-commit"
+	err := WithTx(ctx, dbSession, func(tx *Tx) error {
+		_, err := GetIDB(tx, dbSession).NewInsert().Model(&TestTable{ID: uuid.New(), Name: name}).Exec(ctx)
+		return err
+	})
+	assert.Nil(t, err)
+
+	// Row should be visible: closure returned nil, so commit happened.
+	tt := &TestTable{}
+	err = GetIDB(nil, dbSession).NewSelect().Model(tt).Where("name = ?", name).Scan(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, name, tt.Name)
+}
+
+func TestWithTx_RollsBackOnError(t *testing.T) {
+	dbSession := testTxGetTestSession(t)
+	defer dbSession.Close()
+	testTxSetupSchema(t, dbSession)
+	ctx := context.Background()
+
+	name := "withtx-rollback"
+	sentinel := errors.New("simulated failure")
+	err := WithTx(ctx, dbSession, func(tx *Tx) error {
+		_, ierr := GetIDB(tx, dbSession).NewInsert().Model(&TestTable{ID: uuid.New(), Name: name}).Exec(ctx)
+		assert.Nil(t, ierr)
+		// Closure returns error -> tx must roll back.
+		return sentinel
+	})
+	assert.ErrorIs(t, err, sentinel)
+
+	// Row should NOT be visible: closure returned err, so rollback happened.
+	tt := &TestTable{}
+	err = GetIDB(nil, dbSession).NewSelect().Model(tt).Where("name = ?", name).Scan(ctx)
+	assert.NotNil(t, err)
+}
+
+func TestWithTx_PropagatesBeginTxError(t *testing.T) {
+	// Fail fast if session creation itself errors -- otherwise we'd proceed
+	// with a nil/bad session and the actual assertion below would be
+	// dominated by an unrelated nil-pointer panic.
+	badSession, err := NewSession(context.Background(), "localhost", 1234, "postgres", "postgres", "postgres", "")
+	require.NoError(t, err)
+	defer badSession.Close()
+	ctx := context.Background()
+
+	called := false
+	err = WithTx(ctx, badSession, func(tx *Tx) error {
+		called = true
+		return nil
+	})
+	assert.NotNil(t, err)
+	assert.True(t, errors.Is(err, ErrTransactionInitiation), "BeginTx failures should be tagged with ErrTransactionInitiation")
+	assert.False(t, called, "closure should not be invoked when BeginTx fails")
+}
+
+func TestWithTxResult_CommitsAndReturnsValue(t *testing.T) {
+	dbSession := testTxGetTestSession(t)
+	defer dbSession.Close()
+	testTxSetupSchema(t, dbSession)
+	ctx := context.Background()
+
+	name := "withtxresult-commit"
+	id, err := WithTxResult(ctx, dbSession, func(tx *Tx) (uuid.UUID, error) {
+		newID := uuid.New()
+		_, ierr := GetIDB(tx, dbSession).NewInsert().Model(&TestTable{ID: newID, Name: name}).Exec(ctx)
+		return newID, ierr
+	})
+	assert.Nil(t, err)
+	assert.NotEqual(t, uuid.Nil, id)
+
+	tt := &TestTable{}
+	err = GetIDB(nil, dbSession).NewSelect().Model(tt).Where("id = ?", id).Scan(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, name, tt.Name)
+}
+
+func TestWithTx_RollsBackOnPanicAndRepanics(t *testing.T) {
+	dbSession := testTxGetTestSession(t)
+	defer dbSession.Close()
+	testTxSetupSchema(t, dbSession)
+	ctx := context.Background()
+
+	name := "withtx-panic"
+	defer func() {
+		// The original panic value must propagate to the caller.
+		p := recover()
+		assert.Equal(t, "boom", p)
+
+		// Row should NOT be visible: closure panicked, so rollback happened.
+		tt := &TestTable{}
+		serr := GetIDB(nil, dbSession).NewSelect().Model(tt).Where("name = ?", name).Scan(ctx)
+		assert.NotNil(t, serr)
+	}()
+
+	_ = WithTx(ctx, dbSession, func(tx *Tx) error {
+		_, ierr := GetIDB(tx, dbSession).NewInsert().Model(&TestTable{ID: uuid.New(), Name: name}).Exec(ctx)
+		assert.Nil(t, ierr)
+		panic("boom")
+	})
+
+	t.Fatal("panic should have propagated past WithTx")
+}
+
+func TestWithTxResult_RollsBackOnPanicAndRepanics(t *testing.T) {
+	dbSession := testTxGetTestSession(t)
+	defer dbSession.Close()
+	testTxSetupSchema(t, dbSession)
+	ctx := context.Background()
+
+	name := "withtxresult-panic"
+	defer func() {
+		p := recover()
+		assert.Equal(t, "boom", p)
+
+		tt := &TestTable{}
+		serr := GetIDB(nil, dbSession).NewSelect().Model(tt).Where("name = ?", name).Scan(ctx)
+		assert.NotNil(t, serr)
+	}()
+
+	_, _ = WithTxResult(ctx, dbSession, func(tx *Tx) (uuid.UUID, error) {
+		_, ierr := GetIDB(tx, dbSession).NewInsert().Model(&TestTable{ID: uuid.New(), Name: name}).Exec(ctx)
+		assert.Nil(t, ierr)
+		panic("boom")
+	})
+
+	t.Fatal("panic should have propagated past WithTxResult")
+}
+
+func TestWithTxResult_ReturnsZeroValueOnError(t *testing.T) {
+	dbSession := testTxGetTestSession(t)
+	defer dbSession.Close()
+	testTxSetupSchema(t, dbSession)
+	ctx := context.Background()
+
+	sentinel := errors.New("simulated failure")
+	id, err := WithTxResult(ctx, dbSession, func(tx *Tx) (uuid.UUID, error) {
+		return uuid.New(), sentinel
+	})
+	assert.ErrorIs(t, err, sentinel)
+	// Caller gets the zero value when fn returns an error.
+	assert.Equal(t, uuid.Nil, id)
 }
 
 func TestGetBunTx(t *testing.T) {


### PR DESCRIPTION
## Description

Following on all of the `Expected*` cleanup work I've been doing, I was looking at the database bits, and wanted to attempt to clean things up a bit even more there.

This is modeled on the `with_txn` pattern from the "Core" `api-db` crate, and adds four helpers:
```
      cdb.WithTx(ctx, dbSession, func(tx *cdb.Tx) error { ... })
      cdb.WithTxOpts(ctx, dbSession, opts, fn)              // to provide non-default sql.TxOptions
      cdb.WithTxResult(ctx, dbSession, fn)                  // where the closure returns (T, error)
      cdb.WithTxResultOpts(ctx, dbSession, opts, fn)
```

Where if the closure:
- Returns `nil`, the `tx` is committed.
- Returns an `err`, the `tx`is rolled back.

Callers no longer manage `Begin`/`Commit`/`Rollback` or maintain a "did we commit?" flag manually -- the closure boundary IS the commit boundary. The whole class of "*forgot to set txCommitted = true after Commit()*" bugs goes away because there's no flag to forget.

Example usage:
```
  err := cdb.WithTx(ctx, dbSession, func(tx *cdb.Tx) error {
      if err := helloDAO.Update(ctx, tx, input); err != nil {
          return cutil.NewAPIError(http.StatusInternalServerError, "DB update failed", nil)
      }
      return nil
  })
  if err != nil {
      return common.HandleTxError(c, logger, err, "Failed to update hello, txn rolled back")
  }
```
For now, I'm only wiring up the `Expected*` handlers to keep the size of this PR small, so it's easier to understand what's going on, what things look like after being refactored, etc.

Assuming we like it, I can do another PR that pulls more handlers in.

Tests added!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [x] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [x] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
