### PR TITLE
chore: Add ExpectedPowerShelf/ExpectedSwitch ToProto conversions onto db models

### DIFF
--- a/api/pkg/api/handler/expectedpowershelf.go
+++ b/api/pkg/api/handler/expectedpowershelf.go
@@ -28,7 +28,6 @@ import (
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/internal/config"
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/handler/util/common"
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/model"
-	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/model/util"
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/pagination"
 	sc "github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/client/site"
 	cutil "github.com/NVIDIA/ncx-infra-controller-rest/common/pkg/util"
@@ -43,63 +42,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	tclient "go.temporal.io/sdk/client"
 )
-
-// expectedPowerShelfToProto builds the workflow proto. BMC credentials and
-// labels are passed separately because they may come from the API request
-// rather than the DB record (BMC credentials aren't persisted at all).
-func expectedPowerShelfToProto(eps *cdbm.ExpectedPowerShelf, defaultBmcUsername, defaultBmcPassword *string, labels map[string]string) *cwssaws.ExpectedPowerShelf {
-	proto := &cwssaws.ExpectedPowerShelf{
-		ExpectedPowerShelfId: &cwssaws.UUID{Value: eps.ID.String()},
-		BmcMacAddress:        eps.BmcMacAddress,
-		ShelfSerialNumber:    eps.ShelfSerialNumber,
-	}
-
-	if eps.IpAddress != nil {
-		proto.BmcIpAddress = *eps.IpAddress
-	}
-	if eps.RackID != nil {
-		proto.RackId = &cwssaws.RackId{Id: *eps.RackID}
-	}
-	if eps.Name != nil {
-		proto.Name = eps.Name
-	}
-	if eps.Manufacturer != nil {
-		proto.Manufacturer = eps.Manufacturer
-	}
-	if eps.Model != nil {
-		proto.Model = eps.Model
-	}
-	if eps.Description != nil {
-		proto.Description = eps.Description
-	}
-	if eps.FirmwareVersion != nil {
-		proto.FirmwareVersion = eps.FirmwareVersion
-	}
-	if eps.SlotID != nil {
-		proto.SlotId = eps.SlotID
-	}
-	if eps.TrayIdx != nil {
-		proto.TrayIdx = eps.TrayIdx
-	}
-	if eps.HostID != nil {
-		proto.HostId = eps.HostID
-	}
-
-	if defaultBmcUsername != nil {
-		proto.BmcUsername = *defaultBmcUsername
-	}
-	if defaultBmcPassword != nil {
-		proto.BmcPassword = *defaultBmcPassword
-	}
-
-	if protoLabels := util.ProtobufLabelsFromAPILabels(labels); protoLabels != nil {
-		proto.Metadata = &cwssaws.Metadata{
-			Labels: protoLabels,
-		}
-	}
-
-	return proto
-}
 
 // ~~~~~ Create Handler ~~~~~ //
 
@@ -253,12 +195,10 @@ func (cepsh CreateExpectedPowerShelfHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to create Expected Power Shelf due to DB error", nil)
 	}
 
-	createExpectedPowerShelfRequest := expectedPowerShelfToProto(
-		expectedPowerShelf,
-		apiRequest.DefaultBmcUsername,
-		apiRequest.DefaultBmcPassword,
-		apiRequest.Labels,
-	)
+	createExpectedPowerShelfRequest := expectedPowerShelf.ToProto(cdbm.ExpectedPowerShelfCredentials{
+		Username: apiRequest.DefaultBmcUsername,
+		Password: apiRequest.DefaultBmcPassword,
+	})
 
 	logger.Info().Msg("triggering Expected Power Shelf create workflow on Site")
 
@@ -712,12 +652,10 @@ func (uepsh UpdateExpectedPowerShelfHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to update Expected Power Shelf due to DB error", nil)
 	}
 
-	updateExpectedPowerShelfRequest := expectedPowerShelfToProto(
-		updatedExpectedPowerShelf,
-		apiRequest.DefaultBmcUsername,
-		apiRequest.DefaultBmcPassword,
-		apiRequest.Labels,
-	)
+	updateExpectedPowerShelfRequest := updatedExpectedPowerShelf.ToProto(cdbm.ExpectedPowerShelfCredentials{
+		Username: apiRequest.DefaultBmcUsername,
+		Password: apiRequest.DefaultBmcPassword,
+	})
 
 	logger.Info().Msg("triggering ExpectedPowerShelf update workflow")
 

--- a/api/pkg/api/handler/expectedswitch.go
+++ b/api/pkg/api/handler/expectedswitch.go
@@ -28,7 +28,6 @@ import (
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/internal/config"
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/handler/util/common"
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/model"
-	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/model/util"
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/pagination"
 	sc "github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/client/site"
 	cutil "github.com/NVIDIA/ncx-infra-controller-rest/common/pkg/util"
@@ -43,66 +42,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	tclient "go.temporal.io/sdk/client"
 )
-
-// expectedSwitchToProto builds the workflow proto. BMC and NVOS credentials
-// and labels are passed separately because they may come from the API request
-// rather than the DB record (credentials aren't persisted at all).
-func expectedSwitchToProto(es *cdbm.ExpectedSwitch, defaultBmcUsername, defaultBmcPassword, nvOsUsername, nvOsPassword *string, labels map[string]string) *cwssaws.ExpectedSwitch {
-	proto := &cwssaws.ExpectedSwitch{
-		ExpectedSwitchId:   &cwssaws.UUID{Value: es.ID.String()},
-		BmcMacAddress:      es.BmcMacAddress,
-		SwitchSerialNumber: es.SwitchSerialNumber,
-	}
-
-	if es.RackID != nil {
-		proto.RackId = &cwssaws.RackId{Id: *es.RackID}
-	}
-	if es.Name != nil {
-		proto.Name = es.Name
-	}
-	if es.Manufacturer != nil {
-		proto.Manufacturer = es.Manufacturer
-	}
-	if es.Model != nil {
-		proto.Model = es.Model
-	}
-	if es.Description != nil {
-		proto.Description = es.Description
-	}
-	if es.FirmwareVersion != nil {
-		proto.FirmwareVersion = es.FirmwareVersion
-	}
-	if es.SlotID != nil {
-		proto.SlotId = es.SlotID
-	}
-	if es.TrayIdx != nil {
-		proto.TrayIdx = es.TrayIdx
-	}
-	if es.HostID != nil {
-		proto.HostId = es.HostID
-	}
-
-	if defaultBmcUsername != nil {
-		proto.BmcUsername = *defaultBmcUsername
-	}
-	if defaultBmcPassword != nil {
-		proto.BmcPassword = *defaultBmcPassword
-	}
-	if nvOsUsername != nil {
-		proto.NvosUsername = nvOsUsername
-	}
-	if nvOsPassword != nil {
-		proto.NvosPassword = nvOsPassword
-	}
-
-	if protoLabels := util.ProtobufLabelsFromAPILabels(labels); protoLabels != nil {
-		proto.Metadata = &cwssaws.Metadata{
-			Labels: protoLabels,
-		}
-	}
-
-	return proto
-}
 
 // ~~~~~ Create Handler ~~~~~ //
 
@@ -255,14 +194,12 @@ func (cesh CreateExpectedSwitchHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to create Expected Switch due to DB error", nil)
 	}
 
-	createExpectedSwitchRequest := expectedSwitchToProto(
-		expectedSwitch,
-		apiRequest.DefaultBmcUsername,
-		apiRequest.DefaultBmcPassword,
-		apiRequest.NvOsUsername,
-		apiRequest.NvOsPassword,
-		apiRequest.Labels,
-	)
+	createExpectedSwitchRequest := expectedSwitch.ToProto(cdbm.ExpectedSwitchCredentials{
+		BmcUsername:  apiRequest.DefaultBmcUsername,
+		BmcPassword:  apiRequest.DefaultBmcPassword,
+		NvosUsername: apiRequest.NvOsUsername,
+		NvosPassword: apiRequest.NvOsPassword,
+	})
 
 	logger.Info().Msg("triggering Expected Switch create workflow on Site")
 
@@ -715,14 +652,12 @@ func (uesh UpdateExpectedSwitchHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to update Expected Switch due to DB error", nil)
 	}
 
-	updateExpectedSwitchRequest := expectedSwitchToProto(
-		updatedExpectedSwitch,
-		apiRequest.DefaultBmcUsername,
-		apiRequest.DefaultBmcPassword,
-		apiRequest.NvOsUsername,
-		apiRequest.NvOsPassword,
-		apiRequest.Labels,
-	)
+	updateExpectedSwitchRequest := updatedExpectedSwitch.ToProto(cdbm.ExpectedSwitchCredentials{
+		BmcUsername:  apiRequest.DefaultBmcUsername,
+		BmcPassword:  apiRequest.DefaultBmcPassword,
+		NvosUsername: apiRequest.NvOsUsername,
+		NvosPassword: apiRequest.NvOsPassword,
+	})
 
 	logger.Info().Msg("triggering ExpectedSwitch update workflow")
 

--- a/db/pkg/db/model/expectedpowershelf.go
+++ b/db/pkg/db/model/expectedpowershelf.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/NVIDIA/ncx-infra-controller-rest/db/pkg/db"
 	"github.com/NVIDIA/ncx-infra-controller-rest/db/pkg/db/paginator"
+	cwssaws "github.com/NVIDIA/ncx-infra-controller-rest/workflow-schema/schema/site-agent/workflows/v1"
 	"github.com/google/uuid"
 
 	"github.com/uptrace/bun"
@@ -76,6 +77,79 @@ type ExpectedPowerShelf struct {
 	Created           time.Time         `bun:"created,nullzero,notnull,default:current_timestamp"`
 	Updated           time.Time         `bun:"updated,nullzero,notnull,default:current_timestamp"`
 	CreatedBy         uuid.UUID         `bun:"type:uuid,notnull"`
+}
+
+// ExpectedPowerShelfCredentials carries the BMC credentials for one
+// ExpectedPowerShelf. They live in their own type because they aren't
+// stored in the DB record and have to be threaded through to ToProto
+// separately.
+type ExpectedPowerShelfCredentials struct {
+	Username *string
+	Password *string
+}
+
+// ToProto builds the workflow proto for this ExpectedPowerShelf. BMC
+// credentials are passed in because they aren't persisted on the record;
+// labels are read from eps.Labels.
+func (eps *ExpectedPowerShelf) ToProto(creds ExpectedPowerShelfCredentials) *cwssaws.ExpectedPowerShelf {
+	proto := &cwssaws.ExpectedPowerShelf{
+		ExpectedPowerShelfId: &cwssaws.UUID{Value: eps.ID.String()},
+		BmcMacAddress:        eps.BmcMacAddress,
+		ShelfSerialNumber:    eps.ShelfSerialNumber,
+	}
+
+	if eps.IpAddress != nil {
+		proto.BmcIpAddress = *eps.IpAddress
+	}
+	if eps.RackID != nil {
+		proto.RackId = &cwssaws.RackId{Id: *eps.RackID}
+	}
+	if eps.Name != nil {
+		proto.Name = eps.Name
+	}
+	if eps.Manufacturer != nil {
+		proto.Manufacturer = eps.Manufacturer
+	}
+	if eps.Model != nil {
+		proto.Model = eps.Model
+	}
+	if eps.Description != nil {
+		proto.Description = eps.Description
+	}
+	if eps.FirmwareVersion != nil {
+		proto.FirmwareVersion = eps.FirmwareVersion
+	}
+	if eps.SlotID != nil {
+		proto.SlotId = eps.SlotID
+	}
+	if eps.TrayIdx != nil {
+		proto.TrayIdx = eps.TrayIdx
+	}
+	if eps.HostID != nil {
+		proto.HostId = eps.HostID
+	}
+
+	if creds.Username != nil {
+		proto.BmcUsername = *creds.Username
+	}
+	if creds.Password != nil {
+		proto.BmcPassword = *creds.Password
+	}
+
+	if eps.Labels != nil {
+		protoLabels := make([]*cwssaws.Label, 0, len(eps.Labels))
+		for k, v := range eps.Labels {
+			protoLabels = append(protoLabels, &cwssaws.Label{
+				Key:   k,
+				Value: &v,
+			})
+		}
+		proto.Metadata = &cwssaws.Metadata{
+			Labels: protoLabels,
+		}
+	}
+
+	return proto
 }
 
 // ExpectedPowerShelfCreateInput input parameters for Create method

--- a/db/pkg/db/model/expectedswitch.go
+++ b/db/pkg/db/model/expectedswitch.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/NVIDIA/ncx-infra-controller-rest/db/pkg/db"
 	"github.com/NVIDIA/ncx-infra-controller-rest/db/pkg/db/paginator"
+	cwssaws "github.com/NVIDIA/ncx-infra-controller-rest/workflow-schema/schema/site-agent/workflows/v1"
 	"github.com/google/uuid"
 
 	"github.com/uptrace/bun"
@@ -75,6 +76,83 @@ type ExpectedSwitch struct {
 	Created            time.Time         `bun:"created,nullzero,notnull,default:current_timestamp"`
 	Updated            time.Time         `bun:"updated,nullzero,notnull,default:current_timestamp"`
 	CreatedBy          uuid.UUID         `bun:"type:uuid,notnull"`
+}
+
+// ExpectedSwitchCredentials carries the BMC and NVOS credentials for one
+// ExpectedSwitch. They live in their own type because they aren't stored
+// in the DB record and have to be threaded through to ToProto separately.
+type ExpectedSwitchCredentials struct {
+	BmcUsername  *string
+	BmcPassword  *string
+	NvosUsername *string
+	NvosPassword *string
+}
+
+// ToProto builds the workflow proto for this ExpectedSwitch. BMC and NVOS
+// credentials are passed in because they aren't persisted on the record;
+// labels are read from es.Labels.
+func (es *ExpectedSwitch) ToProto(creds ExpectedSwitchCredentials) *cwssaws.ExpectedSwitch {
+	proto := &cwssaws.ExpectedSwitch{
+		ExpectedSwitchId:   &cwssaws.UUID{Value: es.ID.String()},
+		BmcMacAddress:      es.BmcMacAddress,
+		SwitchSerialNumber: es.SwitchSerialNumber,
+	}
+
+	if es.RackID != nil {
+		proto.RackId = &cwssaws.RackId{Id: *es.RackID}
+	}
+	if es.Name != nil {
+		proto.Name = es.Name
+	}
+	if es.Manufacturer != nil {
+		proto.Manufacturer = es.Manufacturer
+	}
+	if es.Model != nil {
+		proto.Model = es.Model
+	}
+	if es.Description != nil {
+		proto.Description = es.Description
+	}
+	if es.FirmwareVersion != nil {
+		proto.FirmwareVersion = es.FirmwareVersion
+	}
+	if es.SlotID != nil {
+		proto.SlotId = es.SlotID
+	}
+	if es.TrayIdx != nil {
+		proto.TrayIdx = es.TrayIdx
+	}
+	if es.HostID != nil {
+		proto.HostId = es.HostID
+	}
+
+	if creds.BmcUsername != nil {
+		proto.BmcUsername = *creds.BmcUsername
+	}
+	if creds.BmcPassword != nil {
+		proto.BmcPassword = *creds.BmcPassword
+	}
+	if creds.NvosUsername != nil {
+		proto.NvosUsername = creds.NvosUsername
+	}
+	if creds.NvosPassword != nil {
+		proto.NvosPassword = creds.NvosPassword
+	}
+
+	if es.Labels != nil {
+		protoLabels := make([]*cwssaws.Label, 0, len(es.Labels))
+		for k, v := range es.Labels {
+			protoLabels = append(protoLabels, &cwssaws.Label{
+				Key:   k,
+				Value: &v,
+			})
+		}
+		proto.Metadata = &cwssaws.Metadata{
+			Labels: protoLabels,
+		}
+	}
+
+	return proto
 }
 
 // ExpectedSwitchCreateInput input parameters for Create method


### PR DESCRIPTION
## Description

This mirrors new `ExpectedSwitch` pattern introduced in https://github.com/NVIDIA/infra-controller-rest/pull/456.

We introduce `ExpectedPowerShelfCredentials` and `ExpectedSwitchCredentials` structs, along with our `ToProto` receiver methods that read evereything directly from the model.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [x] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [x] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
