### PR TITLE
chore: Move VPC update/delete proto building onto the DB model

### DIFF
--- a/api/pkg/api/handler/subnet.go
+++ b/api/pkg/api/handler/subnet.go
@@ -330,7 +330,7 @@ func (csh CreateSubnetHandler) Handle(c echo.Context) error {
 		Id:          &cwssaws.NetworkSegmentId{Value: common.GetSiteNetworkSegmentID(subnet).String()},
 		Name:        subnet.Name,
 		SubdomainId: subnetDomainID,
-		VpcId:       &cwssaws.VpcId{Value: common.GetSiteVpcID(vpc).String()},
+		VpcId:       &cwssaws.VpcId{Value: vpc.GetSiteID().String()},
 		Mtu:         subnetMTU,
 		Prefixes:    prefixes,
 	}

--- a/api/pkg/api/handler/util/common/common.go
+++ b/api/pkg/api/handler/util/common/common.go
@@ -103,14 +103,6 @@ func GetSiteInstanceID(i *cdbm.Instance) *uuid.UUID {
 	}
 }
 
-func GetSiteVpcID(v *cdbm.Vpc) *uuid.UUID {
-	if v.ControllerVpcID != nil {
-		return v.ControllerVpcID
-	} else {
-		return &v.ID
-	}
-}
-
 func GetSiteNetworkSegmentID(s *cdbm.Subnet) *uuid.UUID {
 	if s.ControllerNetworkSegmentID != nil {
 		return s.ControllerNetworkSegmentID

--- a/api/pkg/api/handler/vpc.go
+++ b/api/pkg/api/handler/vpc.go
@@ -399,7 +399,7 @@ func (cvh CreateVPCHandler) Handle(c echo.Context) error {
 		}
 
 		createVpcRequest := &cwssaws.VpcCreationRequest{
-			Id:                        &cwssaws.VpcId{Value: common.GetSiteVpcID(vpc).String()},
+			Id:                        &cwssaws.VpcId{Value: vpc.GetSiteID().String()},
 			Name:                      vpc.Name,
 			TenantOrganizationId:      tenant.Org,
 			NetworkVirtualizationType: &nwvt,
@@ -847,10 +847,7 @@ func (uvh UpdateVPCHandler) Handle(c echo.Context) error {
 			return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
 		}
 
-		updateVpcRequest := &cwssaws.VpcUpdateRequest{
-			Id:                     &cwssaws.VpcId{Value: common.GetSiteVpcID(vpc).String()},
-			NetworkSecurityGroupId: vpc.NetworkSecurityGroupID,
-		}
+		updateVpcRequest := vpc.ToUpdateRequestProto()
 
 		// Propagate the NVLink Logical Partition ID change to the site controller
 		if apiRequest.NVLinkLogicalPartitionID != nil {
@@ -866,20 +863,6 @@ func (uvh UpdateVPCHandler) Handle(c echo.Context) error {
 			TaskQueue:                queue.SiteTaskQueue,
 			WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
 		}
-
-		// Vpc metadata info
-		metadata := &cwssaws.Metadata{
-			Name:        vpc.Name,
-			Description: "",
-		}
-
-		// Include description
-		if vpc.Description != nil {
-			metadata.Description = *vpc.Description
-		}
-
-		metadata.Labels = util.ProtobufLabelsFromAPILabels(vpc.Labels)
-		updateVpcRequest.Metadata = metadata
 
 		logger.Info().Msg("triggering VPC update workflow")
 
@@ -1134,7 +1117,7 @@ func (uvvh UpdateVPCVirtualizationHandler) Handle(c echo.Context) error {
 		// VPC virtualization type can only be updated to FNN, the request validator guarantees that
 		siteVirtualizationType := cwssaws.VpcVirtualizationType_FNN
 		siteRequest := &cwssaws.VpcUpdateVirtualizationRequest{
-			Id:                        &cwssaws.VpcId{Value: common.GetSiteVpcID(vpc).String()},
+			Id:                        &cwssaws.VpcId{Value: vpc.GetSiteID().String()},
 			NetworkVirtualizationType: &siteVirtualizationType,
 		}
 
@@ -1799,9 +1782,7 @@ func (dvh DeleteVPCHandler) Handle(c echo.Context) error {
 			return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
 		}
 
-		deleteVpcRequest := &cwssaws.VpcDeletionRequest{
-			Id: &cwssaws.VpcId{Value: common.GetSiteVpcID(vpc).String()},
-		}
+		deleteVpcRequest := vpc.ToDeletionRequestProto()
 
 		workflowOptions := temporalClient.StartWorkflowOptions{
 			ID:                       "vpc-delete-" + vpc.ID.String(),

--- a/api/pkg/api/handler/vpcprefix.go
+++ b/api/pkg/api/handler/vpcprefix.go
@@ -267,7 +267,7 @@ func (csh CreateVpcPrefixHandler) Handle(c echo.Context) error {
 
 	createVpcPrefixRequest := &cwssaws.VpcPrefixCreationRequest{
 		Id:    &cwssaws.VpcPrefixId{Value: vpcPrefix.ID.String()},
-		VpcId: &cwssaws.VpcId{Value: common.GetSiteVpcID(vpc).String()},
+		VpcId: &cwssaws.VpcId{Value: vpc.GetSiteID().String()},
 		Config: &cwssaws.VpcPrefixConfig{
 			Prefix: vpcPrefix.Prefix,
 		},

--- a/db/pkg/db/model/vpc.go
+++ b/db/pkg/db/model/vpc.go
@@ -25,6 +25,7 @@ import (
 	"github.com/NVIDIA/infra-controller-rest/db/pkg/db"
 	"github.com/NVIDIA/infra-controller-rest/db/pkg/db/paginator"
 	stracer "github.com/NVIDIA/infra-controller-rest/db/pkg/tracer"
+	cwssaws "github.com/NVIDIA/infra-controller-rest/workflow-schema/schema/site-agent/workflows/v1"
 	"github.com/google/uuid"
 
 	"github.com/uptrace/bun"
@@ -113,6 +114,59 @@ type Vpc struct {
 	Deleted                                *time.Time                              `bun:"deleted,soft_delete"`
 	CreatedBy                              uuid.UUID                               `bun:"type:uuid,notnull"`
 	Vni                                    *int                                    `bun:"vni,type:integer"`
+}
+
+// GetSiteID returns the VPC ID to use when communicating with the Site:
+// the controller-supplied ControllerVpcID when present, otherwise the
+// VPC's own ID. The Site treats both as opaque identifiers.
+func (vpc *Vpc) GetSiteID() *uuid.UUID {
+	if vpc.ControllerVpcID != nil {
+		return vpc.ControllerVpcID
+	}
+	return &vpc.ID
+}
+
+// toMetadataProto builds a workflow Metadata proto from the VPC's Name,
+// Description, and Labels. Description defaults to the empty string when
+// the receiver's pointer is nil; this matches the existing handler
+// behaviour.
+func (vpc *Vpc) toMetadataProto() *cwssaws.Metadata {
+	md := &cwssaws.Metadata{
+		Name:        vpc.Name,
+		Description: "",
+	}
+	if vpc.Description != nil {
+		md.Description = *vpc.Description
+	}
+	if vpc.Labels != nil {
+		labels := make([]*cwssaws.Label, 0, len(vpc.Labels))
+		for k, v := range vpc.Labels {
+			labels = append(labels, &cwssaws.Label{Key: k, Value: &v})
+		}
+		md.Labels = labels
+	}
+	return md
+}
+
+// ToDeletionRequestProto builds the workflow request that asks a Site to
+// delete this VPC.
+func (vpc *Vpc) ToDeletionRequestProto() *cwssaws.VpcDeletionRequest {
+	return &cwssaws.VpcDeletionRequest{
+		Id: &cwssaws.VpcId{Value: vpc.GetSiteID().String()},
+	}
+}
+
+// ToUpdateRequestProto builds the workflow request that pushes this
+// VPC's name, description, labels, and current
+// `NetworkSecurityGroupID` association to a Site. The handler may
+// further set `DefaultNvlinkLogicalPartitionId` after calling this when
+// the API request changes that field.
+func (vpc *Vpc) ToUpdateRequestProto() *cwssaws.VpcUpdateRequest {
+	return &cwssaws.VpcUpdateRequest{
+		Id:                     &cwssaws.VpcId{Value: vpc.GetSiteID().String()},
+		NetworkSecurityGroupId: vpc.NetworkSecurityGroupID,
+		Metadata:               vpc.toMetadataProto(),
+	}
 }
 
 // VpcCreateInput input parameters for Create method

--- a/db/pkg/db/model/vpc_test.go
+++ b/db/pkg/db/model/vpc_test.go
@@ -1488,3 +1488,85 @@ func TestVpcSQLDAO_ClearFromParams(t *testing.T) {
 		})
 	}
 }
+
+func TestVpc_GetSiteID(t *testing.T) {
+	id := uuid.New()
+	ctrlID := uuid.New()
+
+	t.Run("falls back to ID when ControllerVpcID is nil", func(t *testing.T) {
+		v := &Vpc{ID: id}
+		got := v.GetSiteID()
+		require.NotNil(t, got)
+		assert.Equal(t, id, *got)
+	})
+
+	t.Run("uses ControllerVpcID when set", func(t *testing.T) {
+		v := &Vpc{ID: id, ControllerVpcID: &ctrlID}
+		got := v.GetSiteID()
+		require.NotNil(t, got)
+		assert.Equal(t, ctrlID, *got)
+	})
+}
+
+func TestVpc_ToDeletionRequestProto(t *testing.T) {
+	id := uuid.New()
+	v := &Vpc{ID: id}
+	req := v.ToDeletionRequestProto()
+	require.NotNil(t, req)
+	require.NotNil(t, req.Id)
+	assert.Equal(t, id.String(), req.Id.Value)
+}
+
+func TestVpc_ToUpdateRequestProto(t *testing.T) {
+	id := uuid.New()
+	desc := "primary"
+	nsg := "nsg-1"
+
+	t.Run("sets id, metadata, and NSG when present", func(t *testing.T) {
+		v := &Vpc{
+			ID:                     id,
+			Name:                   "vpc-a",
+			Description:            &desc,
+			NetworkSecurityGroupID: &nsg,
+			Labels:                 map[string]string{"env": "prod"},
+		}
+		req := v.ToUpdateRequestProto()
+		require.NotNil(t, req)
+		require.NotNil(t, req.Id)
+		assert.Equal(t, id.String(), req.Id.Value)
+		require.NotNil(t, req.NetworkSecurityGroupId)
+		assert.Equal(t, "nsg-1", *req.NetworkSecurityGroupId)
+		require.NotNil(t, req.Metadata)
+		assert.Equal(t, "vpc-a", req.Metadata.Name)
+		assert.Equal(t, "primary", req.Metadata.Description)
+		require.Len(t, req.Metadata.Labels, 1)
+		assert.Equal(t, "env", req.Metadata.Labels[0].Key)
+		require.NotNil(t, req.Metadata.Labels[0].Value)
+		assert.Equal(t, "prod", *req.Metadata.Labels[0].Value)
+	})
+
+	t.Run("nil description and labels yield zero-value metadata", func(t *testing.T) {
+		v := &Vpc{ID: id, Name: "vpc-a"}
+		req := v.ToUpdateRequestProto()
+		require.NotNil(t, req.Metadata)
+		assert.Equal(t, "", req.Metadata.Description)
+		assert.Nil(t, req.Metadata.Labels)
+		assert.Nil(t, req.NetworkSecurityGroupId)
+	})
+
+	t.Run("uses ControllerVpcID for the request Id when set", func(t *testing.T) {
+		ctrlID := uuid.New()
+		v := &Vpc{ID: id, ControllerVpcID: &ctrlID, Name: "vpc-a"}
+		req := v.ToUpdateRequestProto()
+		require.NotNil(t, req.Id)
+		assert.Equal(t, ctrlID.String(), req.Id.Value)
+	})
+
+	t.Run("explicit NSG clear preserves empty string (distinct from nil)", func(t *testing.T) {
+		empty := ""
+		v := &Vpc{ID: id, Name: "vpc-a", NetworkSecurityGroupID: &empty}
+		req := v.ToUpdateRequestProto()
+		require.NotNil(t, req.NetworkSecurityGroupId)
+		assert.Equal(t, "", *req.NetworkSecurityGroupId)
+	})
+}

--- a/workflow/pkg/activity/vpc/vpc.go
+++ b/workflow/pkg/activity/vpc/vpc.go
@@ -414,7 +414,8 @@ func (mv ManageVpc) UpdateVpcMetadata(ctx context.Context, siteID uuid.UUID, tc 
 		TaskQueue: queue.SiteTaskQueue,
 	}
 
-	// Prepare the config update request workflow object
+	// Prepare the config update request workflow object. NetworkSecurityGroupId is
+	// intentionally omitted: this activity only syncs metadata fields.
 	updateVpcRequest := &cwssaws.VpcUpdateRequest{
 		Id: &cwssaws.VpcId{Value: vpc.ID.String()},
 		Metadata: &cwssaws.Metadata{


### PR DESCRIPTION
## Description

Adds receiver methods on `cdbm.Vpc` so handlers don't have to build update/delete workflow protos inline:

- `(*Vpc).ToUpdateRequestProto()` and `ToDeletionRequestProto()` -- used by the Update and Delete handlers respectively (we do something similar for `Tenant`).
- `(*Vpc).GetSiteID()`, which replaces the `common.GetSiteVpcID` helper.

Tests cover ID-vs-ControllerVpcID fallback, nil description, nil labels, and nil NSG.

This is part of a wider effort I'm going to slowly be churning on for standardizing `ToProto` / `FromProto` across the board (which started with https://github.com/NVIDIA/infra-controller-rest/pull/500, where I'm also dropping an `AGENTS.md` which mentions something similar).

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [x] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **API** - API models or endpoints updated
- [x] **Workflow** - Workflow service updated
- [x] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
