### PR TITLE
ci: Remove unused promotion PAT secret

### DIFF
--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -40,8 +40,6 @@ on:
         required: true
       NVCR_PROD_TOKEN:
         required: true
-      GITTAG_PAT_TOKEN:
-        required: true
 
 jobs:
   # ============================================================================


### PR DESCRIPTION
## Description
Remove the unused GITTAG_PAT_TOKEN required secret from the promotion reusable workflow. The promotion flow only uses NVCR staging/production credentials for image and artifact promotion, so requiring this PAT blocks main promotion before any job steps run.

## Type of Change
- [ ] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [x] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
- [ ] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
Closes #491

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Manual checks:
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/promotion.yaml")'
- rg -n "GITTAG_PAT_TOKEN|GITLAB|GitLab|gitlab" .github/workflows/promotion.yaml .github/workflows/main-build.yml .github/scripts

## Additional Notes
The pinned NVIDIA/dsx-github-actions promote-image reusable workflow only requires SOURCE_USERNAME, SOURCE_PASSWORD, DEST_USERNAME, and DEST_PASSWORD. It does not consume GITTAG_PAT_TOKEN or any GitLab PAT.