### PR TITLE
refactor: factor object metadata fields in APICarbideObjectMetadata

### DIFF
--- a/api/pkg/api/handler/instance_test.go
+++ b/api/pkg/api/handler/instance_test.go
@@ -6765,7 +6765,10 @@ func TestGetInstanceHandler_Handle(t *testing.T) {
 			}
 
 			if tt.queryIncludeRelationVpc != nil {
-				assert.Equal(t, *tt.expectedVpcName, rst.Vpc.Name)
+				require.NotNil(t, tt.expectedVpcName)
+				require.NotNil(t, rst.Vpc)
+				require.NotNil(t, rst.Vpc.Metadata.Name)
+				assert.Equal(t, *tt.expectedVpcName, *rst.Vpc.Metadata.Name)
 			}
 
 			if tt.queryIncludeRelationInstanceType != nil {
@@ -8323,7 +8326,10 @@ func TestGetAllInstanceHandler_Handle(t *testing.T) {
 			}
 
 			if tt.queryIncludeRelationVpc != nil {
-				assert.Equal(t, *tt.expectedVpcName, rst[0].Vpc.Name)
+				require.NotNil(t, tt.expectedVpcName)
+				require.NotNil(t, rst[0].Vpc)
+				require.NotNil(t, rst[0].Vpc.Metadata.Name)
+				assert.Equal(t, *tt.expectedVpcName, *rst[0].Vpc.Metadata.Name)
 			}
 
 			if tt.queryIncludeRelationInstanceType != nil {

--- a/api/pkg/api/handler/subnet_test.go
+++ b/api/pkg/api/handler/subnet_test.go
@@ -1057,7 +1057,8 @@ func TestSubnetHandler_GetAll(t *testing.T) {
 
 			if tc.queryIncludeRelations1 != nil || tc.queryIncludeRelations2 != nil || tc.queryIncludeRelations3 != nil || tc.queryIncludeRelations4 != nil {
 				if tc.expectedVpcName != nil {
-					assert.Equal(t, *tc.expectedVpcName, resp[0].Vpc.Name)
+					require.NotNil(t, resp[0].Vpc.Metadata.Name)
+					assert.Equal(t, *tc.expectedVpcName, *resp[0].Vpc.Metadata.Name)
 				}
 				if tc.expectetIPv4Name != nil {
 					assert.Equal(t, *tc.expectetIPv4Name, resp[0].IPv4Block.Name)
@@ -1295,7 +1296,8 @@ func TestSubnetHandler_Get(t *testing.T) {
 
 				if tc.queryIncludeRelations1 != nil || tc.queryIncludeRelations2 != nil || tc.queryIncludeRelations3 != nil {
 					if tc.expectedVpcName != nil {
-						assert.Equal(t, *tc.expectedVpcName, rsp.Vpc.Name)
+						require.NotNil(t, rsp.Vpc.Metadata.Name)
+						assert.Equal(t, *tc.expectedVpcName, *rsp.Vpc.Metadata.Name)
 					}
 					if tc.expectetIPv4Name != nil {
 						assert.Equal(t, *tc.expectetIPv4Name, rsp.IPv4Block.Name)

--- a/api/pkg/api/handler/vpc.go
+++ b/api/pkg/api/handler/vpc.go
@@ -186,13 +186,13 @@ func (cvh CreateVPCHandler) Handle(c echo.Context) error {
 
 	// check for name uniqueness for the tenant, ie, tenant cannot have another vpc with same name at the site
 	// TODO consider doing this with an advisory lock for correctness
-	vpcs, tot, err := vpcDAO.GetAll(ctx, nil, cdbm.VpcFilterInput{Name: &apiRequest.Name, InfrastructureProviderID: cdb.GetUUIDPtr(site.InfrastructureProviderID), TenantIDs: []uuid.UUID{tenant.ID}, SiteIDs: []uuid.UUID{site.ID}}, cdbp.PageInput{}, nil)
+	vpcs, tot, err := vpcDAO.GetAll(ctx, nil, cdbm.VpcFilterInput{Name: apiRequest.Metadata.Name, InfrastructureProviderID: cdb.GetUUIDPtr(site.InfrastructureProviderID), TenantIDs: []uuid.UUID{tenant.ID}, SiteIDs: []uuid.UUID{site.ID}}, cdbp.PageInput{}, nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("db error checking for name uniqueness of tenant vpc")
 		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to create Vpc due to DB error", nil)
 	}
 	if tot > 0 {
-		logger.Warn().Str("tenantId", tenant.ID.String()).Str("name", apiRequest.Name).Msg("vpc with same name already exists for tenant")
+		logger.Warn().Str("tenantId", tenant.ID.String()).Str("name", *apiRequest.Metadata.Name).Msg("vpc with same name already exists for tenant")
 		return cutil.NewAPIErrorResponse(c, http.StatusConflict, "A Vpc with specified name already exists for Tenant", validation.Errors{
 			"id": errors.New(vpcs[0].ID.String()),
 		})
@@ -308,8 +308,8 @@ func (cvh CreateVPCHandler) Handle(c echo.Context) error {
 
 	// Labels support
 	var labels map[string]string
-	if apiRequest.Labels != nil {
-		labels = apiRequest.Labels
+	if apiRequest.Metadata.Labels != nil {
+		labels = apiRequest.Metadata.Labels
 	}
 
 	// Start a database transaction
@@ -325,8 +325,8 @@ func (cvh CreateVPCHandler) Handle(c echo.Context) error {
 	// Create VPC
 	vpcInput := cdbm.VpcCreateInput{
 		ID:                        apiRequest.ID,
-		Name:                      apiRequest.Name,
-		Description:               apiRequest.Description,
+		Name:                      *apiRequest.Metadata.Name,
+		Description:               apiRequest.Metadata.Description,
 		Org:                       org,
 		InfrastructureProviderID:  site.InfrastructureProviderID,
 		NetworkSecurityGroupID:    apiRequest.NetworkSecurityGroupID,
@@ -621,8 +621,8 @@ func (uvh UpdateVPCHandler) Handle(c echo.Context) error {
 
 	vpcDAO := cdbm.NewVpcDAO(uvh.dbSession)
 	// check for name uniqueness for the tenant, ie, tenant cannot have another vpc with same name at the site
-	if apiRequest.Name != nil && *apiRequest.Name != vpc.Name {
-		vpcs, tot, err := vpcDAO.GetAll(ctx, nil, cdbm.VpcFilterInput{Name: apiRequest.Name, InfrastructureProviderID: &vpc.InfrastructureProviderID, TenantIDs: []uuid.UUID{tenant.ID}, SiteIDs: []uuid.UUID{vpc.SiteID}}, cdbp.PageInput{}, nil)
+	if apiRequest.Metadata.Name != nil && *apiRequest.Metadata.Name != vpc.Name {
+		vpcs, tot, err := vpcDAO.GetAll(ctx, nil, cdbm.VpcFilterInput{Name: apiRequest.Metadata.Name, InfrastructureProviderID: &vpc.InfrastructureProviderID, TenantIDs: []uuid.UUID{tenant.ID}, SiteIDs: []uuid.UUID{vpc.SiteID}}, cdbp.PageInput{}, nil)
 		if err != nil {
 			logger.Error().Err(err).Msg("db error checking for name uniqueness of tenant vpc")
 			return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to create Vpc due to DB error", nil)
@@ -665,8 +665,8 @@ func (uvh UpdateVPCHandler) Handle(c echo.Context) error {
 
 	// Labels support
 	var labels map[string]string
-	if apiRequest.Labels != nil {
-		labels = apiRequest.Labels
+	if apiRequest.Metadata.Labels != nil {
+		labels = apiRequest.Metadata.Labels
 	}
 
 	siteConfig := &cdbm.SiteConfig{}
@@ -757,8 +757,8 @@ func (uvh UpdateVPCHandler) Handle(c echo.Context) error {
 	// Update VPC
 	uvpcInput := cdbm.VpcUpdateInput{
 		VpcID:                  vpc.ID,
-		Name:                   apiRequest.Name,
-		Description:            apiRequest.Description,
+		Name:                   apiRequest.Metadata.Name,
+		Description:            apiRequest.Metadata.Description,
 		Labels:                 labels,
 		NetworkSecurityGroupID: nsgID,
 	}

--- a/api/pkg/api/handler/vpc_test.go
+++ b/api/pkg/api/handler/vpc_test.go
@@ -445,17 +445,19 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcCreateRequest{
-					Name:                      "Test VPC",
-					Description:               cdb.GetStrPtr("Test VPC Description"),
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("Test VPC"),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+						Labels: map[string]string{
+							"vpc-dpu-zone": "east1",
+							"vpc-gpu-zone": "west1",
+						},
+					},
 					SiteID:                    st1.ID.String(),
 					NetworkVirtualizationType: cdb.GetStrPtr(cdbm.VpcFNN),
 					NetworkSecurityGroupID:    &nsgTenant1Site1.ID,
 					Vni:                       cdb.GetIntPtr(555),
-					Labels: map[string]string{
-						"vpc-dpu-zone": "east1",
-						"vpc-gpu-zone": "west1",
-					},
-					NVLinkLogicalPartitionID: cdb.GetStrPtr(nvllp1.ID.String()),
+					NVLinkLogicalPartitionID:  cdb.GetStrPtr(nvllp1.ID.String()),
 				},
 				reqOrg:   tnOrg,
 				reqUser:  tnu,
@@ -473,18 +475,20 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcCreateRequest{
-					Name:                      "Test VPC routing profile",
-					Description:               cdb.GetStrPtr("Test VPC Description"),
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("Test VPC routing profile"),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+						Labels: map[string]string{
+							"vpc-dpu-zone": "east1",
+							"vpc-gpu-zone": "west1",
+						},
+					},
 					SiteID:                    st1.ID.String(),
 					NetworkVirtualizationType: cdb.GetStrPtr(cdbm.VpcFNN),
 					NetworkSecurityGroupID:    &nsgTenant1Site1.ID,
 					Vni:                       cdb.GetIntPtr(559),
 					RoutingProfile:            cdb.GetStrPtr(model.APIVpcRoutingProfileInternal),
-					Labels: map[string]string{
-						"vpc-dpu-zone": "east1",
-						"vpc-gpu-zone": "west1",
-					},
-					NVLinkLogicalPartitionID: cdb.GetStrPtr(nvllp1.ID.String()),
+					NVLinkLogicalPartitionID:  cdb.GetStrPtr(nvllp1.ID.String()),
 				},
 				reqOrg:   tnOrg,
 				reqUser:  tnu,
@@ -502,8 +506,10 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcCreateRequest{
-					Name:                      "Test VPC unsupported routing profile",
-					Description:               cdb.GetStrPtr("Test VPC Description"),
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("Test VPC unsupported routing profile"),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+					},
 					SiteID:                    st1.ID.String(),
 					NetworkVirtualizationType: cdb.GetStrPtr(cdbm.VpcFNN),
 					RoutingProfile:            cdb.GetStrPtr("tenant-edge"),
@@ -525,8 +531,10 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcCreateRequest{
-					Name:                      "Test VPC restricted routing profile",
-					Description:               cdb.GetStrPtr("Test VPC Description"),
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("Test VPC restricted routing profile"),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+					},
 					SiteID:                    st1.ID.String(),
 					NetworkVirtualizationType: cdb.GetStrPtr(cdbm.VpcFNN),
 					RoutingProfile:            cdb.GetStrPtr(model.APIVpcRoutingProfileInternal),
@@ -548,8 +556,10 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcCreateRequest{
-					Name:                      "Test VPC ethernet routing profile",
-					Description:               cdb.GetStrPtr("Test VPC Description"),
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("Test VPC ethernet routing profile"),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+					},
 					SiteID:                    st1.ID.String(),
 					NetworkVirtualizationType: cdb.GetStrPtr(cdbm.VpcEthernetVirtualizer),
 					RoutingProfile:            cdb.GetStrPtr(model.APIVpcRoutingProfileInternal),
@@ -572,18 +582,20 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcCreateRequest{
-					Name:                      "Test VPC",
-					Description:               cdb.GetStrPtr("Test VPC Description"),
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("Test VPC"),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+						Labels: map[string]string{
+							"vpc-dpu-zone": "east1",
+							"vpc-gpu-zone": "west1",
+						},
+					},
 					SiteID:                    st1.ID.String(),
 					NetworkVirtualizationType: cdb.GetStrPtr(cdbm.VpcEthernetVirtualizer),
 					NetworkSecurityGroupID:    &nsgTenant1Site1.ID,
 					Vni:                       cdb.GetIntPtr(555),
 					RoutingProfile:            cdb.GetStrPtr(model.APIVpcRoutingProfileInternal),
-					Labels: map[string]string{
-						"vpc-dpu-zone": "east1",
-						"vpc-gpu-zone": "west1",
-					},
-					NVLinkLogicalPartitionID: cdb.GetStrPtr(nvllp1.ID.String()),
+					NVLinkLogicalPartitionID:  cdb.GetStrPtr(nvllp1.ID.String()),
 				},
 				reqOrg:      tnOrg,
 				reqUser:     tnu,
@@ -602,8 +614,10 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcCreateRequest{
-					Name:           "Test VPC default ethernet routing profile",
-					Description:    cdb.GetStrPtr("Test VPC Description"),
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("Test VPC default ethernet routing profile"),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+					},
 					SiteID:         st3.ID.String(),
 					RoutingProfile: cdb.GetStrPtr(model.APIVpcRoutingProfileInternal),
 				},
@@ -624,18 +638,20 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcCreateRequest{
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("Test VPC 2"),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+						Labels: map[string]string{
+							"vpc-dpu-zone": "east1",
+							"vpc-gpu-zone": "west1",
+						},
+					},
 					ID:                        db.GetUUIDPtr(uuid.New()),
-					Name:                      "Test VPC 2",
-					Description:               cdb.GetStrPtr("Test VPC Description"),
 					SiteID:                    st1.ID.String(),
 					NetworkVirtualizationType: cdb.GetStrPtr(cdbm.VpcFNN),
 					NetworkSecurityGroupID:    &nsgTenant1Site1.ID,
 					Vni:                       cdb.GetIntPtr(557),
-					Labels: map[string]string{
-						"vpc-dpu-zone": "east1",
-						"vpc-gpu-zone": "west1",
-					},
-					NVLinkLogicalPartitionID: cdb.GetStrPtr(nvllp1.ID.String()),
+					NVLinkLogicalPartitionID:  cdb.GetStrPtr(nvllp1.ID.String()),
 				},
 				reqOrg:   tnOrg,
 				reqUser:  tnu,
@@ -653,18 +669,20 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcCreateRequest{
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("Test VPC 3"),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+						Labels: map[string]string{
+							"vpc-dpu-zone": "east1",
+							"vpc-gpu-zone": "west1",
+						},
+					},
 					ID:                        &existingVPCSt1.ID,
-					Name:                      "Test VPC 3",
-					Description:               cdb.GetStrPtr("Test VPC Description"),
 					SiteID:                    st1.ID.String(),
 					NetworkVirtualizationType: cdb.GetStrPtr(cdbm.VpcFNN),
 					NetworkSecurityGroupID:    &nsgTenant1Site1.ID,
 					Vni:                       cdb.GetIntPtr(556),
-					Labels: map[string]string{
-						"vpc-dpu-zone": "east1",
-						"vpc-gpu-zone": "west1",
-					},
-					NVLinkLogicalPartitionID: cdb.GetStrPtr(nvllp1.ID.String()),
+					NVLinkLogicalPartitionID:  cdb.GetStrPtr(nvllp1.ID.String()),
 				},
 				reqOrg:   tnOrg,
 				reqUser:  tnu,
@@ -682,16 +700,17 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcCreateRequest{
-					Name:                      "Test VPC bad nsg tenant",
-					Description:               cdb.GetStrPtr("Test VPC Description"),
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("Test VPC bad nsg tenant"),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+						Labels: map[string]string{
+							"vpc-dpu-zone": "east1",
+							"vpc-gpu-zone": "west1",
+						},
+					},
 					SiteID:                    st1.ID.String(),
 					NetworkVirtualizationType: cdb.GetStrPtr(cdbm.VpcFNN),
 					NetworkSecurityGroupID:    &nsgTenant2Site1.ID,
-
-					Labels: map[string]string{
-						"vpc-dpu-zone": "east1",
-						"vpc-gpu-zone": "west1",
-					},
 				},
 				reqOrg:   tnOrg,
 				reqUser:  tnu,
@@ -709,16 +728,17 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcCreateRequest{
-					Name:                      "Test VPC bad nsg tenant",
-					Description:               cdb.GetStrPtr("Test VPC Description"),
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("Test VPC bad nsg tenant"),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+						Labels: map[string]string{
+							"vpc-dpu-zone": "east1",
+							"vpc-gpu-zone": "west1",
+						},
+					},
 					SiteID:                    st1.ID.String(),
 					NetworkVirtualizationType: cdb.GetStrPtr(cdbm.VpcFNN),
 					NetworkSecurityGroupID:    &nsgTenant1Site2.ID,
-
-					Labels: map[string]string{
-						"vpc-dpu-zone": "east1",
-						"vpc-gpu-zone": "west1",
-					},
 				},
 				reqOrg:   tnOrg,
 				reqUser:  tnu,
@@ -736,16 +756,17 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcCreateRequest{
-					Name:                      "Test VPC bad nsg tenant",
-					Description:               cdb.GetStrPtr("Test VPC Description"),
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("Test VPC bad nsg tenant"),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+						Labels: map[string]string{
+							"vpc-dpu-zone": "east1",
+							"vpc-gpu-zone": "west1",
+						},
+					},
 					SiteID:                    st1.ID.String(),
 					NetworkVirtualizationType: cdb.GetStrPtr(cdbm.VpcFNN),
 					NetworkSecurityGroupID:    cdb.GetStrPtr(uuid.NewString()),
-
-					Labels: map[string]string{
-						"vpc-dpu-zone": "east1",
-						"vpc-gpu-zone": "west1",
-					},
 				},
 				reqOrg:   tnOrg,
 				reqUser:  tnu,
@@ -763,9 +784,11 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcCreateRequest{
-					Name:        "Test VPC",
-					Description: cdb.GetStrPtr("Test VPC Description"),
-					SiteID:      st1.ID.String(),
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("Test VPC"),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+					},
+					SiteID: st1.ID.String(),
 				},
 				reqOrg:   tnOrg,
 				reqUser:  tnu,
@@ -782,9 +805,11 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcCreateRequest{
-					Name:        "Test VPC",
-					Description: cdb.GetStrPtr("Test VPC Description"),
-					SiteID:      st1.ID.String(),
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("Test VPC"),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+					},
+					SiteID: st1.ID.String(),
 				},
 				reqOrg:   ipOrg,
 				reqUser:  ipu,
@@ -801,9 +826,11 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcCreateRequest{
-					Name:        "Test VPC",
-					Description: cdb.GetStrPtr("Test VPC Description"),
-					SiteID:      uuid.NewString(),
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("Test VPC"),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+					},
+					SiteID: uuid.NewString(),
 				},
 				reqOrg:   tnOrg,
 				reqUser:  tnu,
@@ -820,9 +847,11 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcCreateRequest{
-					Name:        "Test VPC",
-					Description: cdb.GetStrPtr("Test VPC Description"),
-					SiteID:      st2.ID.String(),
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("Test VPC"),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+					},
+					SiteID: st2.ID.String(),
 				},
 				reqOrg:   tnOrg,
 				reqUser:  tnu,
@@ -839,8 +868,10 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcCreateRequest{
-					Name:                      "Test VPC 3",
-					Description:               cdb.GetStrPtr("Test VPC Description 3"),
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("Test VPC 3"),
+						Description: cdb.GetStrPtr("Test VPC Description 3"),
+					},
 					SiteID:                    st3.ID.String(),
 					NetworkVirtualizationType: cdb.GetStrPtr(cdbm.VpcFNN),
 				},
@@ -861,13 +892,15 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcCreateRequest{
-					Name:        "Test VPC 3",
-					Description: cdb.GetStrPtr("Test VPC Description 3"),
-					SiteID:      st3.ID.String(),
-					Labels: map[string]string{
-						"vpc-dpu-zone": "east1",
-						"vpc-gpu-zone": "west1",
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("Test VPC 3"),
+						Description: cdb.GetStrPtr("Test VPC Description 3"),
+						Labels: map[string]string{
+							"vpc-dpu-zone": "east1",
+							"vpc-gpu-zone": "west1",
+						},
 					},
+					SiteID: st3.ID.String(),
 				},
 				reqOrg:   tnOrg,
 				reqUser:  tnu,
@@ -885,12 +918,14 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcCreateRequest{
-					Name:        "Test VPC",
-					Description: cdb.GetStrPtr("Test VPC Description"),
-					SiteID:      st1.ID.String(),
-					Labels: map[string]string{
-						"ygsV9MoUjep1rCwbQskkF9wfMolE3oDTCcxuYSJCx9TLKepCIku9pnHfIkxCxHkb7ucbsBL4hyLqQaHoEqpTBmfoX4Un7sGvQdHGZ7nb68JJEJ3ocFAtyCMCBt66z3ldnTqp8SXXOIhNsOh35MLYQjI8557Pu6o91TsEBqyTz0yz68HHmfNgJoreHpXfeujq4cpElUXXbQ3xfFICkNyghXgFZ0MLs2o0u1Nd29aB113X5g3FKJBCskW6eBULNmeFFG61DMM37q": "east1",
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("Test VPC"),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+						Labels: map[string]string{
+							"ygsV9MoUjep1rCwbQskkF9wfMolE3oDTCcxuYSJCx9TLKepCIku9pnHfIkxCxHkb7ucbsBL4hyLqQaHoEqpTBmfoX4Un7sGvQdHGZ7nb68JJEJ3ocFAtyCMCBt66z3ldnTqp8SXXOIhNsOh35MLYQjI8557Pu6o91TsEBqyTz0yz68HHmfNgJoreHpXfeujq4cpElUXXbQ3xfFICkNyghXgFZ0MLs2o0u1Nd29aB113X5g3FKJBCskW6eBULNmeFFG61DMM37q": "east1",
+						},
 					},
+					SiteID: st1.ID.String(),
 				},
 				reqOrg:      tnOrg,
 				reqUser:     tnu,
@@ -951,17 +986,17 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 				t.Fatal(serr)
 			}
 
-			assert.Equal(t, rst.Name, tt.args.reqData.Name)
+			assert.Equal(t, rst.Metadata.Name, tt.args.reqData.Metadata.Name)
 			assert.True(t, tt.args.reqData.ID == nil || rst.ID == tt.args.reqData.ID.String(), "%+v != %+v", rst.ID, tt.args.reqData.ID)
 			if tt.args.reqData.Vni != nil {
 				assert.NotNil(t, rst.RequestedVni)
 				assert.Equal(t, *tt.args.reqData.Vni, *rst.RequestedVni)
 			}
-			if tt.args.reqData.Description != nil {
-				assert.NotNil(t, rst.Description)
-				assert.Equal(t, *rst.Description, *tt.args.reqData.Description)
+			if tt.args.reqData.Metadata.Description != nil {
+				assert.NotNil(t, rst.Metadata.Description)
+				assert.Equal(t, *rst.Metadata.Description, *tt.args.reqData.Metadata.Description)
 			} else {
-				assert.Nil(t, rst.Description)
+				assert.Nil(t, rst.Metadata.Description)
 			}
 			assert.Equal(t, tt.args.reqData.RoutingProfile, rst.RoutingProfile)
 			if tt.args.reqData.NetworkVirtualizationType != nil {
@@ -978,8 +1013,8 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 				assert.Nil(t, rst.NVLinkLogicalPartitionID)
 			}
 
-			if tt.args.reqData.Labels != nil {
-				assert.Equal(t, len(rst.Labels), len(tt.args.reqData.Labels))
+			if tt.args.reqData.Metadata.Labels != nil {
+				assert.Equal(t, len(rst.Metadata.Labels), len(tt.args.reqData.Metadata.Labels))
 			}
 
 			assert.True(t, tsc.AssertCalled(t, "ExecuteWorkflow", mock.Anything, mock.AnythingOfType("internal.StartWorkflowOptions"), "CreateVPCV2", mock.MatchedBy(func(req *cwssaws.VpcCreationRequest) bool {
@@ -1163,10 +1198,12 @@ func TestUpdateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcUpdateRequest{
-					Name:        cdb.GetStrPtr("test-vpc"),
-					Description: cdb.GetStrPtr("Test VPC Description"),
-					Labels: map[string]string{
-						"zone": "westnew",
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("test-vpc"),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+						Labels: map[string]string{
+							"zone": "westnew",
+						},
 					},
 					NVLinkLogicalPartitionID: cdb.GetStrPtr(nvllp1.ID.String()),
 				},
@@ -1188,12 +1225,14 @@ func TestUpdateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcUpdateRequest{
-					Name:                   cdb.GetStrPtr(uuid.NewString()),
-					Description:            cdb.GetStrPtr("Test VPC Description"),
-					NetworkSecurityGroupID: &nsgTenant2Site1.ID,
-					Labels: map[string]string{
-						"zone": "westnew",
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr(uuid.NewString()),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+						Labels: map[string]string{
+							"zone": "westnew",
+						},
 					},
+					NetworkSecurityGroupID: &nsgTenant2Site1.ID,
 				},
 				reqVPCID: vpc.ID.String(),
 				reqVPC:   vpc,
@@ -1213,12 +1252,14 @@ func TestUpdateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcUpdateRequest{
-					Name:                   cdb.GetStrPtr(uuid.NewString()),
-					Description:            cdb.GetStrPtr("Test VPC Description"),
-					NetworkSecurityGroupID: &nsgTenant1Site2.ID,
-					Labels: map[string]string{
-						"zone": "westnew",
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr(uuid.NewString()),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+						Labels: map[string]string{
+							"zone": "westnew",
+						},
 					},
+					NetworkSecurityGroupID: &nsgTenant1Site2.ID,
 				},
 				reqVPCID: vpc.ID.String(),
 				reqVPC:   vpc,
@@ -1238,12 +1279,14 @@ func TestUpdateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcUpdateRequest{
-					Name:                   cdb.GetStrPtr(uuid.NewString()),
-					Description:            cdb.GetStrPtr("Test VPC Description"),
-					NetworkSecurityGroupID: cdb.GetStrPtr(uuid.NewString()),
-					Labels: map[string]string{
-						"zone": "westnew",
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr(uuid.NewString()),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+						Labels: map[string]string{
+							"zone": "westnew",
+						},
 					},
+					NetworkSecurityGroupID: cdb.GetStrPtr(uuid.NewString()),
 				},
 				reqVPCID: vpc.ID.String(),
 				reqVPC:   vpc,
@@ -1263,12 +1306,14 @@ func TestUpdateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcUpdateRequest{
-					Name:                   cdb.GetStrPtr(uuid.NewString()),
-					Description:            cdb.GetStrPtr("Test VPC Description"),
-					NetworkSecurityGroupID: cdb.GetStrPtr(""),
-					Labels: map[string]string{
-						"zone": "westnew",
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr(uuid.NewString()),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+						Labels: map[string]string{
+							"zone": "westnew",
+						},
 					},
+					NetworkSecurityGroupID: cdb.GetStrPtr(""),
 				},
 				reqVPCID: vpc.ID.String(),
 				reqVPC:   vpc,
@@ -1289,9 +1334,11 @@ func TestUpdateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcUpdateRequest{
-					Name:        cdb.GetStrPtr("test-vpc-2"),
-					Description: cdb.GetStrPtr("Test VPC Description"),
-				},
+
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("test-vpc-2"),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+					}},
 				reqVPCID: vpc.ID.String(),
 				reqVPC:   vpc,
 				reqOrg:   tnOrg,
@@ -1309,9 +1356,11 @@ func TestUpdateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcUpdateRequest{
-					Name:        cdb.GetStrPtr("test-vpc-2"),
-					Description: cdb.GetStrPtr("Test VPC Description"),
-				},
+
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("test-vpc-2"),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+					}},
 				reqVPCID: vpc2.ID.String(),
 				reqVPC:   vpc2,
 				reqOrg:   tnOrg,
@@ -1329,9 +1378,11 @@ func TestUpdateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcUpdateRequest{
-					Name:        cdb.GetStrPtr("test-vpc"),
-					Description: cdb.GetStrPtr("Test VPC Description"),
-				},
+
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("test-vpc"),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+					}},
 				reqVPCID: vpc.ID.String(),
 				reqVPC:   vpc,
 				reqOrg:   ipOrg,
@@ -1349,9 +1400,11 @@ func TestUpdateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcUpdateRequest{
-					Name:        cdb.GetStrPtr("test-vpc"),
-					Description: cdb.GetStrPtr("Test VPC Description"),
-				},
+
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("test-vpc"),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+					}},
 				reqVPC:   vpc,
 				reqVPCID: "",
 				reqOrg:   tnOrg,
@@ -1369,9 +1422,11 @@ func TestUpdateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcUpdateRequest{
-					Name:        cdb.GetStrPtr("test-vpc-3"),
-					Description: cdb.GetStrPtr("Test VPC Description"),
-				},
+
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("test-vpc-3"),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+					}},
 				reqVPCID: vpc4.ID.String(),
 				reqVPC:   vpc4,
 				reqOrg:   tnOrg,
@@ -1389,13 +1444,15 @@ func TestUpdateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcUpdateRequest{
-					Name:        cdb.GetStrPtr("Test VPC 3"),
-					Description: cdb.GetStrPtr("Test VPC Description 3"),
-					Labels: map[string]string{
-						"vpc-dpu-zone": "east1",
-						"vpc-gpu-zone": "west1",
-					},
-				},
+
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("Test VPC 3"),
+						Description: cdb.GetStrPtr("Test VPC Description 3"),
+						Labels: map[string]string{
+							"vpc-dpu-zone": "east1",
+							"vpc-gpu-zone": "west1",
+						},
+					}},
 				reqOrg:      tnOrg,
 				reqVPCID:    vpc3.ID.String(),
 				reqVPC:      vpc3,
@@ -1415,12 +1472,14 @@ func TestUpdateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcUpdateRequest{
-					Name:        db.GetStrPtr("Test VPC"),
-					Description: cdb.GetStrPtr("Test VPC Description"),
-					Labels: map[string]string{
-						"ygsV9MoUjep1rCwbQskkF9wfMolE3oDTCcxuYSJCx9TLKepCIku9pnHfIkxCxHkb7ucbsBL4hyLqQaHoEqpTBmfoX4Un7sGvQdHGZ7nb68JJEJ3ocFAtyCMCBt66z3ldnTqp8SXXOIhNsOh35MLYQjI8557Pu6o91TsEBqyTz0yz68HHmfNgJoreHpXfeujq4cpElUXXbQ3xfFICkNyghXgFZ0MLs2o0u1Nd29aB113X5g3FKJBCskW6eBULNmeFFG61DMM37q": "east1",
-					},
-				},
+
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("Test VPC"),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+						Labels: map[string]string{
+							"ygsV9MoUjep1rCwbQskkF9wfMolE3oDTCcxuYSJCx9TLKepCIku9pnHfIkxCxHkb7ucbsBL4hyLqQaHoEqpTBmfoX4Un7sGvQdHGZ7nb68JJEJ3ocFAtyCMCBt66z3ldnTqp8SXXOIhNsOh35MLYQjI8557Pu6o91TsEBqyTz0yz68HHmfNgJoreHpXfeujq4cpElUXXbQ3xfFICkNyghXgFZ0MLs2o0u1Nd29aB113X5g3FKJBCskW6eBULNmeFFG61DMM37q": "east1",
+						},
+					}},
 				reqOrg:      tnOrg,
 				reqVPCID:    vpc.ID.String(),
 				reqVPC:      vpc,
@@ -1440,8 +1499,10 @@ func TestUpdateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcUpdateRequest{
-					Name:                     cdb.GetStrPtr("test-vpc"),
-					Description:              cdb.GetStrPtr("Test VPC Description"),
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("test-vpc"),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+					},
 					NVLinkLogicalPartitionID: cdb.GetStrPtr(""),
 				},
 				reqVPCID: vpc.ID.String(),
@@ -1462,8 +1523,10 @@ func TestUpdateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcUpdateRequest{
-					Name:                     cdb.GetStrPtr("test-vpc"),
-					Description:              cdb.GetStrPtr("Test VPC Description"),
+					Metadata: model.APICarbideObjectMetadata{
+						Name:        cdb.GetStrPtr("test-vpc"),
+						Description: cdb.GetStrPtr("Test VPC Description"),
+					},
 					NVLinkLogicalPartitionID: cdb.GetStrPtr(nvllp2.ID.String()),
 				},
 				reqVPCID: vpc.ID.String(),
@@ -1525,8 +1588,8 @@ func TestUpdateVPCHandler_Handle(t *testing.T) {
 				t.Fatal(serr)
 			}
 
-			assert.Equal(t, rst.Name, *tt.args.reqData.Name)
-			assert.Equal(t, *rst.Description, *tt.args.reqData.Description)
+			assert.Equal(t, rst.Metadata.Name, tt.args.reqData.Metadata.Name)
+			assert.Equal(t, *rst.Metadata.Description, *tt.args.reqData.Metadata.Description)
 			assert.NotEqual(t, rst.Updated.String(), tt.args.reqVPC.Updated.String())
 
 			if tt.args.reqData.NVLinkLogicalPartitionID != nil {
@@ -1537,8 +1600,8 @@ func TestUpdateVPCHandler_Handle(t *testing.T) {
 				}
 			}
 
-			if tt.args.reqData.Labels != nil {
-				assert.Equal(t, len(rst.Labels), len(tt.args.reqData.Labels))
+			if tt.args.reqData.Metadata.Labels != nil {
+				assert.Equal(t, len(rst.Metadata.Labels), len(tt.args.reqData.Metadata.Labels))
 			}
 
 			if tt.expectedNVLinkPartitionValue != nil {
@@ -2160,8 +2223,8 @@ func TestGetVPCHandler_Handle(t *testing.T) {
 				t.Fatal(serr)
 			}
 
-			assert.Equal(t, rst.Name, tt.args.reqVPC.Name)
-			assert.Equal(t, rst.Description, tt.args.reqVPC.Description)
+			assert.Equal(t, *rst.Metadata.Name, tt.args.reqVPC.Name)
+			assert.Equal(t, rst.Metadata.Description, tt.args.reqVPC.Description)
 
 			if tt.expectedTenantOrg != nil {
 				assert.Equal(t, rst.Tenant.Org, *tt.expectedTenantOrg)
@@ -2868,7 +2931,7 @@ func TestGetAllVPCHandler_Handle(t *testing.T) {
 			assert.Equal(t, tt.wantTotalCount, pr.Total)
 
 			if tt.wantFirstEntry != nil {
-				assert.Equal(t, tt.wantFirstEntry.Name, resp[0].Name)
+				assert.Equal(t, tt.wantFirstEntry.Name, *resp[0].Metadata.Name)
 			}
 
 			if len(resp) > 0 {

--- a/api/pkg/api/handler/vpcprefix_test.go
+++ b/api/pkg/api/handler/vpcprefix_test.go
@@ -1006,7 +1006,7 @@ func TestVpcPrefixHandler_GetAll(t *testing.T) {
 
 			if tc.queryIncludeRelations1 != nil || tc.queryIncludeRelations2 != nil || tc.queryIncludeRelations3 != nil || tc.queryIncludeRelations4 != nil {
 				if tc.expectedVpcName != nil {
-					assert.Equal(t, *tc.expectedVpcName, resp[0].Vpc.Name)
+					assert.Equal(t, *tc.expectedVpcName, resp[0].Vpc.Metadata.Name)
 				}
 				if tc.expectetIPv4Name != nil {
 					assert.Equal(t, *tc.expectetIPv4Name, resp[0].IPBlock.Name)
@@ -1237,7 +1237,7 @@ func TestVpcPrefixHandler_Get(t *testing.T) {
 
 				if tc.queryIncludeRelations1 != nil || tc.queryIncludeRelations2 != nil || tc.queryIncludeRelations3 != nil {
 					if tc.expectedVpcName != nil {
-						assert.Equal(t, *tc.expectedVpcName, rsp.Vpc.Name)
+						assert.Equal(t, *tc.expectedVpcName, rsp.Vpc.Metadata.Name)
 					}
 					if tc.expectetIPName != nil {
 						assert.Equal(t, *tc.expectetIPName, rsp.IPBlock.Name)

--- a/api/pkg/api/model/carbide_object_metadata.go
+++ b/api/pkg/api/model/carbide_object_metadata.go
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package model
+
+import (
+	"github.com/NVIDIA/ncx-infra-controller-rest/api/pkg/api/model/util"
+	cdbm "github.com/NVIDIA/ncx-infra-controller-rest/db/pkg/db/model"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// APICarbideObjectMetadata mirrors the carbide-api gRPC `Metadata` message.
+type APICarbideObjectMetadata struct {
+	// Name is the user-assigned name of the object.
+	Name *string `json:"name"`
+	// Description is the user-supplied description of the object.
+	Description *string `json:"description"`
+	// Labels are key/value pairs attached to the object.
+	Labels map[string]string `json:"labels"`
+}
+
+// ValidateOnCreate runs the validation rules that apply when an object is
+// being created. Name is required; Description and Labels are optional.
+func (m APICarbideObjectMetadata) ValidateOnCreate() error {
+	if err := validation.ValidateStruct(&m,
+		validation.Field(&m.Name,
+			validation.Required.Error(validationErrorStringLength),
+			validation.By(util.ValidateNameCharacters),
+			validation.When(m.Name != nil,
+				validation.Length(2, 256).Error(validationErrorStringLength)),
+		),
+		validation.Field(&m.Description,
+			validation.When(m.Description != nil,
+				validation.Length(0, 1024).Error(validationErrorDescriptionStringLength)),
+		),
+	); err != nil {
+		return err
+	}
+	return util.ValidateLabels(m.Labels)
+}
+
+// ValidateOnUpdate runs the validation rules that apply when an object is
+// being updated. All fields are optional; what's present must still validate.
+func (m APICarbideObjectMetadata) ValidateOnUpdate() error {
+	if err := validation.ValidateStruct(&m,
+		validation.Field(&m.Name,
+			validation.When(m.Name != nil,
+				validation.By(util.ValidateNameCharacters),
+				validation.Length(2, 256).Error(validationErrorStringLength)),
+		),
+		validation.Field(&m.Description,
+			validation.When(m.Description != nil,
+				validation.Length(0, 1024).Error(validationErrorDescriptionStringLength)),
+		),
+	); err != nil {
+		return err
+	}
+	return util.ValidateLabels(m.Labels)
+}
+
+// NewAPICarbideObjectMetadataFromVpc builds metadata from a DB Vpc row.
+// Each adopting type gets its own constructor that pulls from its DB shape.
+func NewAPICarbideObjectMetadataFromVpc(v cdbm.Vpc) APICarbideObjectMetadata {
+	return APICarbideObjectMetadata{
+		Name:        &v.Name,
+		Description: v.Description,
+		Labels:      v.Labels,
+	}
+}

--- a/api/pkg/api/model/carbide_object_metadata_test.go
+++ b/api/pkg/api/model/carbide_object_metadata_test.go
@@ -1,0 +1,251 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package model
+
+import (
+	"strings"
+	"testing"
+
+	cdb "github.com/NVIDIA/ncx-infra-controller-rest/db/pkg/db"
+	cdbm "github.com/NVIDIA/ncx-infra-controller-rest/db/pkg/db/model"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAPICarbideObjectMetadata_ValidateOnCreate(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata APICarbideObjectMetadata
+		wantErr  bool
+	}{
+		{
+			name: "minimal valid metadata",
+			metadata: APICarbideObjectMetadata{
+				Name: cdb.GetStrPtr("test-name"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "full valid metadata",
+			metadata: APICarbideObjectMetadata{
+				Name:        cdb.GetStrPtr("test-name"),
+				Description: cdb.GetStrPtr("Test description"),
+				Labels:      map[string]string{"env": "prod"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing name is rejected",
+			metadata: APICarbideObjectMetadata{
+				Name: nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "name too short (1 char)",
+			metadata: APICarbideObjectMetadata{
+				Name: cdb.GetStrPtr("a"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "name too long (257 chars)",
+			metadata: APICarbideObjectMetadata{
+				Name: cdb.GetStrPtr(strings.Repeat("a", 257)),
+			},
+			wantErr: true,
+		},
+		{
+			name: "name with leading whitespace is rejected",
+			metadata: APICarbideObjectMetadata{
+				Name: cdb.GetStrPtr(" bad-name"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "name with trailing whitespace is rejected",
+			metadata: APICarbideObjectMetadata{
+				Name: cdb.GetStrPtr("bad-name "),
+			},
+			wantErr: true,
+		},
+		{
+			name: "description over the 1024 char limit",
+			metadata: APICarbideObjectMetadata{
+				Name:        cdb.GetStrPtr("test-name"),
+				Description: cdb.GetStrPtr(strings.Repeat("a", 1025)),
+			},
+			wantErr: true,
+		},
+		{
+			name: "description at the 1024 char limit",
+			metadata: APICarbideObjectMetadata{
+				Name:        cdb.GetStrPtr("test-name"),
+				Description: cdb.GetStrPtr(strings.Repeat("a", 1024)),
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty-string description is allowed",
+			metadata: APICarbideObjectMetadata{
+				Name:        cdb.GetStrPtr("test-name"),
+				Description: cdb.GetStrPtr(""),
+			},
+			wantErr: false,
+		},
+		{
+			name: "nil description is allowed",
+			metadata: APICarbideObjectMetadata{
+				Name:        cdb.GetStrPtr("test-name"),
+				Description: nil,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.metadata.ValidateOnCreate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAPICarbideObjectMetadata_ValidateOnUpdate(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata APICarbideObjectMetadata
+		wantErr  bool
+	}{
+		{
+			name:     "empty metadata is allowed (no fields being updated)",
+			metadata: APICarbideObjectMetadata{},
+			wantErr:  false,
+		},
+		{
+			name: "valid name",
+			metadata: APICarbideObjectMetadata{
+				Name: cdb.GetStrPtr("new-name"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "name too short (1 char)",
+			metadata: APICarbideObjectMetadata{
+				Name: cdb.GetStrPtr("a"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "name too long (257 chars)",
+			metadata: APICarbideObjectMetadata{
+				Name: cdb.GetStrPtr(strings.Repeat("a", 257)),
+			},
+			wantErr: true,
+		},
+		{
+			name: "name with leading whitespace is rejected",
+			metadata: APICarbideObjectMetadata{
+				Name: cdb.GetStrPtr(" bad-name"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "name with trailing whitespace is rejected",
+			metadata: APICarbideObjectMetadata{
+				Name: cdb.GetStrPtr("bad-name "),
+			},
+			wantErr: true,
+		},
+		{
+			name: "description over the 1024 char limit",
+			metadata: APICarbideObjectMetadata{
+				Description: cdb.GetStrPtr(strings.Repeat("a", 1025)),
+			},
+			wantErr: true,
+		},
+		{
+			name: "labels-only update",
+			metadata: APICarbideObjectMetadata{
+				Labels: map[string]string{"env": "prod"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "all fields together",
+			metadata: APICarbideObjectMetadata{
+				Name:        cdb.GetStrPtr("new-name"),
+				Description: cdb.GetStrPtr("new description"),
+				Labels:      map[string]string{"env": "prod"},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.metadata.ValidateOnUpdate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNewAPICarbideObjectMetadataFromVpc(t *testing.T) {
+	desc := "a description"
+	labels := map[string]string{"team": "platform", "env": "prod"}
+
+	t.Run("copies all fields", func(t *testing.T) {
+		dbVpc := cdbm.Vpc{
+			ID:          uuid.New(),
+			Name:        "vpc-east",
+			Description: &desc,
+			Labels:      labels,
+		}
+		m := NewAPICarbideObjectMetadataFromVpc(dbVpc)
+		assert.Equal(t, "vpc-east", *m.Name)
+		assert.Equal(t, &desc, m.Description)
+		assert.Equal(t, labels, m.Labels)
+	})
+
+	t.Run("preserves nil description", func(t *testing.T) {
+		dbVpc := cdbm.Vpc{
+			ID:   uuid.New(),
+			Name: "vpc-east",
+		}
+		m := NewAPICarbideObjectMetadataFromVpc(dbVpc)
+		assert.Equal(t, "vpc-east", *m.Name)
+		assert.Nil(t, m.Description)
+	})
+
+	t.Run("preserves nil labels", func(t *testing.T) {
+		dbVpc := cdbm.Vpc{
+			ID:   uuid.New(),
+			Name: "vpc-east",
+		}
+		m := NewAPICarbideObjectMetadataFromVpc(dbVpc)
+		assert.Nil(t, m.Labels)
+	})
+}

--- a/api/pkg/api/model/nvlinklogicalpartition_test.go
+++ b/api/pkg/api/model/nvlinklogicalpartition_test.go
@@ -150,7 +150,7 @@ func TestAPINVLinkLogicalPartitionNew(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			got := NewAPINVLinkLogicalPartition(tc.dbNLP, tc.dbVpcs, tc.dbNLPInterfaces, tc.dbSds)
 			assert.Equal(t, tc.dbNLP.ID.String(), got.ID)
-			assert.Equal(t, tc.dbVpcs[0].Name, got.Vpcs[0].Name)
+			assert.Equal(t, tc.dbVpcs[0].Name, *got.Vpcs[0].Metadata.Name)
 		})
 	}
 }

--- a/api/pkg/api/model/vpc.go
+++ b/api/pkg/api/model/vpc.go
@@ -78,16 +78,12 @@ func normalizeAPIVpcRoutingProfileFromSite(routingProfile string) string {
 type APIVpcCreateRequest struct {
 	// ID is the user-specified UUID of the VPC.
 	ID *uuid.UUID `json:"id"`
-	// Name is the name of the VPC
-	Name string `json:"name"`
-	// Description is the description of the VPC
-	Description *string `json:"description"`
+	// Carbide VPC object metadata
+	Metadata APICarbideObjectMetadata `json:"metadata"`
 	// SiteID is the ID of the Site
 	SiteID string `json:"siteId"`
 	// NetworkVirtualizationType is a VPC virtualization type
 	NetworkVirtualizationType *string `json:"networkVirtualizationType"`
-	// Labels is a key value objects
-	Labels map[string]string `json:"labels"`
 	// NetworkSecurityGroupID is the ID if a desired
 	// NSG to attach to the VPC
 	NetworkSecurityGroupID *string `json:"networkSecurityGroupId"`
@@ -107,15 +103,10 @@ type APIVpcCreateRequest struct {
 
 // Validate ensure the values passed in create request are acceptable
 func (ascr APIVpcCreateRequest) Validate() error {
+	if err := ascr.Metadata.ValidateOnCreate(); err != nil {
+		return err
+	}
 	err := validation.ValidateStruct(&ascr,
-		validation.Field(&ascr.Name,
-			validation.Required.Error(validationErrorStringLength),
-			validation.By(util.ValidateNameCharacters),
-			validation.Length(2, 256).Error(validationErrorStringLength)),
-		validation.Field(&ascr.Description,
-			validation.When(ascr.Description != nil,
-				validation.Length(0, 1024).Error(validationErrorDescriptionStringLength)),
-		),
 		validation.Field(&ascr.RoutingProfile,
 			validation.When(ascr.RoutingProfile != nil,
 				validation.Length(3, 64).Error("`routingProfile` must contain at least 3 characters and a maximum of 64 characters"),
@@ -163,21 +154,13 @@ func (ascr APIVpcCreateRequest) Validate() error {
 		}
 	}
 
-	if err := util.ValidateLabels(ascr.Labels); err != nil {
-		return err
-	}
-
 	return err
 }
 
 // APIVpcUpdateRequest captures the request data for updating a new VPC
 type APIVpcUpdateRequest struct {
-	// Name is the name of the VPC
-	Name *string `json:"name"`
-	// Description is the description of the VPC
-	Description *string `json:"description"`
-	// Labels is a key value objects
-	Labels map[string]string `json:"labels"`
+	// Carbide Object metadata
+	Metadata APICarbideObjectMetadata `json:"metadata"`
 	// NetworkSecurityGroupID is the ID if a desired
 	// NSG to attach to the VPC
 	NetworkSecurityGroupID *string `json:"networkSecurityGroupId"`
@@ -187,25 +170,7 @@ type APIVpcUpdateRequest struct {
 
 // Validate ensure the values passed in update request are acceptable
 func (asur APIVpcUpdateRequest) Validate() error {
-	err := validation.ValidateStruct(&asur,
-		validation.Field(&asur.Name,
-			validation.When(asur.Name != nil, validation.Required.Error(validationErrorStringLength)),
-			validation.When(asur.Name != nil, validation.By(util.ValidateNameCharacters)),
-			validation.When(asur.Name != nil, validation.Length(2, 256).Error(validationErrorStringLength))),
-		validation.Field(&asur.Description,
-			validation.When(asur.Description != nil, validation.Length(0, 1024).Error(validationErrorDescriptionStringLength)),
-		),
-	)
-
-	if err != nil {
-		return err
-	}
-
-	if err := util.ValidateLabels(asur.Labels); err != nil {
-		return err
-	}
-
-	return err
+	return asur.Metadata.ValidateOnUpdate()
 }
 
 // APIVpcVirtualizationUpdateRequest captures the request data for updating virtualization type for a give VPC
@@ -246,10 +211,8 @@ func (avvur APIVpcVirtualizationUpdateRequest) Validate(existingVpc *cdbm.Vpc) e
 type APIVpc struct {
 	// ID is the unique UUID v4 identifier of the VPC in Forge Cloud
 	ID string `json:"id"`
-	// Name is the name of the VPC
-	Name string `json:"name"`
-	// Description is the description of the VPC
-	Description *string `json:"description"`
+	// Carbide VPC Object metadata
+	Metadata APICarbideObjectMetadata `json:"metadata"`
 	// Org is the NGC organization ID of the infrastructure provider and the org the VPC belongs to
 	Org string `json:"org"`
 	// InfrastructureProviderID is the ID of the infrastructure provider who owns the site
@@ -268,8 +231,6 @@ type APIVpc struct {
 	NetworkVirtualizationType *string `json:"networkVirtualizationType"`
 	// ControllerVpcID is the ID of the corresponding VPC in Site Controller
 	ControllerVpcID *string `json:"controllerVpcId"`
-	// Labels is VPC labels specified by user
-	Labels map[string]string `json:"labels"`
 	// NVLinkLogicalPartitionID is the ID of the NVLinkLogicalPartition
 	NVLinkLogicalPartitionID *string `json:"nvLinkLogicalPartitionId"`
 	// NVLinkLogicalPartitionSummary is the summary of the NVLinkLogicalPartition
@@ -301,13 +262,11 @@ type APIVpc struct {
 func NewAPIVpc(dbVpc cdbm.Vpc, dbsds []cdbm.StatusDetail) APIVpc {
 	apivpc := APIVpc{
 		ID:                                     dbVpc.ID.String(),
-		Name:                                   dbVpc.Name,
-		Description:                            dbVpc.Description,
+		Metadata:                               NewAPICarbideObjectMetadataFromVpc(dbVpc),
 		Org:                                    dbVpc.Org,
 		InfrastructureProviderID:               util.GetUUIDPtrToStrPtr(&dbVpc.InfrastructureProviderID),
 		TenantID:                               util.GetUUIDPtrToStrPtr(&dbVpc.TenantID),
 		SiteID:                                 util.GetUUIDPtrToStrPtr(&dbVpc.SiteID),
-		Labels:                                 dbVpc.Labels,
 		Status:                                 dbVpc.Status,
 		NetworkSecurityGroupID:                 dbVpc.NetworkSecurityGroupID,
 		NetworkSecurityGroupPropagationDetails: NewAPINetworkSecurityGroupPropagationDetails(dbVpc.NetworkSecurityGroupPropagationDetails),
@@ -382,8 +341,8 @@ type APIVpcStats struct {
 type APIVpcSummary struct {
 	// ID is the unique UUID v4 identifier of the VPC in Forge Cloud
 	ID string `json:"id"`
-	// Name of the Vpc, only lowercase characters, digits, hyphens and cannot begin/end with hyphen
-	Name string `json:"name"`
+	// Carbide VPC Object metadata
+	Metadata APICarbideObjectMetadata `json:"metadata"`
 	// ControllerVpcID is the ID of the corresponding VPC in Site Controller
 	ControllerVpcID *string `json:"controllerVpcId"`
 	// Network virtualization type is a VPC virtualization type
@@ -396,7 +355,7 @@ type APIVpcSummary struct {
 func NewAPIVpcSummary(dbVpc *cdbm.Vpc) *APIVpcSummary {
 	apiVpcSummary := APIVpcSummary{
 		ID:                        dbVpc.ID.String(),
-		Name:                      dbVpc.Name,
+		Metadata:                  NewAPICarbideObjectMetadataFromVpc(*dbVpc),
 		NetworkVirtualizationType: dbVpc.NetworkVirtualizationType,
 		Status:                    dbVpc.Status,
 	}

--- a/api/pkg/api/model/vpc_test.go
+++ b/api/pkg/api/model/vpc_test.go
@@ -209,11 +209,13 @@ func TestAPIVpcCreateRequest_Validate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			vcr := APIVpcCreateRequest{
-				Name:                      tt.fields.Name,
-				Description:               tt.fields.Description,
+				Metadata: APICarbideObjectMetadata{
+					Name:        &tt.fields.Name,
+					Description: tt.fields.Description,
+					Labels:      tt.fields.Labels,
+				},
 				SiteID:                    tt.fields.SiteID,
 				NetworkVirtualizationType: tt.fields.NetworkVirtualizationType,
-				Labels:                    tt.fields.Labels,
 				Vni:                       tt.fields.Vni,
 				RoutingProfile:            tt.fields.RoutingProfile,
 			}
@@ -301,9 +303,11 @@ func TestAPIVpcUpdateRequest_Validate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			vur := APIVpcUpdateRequest{
-				Name:        &tt.fields.Name,
-				Description: tt.fields.Description,
-				Labels:      tt.fields.Labels,
+				Metadata: APICarbideObjectMetadata{
+					Name:        &tt.fields.Name,
+					Description: tt.fields.Description,
+					Labels:      tt.fields.Labels,
+				},
 			}
 
 			if err := vur.Validate(); (err != nil) != tt.wantErr {
@@ -443,9 +447,15 @@ func TestNewAPIVpc(t *testing.T) {
 				dbsds: dbsds,
 			},
 			want: APIVpc{
-				ID:                        dbVpc.ID.String(),
-				Name:                      dbVpc.Name,
-				Description:               dbVpc.Description,
+				ID: dbVpc.ID.String(),
+				Metadata: APICarbideObjectMetadata{
+					Name:        &dbVpc.Name,
+					Description: dbVpc.Description,
+					Labels: map[string]string{
+						"zone": "1",
+						"west": "2",
+					},
+				},
 				Org:                       dbVpc.Org,
 				InfrastructureProviderID:  util.GetUUIDPtrToStrPtr(&dbVpc.InfrastructureProviderID),
 				TenantID:                  util.GetUUIDPtrToStrPtr(&dbVpc.TenantID),
@@ -456,13 +466,9 @@ func TestNewAPIVpc(t *testing.T) {
 				RequestedVni:              dbVpc.Vni,
 				Vni:                       dbVpc.ActiveVni,
 				Status:                    dbVpc.Status,
-				Labels: map[string]string{
-					"zone": "1",
-					"west": "2",
-				},
-				StatusHistory: apidbsh,
-				Created:       dbVpc.Created,
-				Updated:       dbVpc.Updated,
+				StatusHistory:             apidbsh,
+				Created:                   dbVpc.Created,
+				Updated:                   dbVpc.Updated,
 			},
 		},
 		{
@@ -476,9 +482,15 @@ func TestNewAPIVpc(t *testing.T) {
 				dbsds: dbsds,
 			},
 			want: APIVpc{
-				ID:                        dbVpc.ID.String(),
-				Name:                      dbVpc.Name,
-				Description:               dbVpc.Description,
+				ID: dbVpc.ID.String(),
+				Metadata: APICarbideObjectMetadata{
+					Name:        &dbVpc.Name,
+					Description: dbVpc.Description,
+					Labels: map[string]string{
+						"zone": "1",
+						"west": "2",
+					},
+				},
 				Org:                       dbVpc.Org,
 				InfrastructureProviderID:  util.GetUUIDPtrToStrPtr(&dbVpc.InfrastructureProviderID),
 				TenantID:                  util.GetUUIDPtrToStrPtr(&dbVpc.TenantID),
@@ -489,13 +501,9 @@ func TestNewAPIVpc(t *testing.T) {
 				RequestedVni:              dbVpc.Vni,
 				Vni:                       dbVpc.ActiveVni,
 				Status:                    dbVpc.Status,
-				Labels: map[string]string{
-					"zone": "1",
-					"west": "2",
-				},
-				StatusHistory: apidbsh,
-				Created:       dbVpc.Created,
-				Updated:       dbVpc.Updated,
+				StatusHistory:             apidbsh,
+				Created:                   dbVpc.Created,
+				Updated:                   dbVpc.Updated,
 			},
 		},
 	}
@@ -504,8 +512,8 @@ func TestNewAPIVpc(t *testing.T) {
 			got := NewAPIVpc(tt.args.dbVpc, tt.args.dbsds)
 
 			assert.Equal(t, tt.want.ID, got.ID)
-			assert.Equal(t, tt.want.Name, got.Name)
-			assert.Equal(t, tt.want.Description, got.Description)
+			assert.Equal(t, tt.want.Metadata.Name, got.Metadata.Name)
+			assert.Equal(t, tt.want.Metadata.Description, got.Metadata.Description)
 			assert.Equal(t, tt.want.Org, got.Org)
 			assert.Equal(t, *tt.want.InfrastructureProviderID, *got.InfrastructureProviderID)
 			assert.Equal(t, *tt.want.TenantID, *got.TenantID)
@@ -521,7 +529,7 @@ func TestNewAPIVpc(t *testing.T) {
 				assert.NotNil(t, got.RequestedVni)
 				assert.Equal(t, *tt.want.RequestedVni, *got.RequestedVni)
 			}
-			assert.Equal(t, len(tt.want.Labels), len(got.Labels))
+			assert.Equal(t, len(tt.want.Metadata.Labels), len(got.Metadata.Labels))
 			assert.Equal(t, tt.want.Status, got.Status)
 			assert.Equal(t, tt.want.StatusHistory, got.StatusHistory)
 			assert.Equal(t, tt.want.Created, got.Created)


### PR DESCRIPTION
## Description
Mirror carbide-api gRPC `Metadata` message on the REST side by introducing a shared `APICarbideObjectMetadata`. For now this is only used in VPC related API calls.

Clients that read or set these three fields need to migrate to to the new API.  The OpenAPI spec and generated clients will need to regenerated after this commit.


## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [X ] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [X ] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ X] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
