### PR TITLE
chore: Move Tenant proto conversion onto the db model

### DIFF
--- a/api/pkg/api/handler/allocation.go
+++ b/api/pkg/api/handler/allocation.go
@@ -48,7 +48,6 @@ import (
 	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/pagination"
 	sc "github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/client/site"
 	auth "github.com/NVIDIA/ncx-infra-controller-rest/auth/pkg/authorization"
-	cwssaws "github.com/NVIDIA/ncx-infra-controller-rest/workflow-schema/schema/site-agent/workflows/v1"
 
 	"github.com/NVIDIA/ncx-infra-controller-rest/db/pkg/db/ipam"
 )
@@ -440,17 +439,7 @@ func (cah CreateAllocationHandler) Handle(c echo.Context) error {
 		}
 
 		// Trigger apporpriate workflow on Site
-		// Unlikely case, but ensure that Tenant has an org display name populated
-		orgDisplayName := tenant.Org
-		if tenant.OrgDisplayName != nil {
-			orgDisplayName = *tenant.OrgDisplayName
-		}
-		createTenantRequest := &cwssaws.CreateTenantRequest{
-			OrganizationId: tenant.Org,
-			Metadata: &cwssaws.Metadata{
-				Name: orgDisplayName,
-			},
-		}
+		createTenantRequest := tenant.ToCreateRequestProto()
 
 		we, err := stc.ExecuteWorkflow(ctx, workflowOptions, "CreateTenant", createTenantRequest)
 		if err != nil {

--- a/db/pkg/db/model/tenant.go
+++ b/db/pkg/db/model/tenant.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/NVIDIA/ncx-infra-controller-rest/db/pkg/db"
 	stracer "github.com/NVIDIA/ncx-infra-controller-rest/db/pkg/tracer"
+	cwssaws "github.com/NVIDIA/ncx-infra-controller-rest/workflow-schema/schema/site-agent/workflows/v1"
 	"github.com/google/uuid"
 
 	"github.com/uptrace/bun"
@@ -55,6 +56,37 @@ type Tenant struct {
 	Updated        time.Time     `bun:"updated,nullzero,notnull,default:current_timestamp"`
 	Deleted        *time.Time    `bun:"deleted,soft_delete"`
 	CreatedBy      uuid.UUID     `bun:"type:uuid,notnull"`
+}
+
+// ToCreateRequestProto builds a CreateTenantRequest proto for sending this Tenant
+// to a Site. Falls back to Org for the metadata Name when OrgDisplayName
+// isn't set.
+func (tn *Tenant) ToCreateRequestProto() *cwssaws.CreateTenantRequest {
+	name := tn.Org
+	if tn.OrgDisplayName != nil {
+		name = *tn.OrgDisplayName
+	}
+	return &cwssaws.CreateTenantRequest{
+		OrganizationId: tn.Org,
+		Metadata: &cwssaws.Metadata{
+			Name: name,
+		},
+	}
+}
+
+// ToUpdateRequestProto builds an UpdateTenantRequest proto for sending this Tenant
+// to a Site.
+func (tn *Tenant) ToUpdateRequestProto() *cwssaws.UpdateTenantRequest {
+	name := tn.Org
+	if tn.OrgDisplayName != nil {
+		name = *tn.OrgDisplayName
+	}
+	return &cwssaws.UpdateTenantRequest{
+		OrganizationId: tn.Org,
+		Metadata: &cwssaws.Metadata{
+			Name: name,
+		},
+	}
 }
 
 var _ bun.BeforeAppendModelHook = (*Tenant)(nil)

--- a/workflow/pkg/activity/tenant/tenant.go
+++ b/workflow/pkg/activity/tenant/tenant.go
@@ -191,12 +191,7 @@ func (mt ManageTenant) CreateOrUpdateTenantOnSite(ctx context.Context, siteID uu
 		}
 
 		// Trigger apporpriate workflow on Site
-		createTenantRequest := &cwssaws.CreateTenantRequest{
-			OrganizationId: tenant.Org,
-			Metadata: &cwssaws.Metadata{
-				Name: *tenant.OrgDisplayName,
-			},
-		}
+		createTenantRequest := tenant.ToCreateRequestProto()
 
 		we, err := tc.ExecuteWorkflow(ctx, workflowOptions, "CreateTenant", createTenantRequest)
 		if err != nil {
@@ -211,12 +206,7 @@ func (mt ManageTenant) CreateOrUpdateTenantOnSite(ctx context.Context, siteID uu
 		}
 
 		// Trigger apporpriate workflow on Site
-		updateTenantRequest := &cwssaws.UpdateTenantRequest{
-			OrganizationId: tenant.Org,
-			Metadata: &cwssaws.Metadata{
-				Name: *tenant.OrgDisplayName,
-			},
-		}
+		updateTenantRequest := tenant.ToUpdateRequestProto()
 
 		we, err := tc.ExecuteWorkflow(ctx, workflowOptions, "UpdateTenant", updateTenantRequest)
 		if err != nil {


### PR DESCRIPTION
## Description

Add `Tenant.ToCreateRequestProto` and `Tenant.ToUpdateRequestProto` receiver methods that build the workflow protos for sending a `Tenant` down to a `Site`. Not as nice as `ToProto()`, but since a `tenant` can be turned into either request type, this is what I came up with.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [x] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **API** - API models or endpoints updated
- [x] **Workflow** - Workflow service updated
- [x] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
