### PR TITLE
docs: Improve Allocation guidance, fix Machine ID format in OpenAPI spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -673,7 +673,7 @@ lint-openapi:
 # Preview OpenAPI spec in Redoc UI (Docker)
 preview-openapi:
 	@echo "Starting Redoc UI at http://127.0.0.1:8090"
-	docker run -it --rm -p 8090:80 -v ./openapi/spec.yaml:/usr/share/nginx/html/openapi.yaml -e SPEC_URL=openapi.yaml -e REDOC_OPTIONS="expand-responses=200,201" redocly/redoc:v2.5.1
+	docker run -it --rm -p 8090:80 -v ./openapi/spec.yaml:/usr/share/nginx/html/openapi.yaml -e SPEC_URL=openapi.yaml -e REDOC_OPTIONS="expand-responses=200,201 schemas-expansion-level=2" redocly/redoc:v2.5.1
 
 publish-openapi:
 	npx @redocly/cli build-docs --config=./openapi/redocly.yaml ./openapi/spec.yaml -o ./docs/index.html

--- a/openapi/redocly.yaml
+++ b/openapi/redocly.yaml
@@ -15,3 +15,4 @@
 
 openapi:
   expandResponses: "200,201"
+  schemasExpansionLevel: 2

--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -1327,7 +1327,7 @@ paths:
         Org must have an Infrastructure Provider entity. User must have authorization role with `PROVIDER_ADMIN` suffix.
 
         To successfully create a compute Allocation, there must be enough unallocated Machines associated with the Instance Type to satisfy the constraint value.
-        For network Allocation, the source Site level IP Block must have an available prefix of the size of constraint value.
+        For network Allocation, the source site-level IP Block must have an available prefix with length equal to constraint value.
       requestBody:
         content:
           application/json:

--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -1326,7 +1326,8 @@ paths:
 
         Org must have an Infrastructure Provider entity. User must have authorization role with `PROVIDER_ADMIN` suffix.
 
-        Tenant management of Allocation is not supported in MVP.
+        To successfully create a compute Allocation, there must be enough unallocated Machines associated with the Instance Type to satisfy the constraint value.
+        For network Allocation, the source Site level IP Block must have an available prefix of the size of constraint value.
       requestBody:
         content:
           application/json:
@@ -5605,6 +5606,8 @@ paths:
         Associate a Machine to an Instance Type
 
         Org must have an Infrastructure Provider entity that owns the Instance Type and the Machine. User must have authorization role with `PROVIDER_ADMIN` suffix.
+
+        The Machine's capabilities must be a superset of the Instance Type's required capabilities for the association to succeed.
       requestBody:
         content:
           application/json:
@@ -5614,9 +5617,9 @@ paths:
               example-1:
                 value:
                   machineIds:
-                    - 497f6eca-6276-4993-bfeb-53cbbbba6f08
-                    - 59c8d465-69f1-447f-80f8-1bc85627a03b
-                    - 0a44ffc3-39ba-46c6-b483-be00a1e2cc27
+                    - fm100ht4v4mce2qstjnl8970nnj3ie6ecek4mtjn27pea4kre5gsa49jg0g
+                    - fm100htrh18t1lrjg2pqagkh3sfigr9m65dejvkq168ako07sc0uibpp5q0
+                    - fm100ht68sf2m52idrpslcjkpdj5r3tb3j5o0bkfubhoglbq47u18nknfog
   '/v2/org/{org}/nico/instance/type/{instanceTypeId}/machine/{machineAssociationId}':
     parameters:
       - schema:
@@ -12862,17 +12865,18 @@ components:
         resourceTypeId:
           type: string
           format: uuid
-          description: ID of the Resource Type that the Allocation Constraint applies to. For InstanceType, this is the ID of the Instance Type. For IPBlock, this is the ID of the IP Block.
+          description: 'ID of the Resource Type that acts as the source of the Allocation. For resource type: `InstanceType`, this is the ID of the Instance Type whose associated Machines are allocated to the Tenant. For resource type `IPBlock`, this is the ID of the Site level IP Block from where a prefix is allocated to the Tenant.'
         constraintType:
           type: string
-          description: Type of the Allocation Constraint. Please note that OnDemand and Preemptible are not supported by current implementation.
+          description: 'Type of the Allocation Constraint. `Reserved` is the only constraint type supported by current implementation.'
           enum:
             - Reserved
             - OnDemand
             - Preemptible
         constraintValue:
           type: integer
-          description: Value of the Allocation Constraint. For InstanceType, this value represents number of Machines allocated for Tenant. For IPBlock, this value represents the prefix Length of the IP Block.
+          description: |-
+            Value of the Allocation Constraint. For resource type: `InstanceType`, this value represents number of Machines associated with the Instance Type that is allocated to the Tenant. For resource type `IPBlock`, this value represents the prefix length of the IP Block allocated to the Tenant.
         derivedResourceId:
           type:
             - string
@@ -17537,20 +17541,21 @@ components:
     MachineInstanceTypeCreateRequest:
       title: MachineInstanceTypeCreateRequest
       type: object
-      description: Associates one or more Machines with an Instance Type
+      description: |-
+        Associates one or more Machines with an Instance Type.
+
+        The Machine's capabilities must be a superset of the Instance Type's required capabilities for the association to succeed.
       examples:
         - machineIds:
-            - 497f6eca-6276-4993-bfeb-53cbbbba6f08
-            - 59c8d465-69f1-447f-80f8-1bc85627a03b
-            - 0a44ffc3-39ba-46c6-b483-be00a1e2cc27
+            - fm100ht4v4mce2qstjnl8970nnj3ie6ecek4mtjn27pea4kre5gsa49jg0g
+            - fm100htrh18t1lrjg2pqagkh3sfigr9m65dejvkq168ako07sc0uibpp5q0
+            - fm100ht68sf2m52idrpslcjkpdj5r3tb3j5o0bkfubhoglbq47u18nknfog
       properties:
         machineIds:
           type: array
-          format: uuid
           minItems: 1
           items:
             type: string
-            format: uuid
       required:
         - machineIds
     ExpectedMachine:

--- a/sdk/standard/api_allocation.go
+++ b/sdk/standard/api_allocation.go
@@ -62,7 +62,8 @@ Create an Allocation for the org.
 
 Org must have an Infrastructure Provider entity. User must have authorization role with `PROVIDER_ADMIN` suffix.
 
-Tenant management of Allocation is not supported in MVP.
+To successfully create a compute Allocation, there must be enough unallocated Machines associated with the Instance Type to satisfy the constraint value.
+For network Allocation, the source Site level IP Block must have an available prefix of the size of constraint value.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param org Name of the Org

--- a/sdk/standard/api_allocation.go
+++ b/sdk/standard/api_allocation.go
@@ -63,7 +63,7 @@ Create an Allocation for the org.
 Org must have an Infrastructure Provider entity. User must have authorization role with `PROVIDER_ADMIN` suffix.
 
 To successfully create a compute Allocation, there must be enough unallocated Machines associated with the Instance Type to satisfy the constraint value.
-For network Allocation, the source Site level IP Block must have an available prefix of the size of constraint value.
+For network Allocation, the source site-level IP Block must have an available prefix with length equal to constraint value.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param org Name of the Org

--- a/sdk/standard/api_instance_type.go
+++ b/sdk/standard/api_instance_type.go
@@ -198,6 +198,8 @@ CreateInstanceTypeMachineAssociation Create a Machine/Instance Type association
 
 Org must have an Infrastructure Provider entity that owns the Instance Type and the Machine. User must have authorization role with `PROVIDER_ADMIN` suffix.
 
+The Machine's capabilities must be a superset of the Instance Type's required capabilities for the association to succeed.
+
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param org Name of the Org
 	@param instanceTypeId ID of the Instance Type

--- a/sdk/standard/model_allocation_constraint.go
+++ b/sdk/standard/model_allocation_constraint.go
@@ -43,11 +43,11 @@ type AllocationConstraint struct {
 	AllocationId *string `json:"allocationId,omitempty"`
 	// Type of the Resource that the Allocation Constraint applies to
 	ResourceType *string `json:"resourceType,omitempty"`
-	// ID of the Resource Type that the Allocation Constraint applies to. For InstanceType, this is the ID of the Instance Type. For IPBlock, this is the ID of the IP Block.
+	// ID of the Resource Type that acts as the source of the Allocation. For resource type: `InstanceType`, this is the ID of the Instance Type whose associated Machines are allocated to the Tenant. For resource type `IPBlock`, this is the ID of the Site level IP Block from where a prefix is allocated to the Tenant.
 	ResourceTypeId *string `json:"resourceTypeId,omitempty"`
-	// Type of the Allocation Constraint. Please note that OnDemand and Preemptible are not supported by current implementation.
+	// Type of the Allocation Constraint. `Reserved` is the only constraint type supported by current implementation.
 	ConstraintType *string `json:"constraintType,omitempty"`
-	// Value of the Allocation Constraint. For InstanceType, this value represents number of Machines allocated for Tenant. For IPBlock, this value represents the prefix Length of the IP Block.
+	// Value of the Allocation Constraint. For resource type: `InstanceType`, this value represents number of Machines associated with the Instance Type that is allocated to the Tenant. For resource type `IPBlock`, this value represents the prefix length of the IP Block allocated to the Tenant.
 	ConstraintValue *int32 `json:"constraintValue,omitempty"`
 	// ID of the allocated Tenant IP Block when resource type is IPBlock
 	DerivedResourceId NullableString       `json:"derivedResourceId,omitempty"`

--- a/sdk/standard/model_machine_instance_type_create_request.go
+++ b/sdk/standard/model_machine_instance_type_create_request.go
@@ -36,7 +36,7 @@ import (
 // checks if the MachineInstanceTypeCreateRequest type satisfies the MappedNullable interface at compile time
 var _ MappedNullable = &MachineInstanceTypeCreateRequest{}
 
-// MachineInstanceTypeCreateRequest Associates one or more Machines with an Instance Type
+// MachineInstanceTypeCreateRequest Associates one or more Machines with an Instance Type.  The Machine's capabilities must be a superset of the Instance Type's required capabilities for the association to succeed.
 type MachineInstanceTypeCreateRequest struct {
 	MachineIds []string `json:"machineIds"`
 }


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
- Currently Machine ID specifies invalid UUID format for Machine/Instance Type object, this PR fixes that
- Allocation object and API documentation requires more clarity, this PR updates the language
- PR also modifies Redocly config to expand second level schema, making it easier to read

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Docs** - Changes in documentation or OpenAPI schema (docs:)

## Services Affected
<!-- Check one or more if appropriate -->
None

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->
Addresses: https://github.com/NVIDIA/infra-controller/issues/2099 and https://github.com/NVIDIA/infra-controller/issues/2100

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
None