### PR TITLE
refactor: Add defensive nil check in GetForgeClient

### DIFF
--- a/site-workflow/pkg/grpc/client/carbide_client.go
+++ b/site-workflow/pkg/grpc/client/carbide_client.go
@@ -297,7 +297,16 @@ func (cac *CarbideAtomicClient) GetForgeClient() (wflows.ForgeClient, error) {
 	if client == nil {
 		return nil, ErrClientNotConnected
 	}
-	return client.Carbide(), nil
+
+	// It's true that NewCarbideClient always populates the inner carbide
+	// field, BUT, guard against zero-value CarbideClient instances slipping
+	// in via direct construction. Without this, a misconstructed wrapper
+	// would yield (nil, nil) and break things.
+	forge := client.Carbide()
+	if forge == nil {
+		return nil, ErrClientNotConnected
+	}
+	return forge, nil
 }
 
 // CheckAndReloadCerts continuously monitors the TLS certificates for changes.

--- a/site-workflow/pkg/grpc/client/carbide_client_test.go
+++ b/site-workflow/pkg/grpc/client/carbide_client_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
 
 	wflows "github.com/NVIDIA/ncx-infra-controller-rest/workflow-schema/schema/site-agent/workflows/v1"
 )
@@ -126,12 +127,17 @@ func TestCarbideAtomicClient_GetForgeClient_ReturnsForgeAfterSwap(t *testing.T) 
 	cac := &CarbideAtomicClient{
 		value: &atomic.Value{},
 	}
-	// Once a CarbideClient is stored, GetForgeClient should succeed and delegate to
-	// (*CarbideClient).Carbide(). The underlying carbide field is zero-value
-	// in this test, so we just verify there's no error.
-	cac.value.Store(&CarbideClient{})
-	_, err := cac.GetForgeClient()
+	// Once a CarbideClient with a populated carbide field is stored,
+	// GetForgeClient should return that exact inner client. We construct a
+	// stub via wflows.NewForgeClient(nil); it isn't usable for real RPCs but
+	// is a non-nil wflows.ForgeClient interface value, which is all we need
+	// to exercise the success path.
+	expected := wflows.NewForgeClient((*grpc.ClientConn)(nil))
+	cac.value.Store(&CarbideClient{carbide: expected})
+	got, err := cac.GetForgeClient()
 	assert.NoError(t, err)
+	assert.NotNil(t, got)
+	assert.Equal(t, expected, got)
 }
 
 func TestCarbideAtomicClient_CheckCertificates(t *testing.T) {


### PR DESCRIPTION
## Description

Follow-up to #461 (the RLA helper) for symmetry. Applies the same two fixes that got flagged on the RLA side for `nil` checking.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Refactor** - Refactoring of existing functionality (refactor:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **Site Agent** - Site Agent updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->
None

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
None