### PR TITLE
fix: Preserve newline before apiVersion in nico-rest-api configmap

### DIFF
--- a/helm/charts/nico-rest/Chart.lock
+++ b/helm/charts/nico-rest/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 0.1.0
 - name: nico-rest-api
   repository: ""
-  version: 0.1.0
+  version: 0.1.1
 - name: nico-rest-workflow
   repository: ""
   version: 0.1.0
@@ -17,5 +17,5 @@ dependencies:
 - name: nico-rest-db
   repository: ""
   version: 0.1.0
-digest: sha256:07a8f06cb894085e3a01b050c1496bb976a0a2f3088c2180e9134342eb33a649
-generated: "2026-05-02T01:26:03.810025-07:00"
+digest: sha256:7cec75245925550764a6da00ce3cb01a9d065b7edffc76c07736d4c05aca860e
+generated: "2026-05-13T10:07:24.468333-07:00"

--- a/helm/charts/nico-rest/Chart.yaml
+++ b/helm/charts/nico-rest/Chart.yaml
@@ -17,7 +17,7 @@ apiVersion: v2
 name: nico-rest
 description: Umbrella chart for the NICo REST API platform
 type: application
-version: 0.1.7
+version: 0.1.8
 appVersion: "1.4.0"
 keywords:
   - nico

--- a/helm/charts/nico-rest/Chart.yaml
+++ b/helm/charts/nico-rest/Chart.yaml
@@ -33,7 +33,7 @@ dependencies:
     version: "0.1.0"
     condition: nico-rest-cert-manager.enabled
   - name: nico-rest-api
-    version: "0.1.0"
+    version: "0.1.1"
     condition: nico-rest-api.enabled
   - name: nico-rest-workflow
     version: "0.1.0"

--- a/helm/charts/nico-rest/charts/nico-rest-api/Chart.yaml
+++ b/helm/charts/nico-rest/charts/nico-rest-api/Chart.yaml
@@ -17,7 +17,7 @@ apiVersion: v2
 name: nico-rest-api
 description: Helm chart for the NICo REST API server
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "latest"
 keywords:
   - nico

--- a/helm/charts/nico-rest/charts/nico-rest-api/templates/configmap.yaml
+++ b/helm/charts/nico-rest/charts/nico-rest-api/templates/configmap.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- include "nico-rest-api.validateAuth" . -}}
+{{- include "nico-rest-api.validateAuth" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
## Description

The `validateAuth` include at the top of `nico-rest-api/templates/configmap.yaml` uses `{{- ... -}}`, which strips whitespace on both sides of the action. When `validateAuth` succeeds (the common case — auth is configured correctly), the helper produces empty output, and the trailing `-}}` strips the newline that should separate the action from `apiVersion: v1`. The result is that `apiVersion: v1` gets glued onto the end of the SPDX header's last comment line, producing invalid YAML that breaks `helm install`.

### Reproduction

```bash
helm template test helm/charts/nico-rest/charts/nico-rest-api \
  -s templates/configmap.yaml \
  --set global.image.repository=foo --set global.image.tag=v1 --set global.imagePullSecrets= \
  --set config.keycloak.enabled=true \
  --set config.keycloak.baseURL=https://kc.example.com \
  --set config.keycloak.realm=nico \
  --set config.keycloak.clientID=nico \
  --set config.db.user=nico --set config.db.password=changeme \
  --set config.db.host=localhost --set config.db.port=5432 --set config.db.name=nico \
  --set secrets.dbCreds=false
```

### Before (broken)

```yaml
# See the License for the specific language governing permissions and
# limitations under the License.apiVersion: v1
kind: ConfigMap
```

### After (this PR)

```yaml
# See the License for the specific language governing permissions and
# limitations under the License.

apiVersion: v1
kind: ConfigMap
```

### Root cause

`{{- ... -}}` strips all preceding whitespace (including the blank line above the action and the trailing newline of the previous comment) and all trailing whitespace (the newline before `apiVersion`). When the include's success-path output is `""`, the comment line and `apiVersion: v1` end up directly concatenated. Replacing `-}}` with `}}` preserves the trailing newline.

## Type of Change

- [ ] **Feature** - New feature or functionality (feat:)
- [x] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected

- [x] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

(Helm chart for the API service.)

## Related Issues (Optional)

The same one-line change is bundled inside #507 ("Feat/rename ncx to nico") alongside unrelated rename work. Per [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) (*"Keep pull requests focused on a single change"*), this PR extracts the configmap fix so it can land independently.

cc @shayan1995 — your #507 already includes this exact fix; opening this narrower PR so it can land on its own without waiting for the rest of the rename work. Happy to close in favor of #507 if you'd prefer it stay bundled there.

## Breaking Changes

- [ ] This PR contains breaking changes

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Verified with `helm template` before/after on a clean checkout (see Reproduction section). Existing chart unit tests not affected.

## Additional Notes

The same whitespace-trim pattern (`{{- include ... -}}` at the top of a file with text above) does not currently appear in any other template in `helm/charts/nico-rest/`, so this is an isolated occurrence.

> _Drafted with Claude assistance; manually verified by rendering the chart before/after with `helm template` and confirming `apiVersion: v1` lands on its own line._

