### PR TITLE
fix: VPC Peering create check auth before duplicate

### DIFF
--- a/api/pkg/api/handler/vpcpeering.go
+++ b/api/pkg/api/handler/vpcpeering.go
@@ -167,22 +167,6 @@ func (cvph CreateVpcPeeringHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "Both VPCs must be in Ready state to proceed with peering", nil)
 	}
 
-	// Check if peering already exists
-	vpcPeeringDAO := cdbm.NewVpcPeeringDAO(cvph.dbSession)
-	existingPeerings, _, err := vpcPeeringDAO.GetAll(ctx, nil, cdbm.VpcPeeringFilterInput{
-		VpcIDs: []uuid.UUID{vpc1ID},
-	}, cdbp.PageInput{}, nil)
-	if err != nil {
-		logger.Error().Err(err).Msg("error checking for existing VPC Peering")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to check for existing VPC Peering, DB error", nil)
-	}
-	for _, peering := range existingPeerings {
-		// One of the VPC IDs must match the VPC ID, so we only need to check if either one equals the peer VPC ID
-		if peering.Vpc1ID == vpc2ID || peering.Vpc2ID == vpc2ID {
-			return cutil.NewAPIErrorResponse(c, http.StatusConflict, "VPC Peering already exists between VPCs specified in request data", nil)
-		}
-	}
-
 	// Determine if the two VPCs belong to different tenants
 	isMultiTenant := vpc1.TenantID != vpc2.TenantID
 
@@ -263,6 +247,22 @@ func (cvph CreateVpcPeeringHandler) Handle(c echo.Context) error {
 	if !providerAuthorized && !tenantAuthorized {
 		logger.Warn().Msg("User does not have access to create the VPC Peering")
 		return cutil.NewAPIErrorResponse(c, http.StatusForbidden, "User does not have access to create the VPC Peering", nil)
+	}
+
+	// Check if peering already exists
+	vpcPeeringDAO := cdbm.NewVpcPeeringDAO(cvph.dbSession)
+	existingPeerings, _, err := vpcPeeringDAO.GetAll(ctx, nil, cdbm.VpcPeeringFilterInput{
+		VpcIDs: []uuid.UUID{vpc1ID},
+	}, cdbp.PageInput{}, nil)
+	if err != nil {
+		logger.Error().Err(err).Msg("error checking for existing VPC Peering")
+		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to check for existing VPC Peering, DB error", nil)
+	}
+	for _, peering := range existingPeerings {
+		// One of the VPC IDs must match the VPC ID, so we only need to check if either one equals the peer VPC ID.
+		if peering.Vpc1ID == vpc2ID || peering.Vpc2ID == vpc2ID {
+			return cutil.NewAPIErrorResponse(c, http.StatusConflict, "VPC Peering already exists between VPCs specified in request data", nil)
+		}
 	}
 
 	var infrastructureProviderID *uuid.UUID


### PR DESCRIPTION
## Description
When tenants try to create a multi-tenant peering that's already peered, they get a 409 with a mesage indicating a duplicate peering instead of a 403 Forbidden. This leaks the existence of multi-tenant peerings to the relevant tenants but also potentially to third-party tenants.

This PR puts authorization checks before duplicate check inside VPC Peering creation handler to prevent the above issue. 

Related: https://nvbugspro.nvidia.com/bug/6151160

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [x] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)