### PR TITLE
fix: Clear sticky error in DynTLSCfg.refresh() after success

### DIFF
--- a/common/pkg/tls/dynamic.go
+++ b/common/pkg/tls/dynamic.go
@@ -206,4 +206,11 @@ func (d *DynTLSCfg) refresh() {
 		d.cachedCert = &cert
 		d.cacheUpdated = true
 	}
+
+	// A complete refresh succeeded — clear any sticky error from a prior
+	// failed attempt. Without this, a single transient mismatch (e.g. when
+	// cert and key files are updated non-atomically by a k8s secret remount)
+	// would poison the config until the process restarted, even after files
+	// settle into a consistent state.
+	d.err = nil
 }

--- a/common/pkg/tls/dynamic_test.go
+++ b/common/pkg/tls/dynamic_test.go
@@ -20,6 +20,7 @@ package tls
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -249,4 +250,39 @@ func TestDynTLSCfg(t *testing.T) {
 	caCertPool = x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM([]byte(test2Cert))
 	assert.True(t, caCertPool.Equal(sCfg.RootCAs))
+}
+
+// TestDynTLSCfg_RefreshClearsStickyError verifies that a successful refresh
+// clears any error stored from a prior failed refresh. Without this, a
+// transient cert/key mismatch (e.g. when k8s remounts a Secret and writes
+// the two files non-atomically) would poison the tls config until the
+// process restarted, even after the files settled into a consistent state.
+func TestDynTLSCfg_RefreshClearsStickyError(t *testing.T) {
+	dir, err := os.MkdirTemp("", "certs-sticky")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	key := filepath.Join(dir, "t.key")
+	require.NoError(t, os.WriteFile(key, []byte(test1Key), 0600))
+	cert := filepath.Join(dir, "t.pem")
+	require.NoError(t, os.WriteFile(cert, []byte(test1Cert), 0644))
+	ca := filepath.Join(dir, "ca.pem")
+	require.NoError(t, os.WriteFile(ca, []byte(testCaCert), 0644))
+
+	d, err := NewDynTLSCfg(key, cert, ca)
+	require.NoError(t, err)
+	defer d.Close()
+
+	// Simulate a prior failed refresh leaving a sticky error behind
+	// (the bug this test guards against).
+	d.Lock()
+	d.err = errors.New("simulated prior refresh failure")
+	d.Unlock()
+
+	d.refresh()
+
+	d.Lock()
+	gotErr := d.err
+	d.Unlock()
+	assert.NoError(t, gotErr, "refresh() should clear sticky error from prior failed attempt")
 }


### PR DESCRIPTION


## Description
`common/pkg/tls.DynTLSCfg.refresh()`  set `d.err` whenever loading the CA or the cert/key pair failed, but never cleared it on a subsequent successful reload. A single transient `tls: private key does not match public key` — easy to hit when k8s remounts a Secret and writes the cert and key files non-atomically — would therefore poison `GetClientCertificate` / `GetConfigForClient` until the process restarted, even after the files settled into a consistent state.

Clear `d.err` only after a complete refresh succeeds (both CA and cert/key paths). Failures still surface immediately with a non-nil `d.err` as before.

Add a deterministic regression test that pre-seeds `d.err` and asserts `refresh()` clears it. This also stabilises the existing `TestDynTLSCfg` which had been flaking in CI for the same reason: when its 30ms-tick poller raced its multi-file `WriteFile` updates, an interim mismatch got recorded in `d.err` and was never cleared by the next successful tick before the test's `GetConfigForClient` assertion ran.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [x] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [ ] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
