### PR TITLE
fix: Persist firmware updates atomically in QueueUpdate

### DIFF
--- a/nvswitch-manager/pkg/credentials/inmemory_test.go
+++ b/nvswitch-manager/pkg/credentials/inmemory_test.go
@@ -331,7 +331,7 @@ func TestInMemoryBMCDelete(t *testing.T) {
 
 func TestInMemoryKeys(t *testing.T) {
 	testCases := map[string]struct {
-		putPairs    [][2]interface{} // [mac string, *credential.Credential]
+		putPairs    [][2]any // [mac string, *credential.Credential]
 		expectCount int
 		expectSet   map[string]bool
 	}{
@@ -341,14 +341,14 @@ func TestInMemoryKeys(t *testing.T) {
 			expectSet:   map[string]bool{},
 		},
 		"one entry returns that MAC": {
-			putPairs: [][2]interface{}{
+			putPairs: [][2]any{
 				{"00:11:22:33:44:55", newCredential("admin", "secret")},
 			},
 			expectCount: 1,
 			expectSet:   map[string]bool{"00:11:22:33:44:55": true},
 		},
 		"multiple entries return all MACs": {
-			putPairs: [][2]interface{}{
+			putPairs: [][2]any{
 				{"00:11:22:33:44:55", newCredential("admin", "a")},
 				{"66:77:88:99:00:11", newCredential("root", "r")},
 				{"aa:bb:cc:dd:ee:ff", newCredential("user", "u")},

--- a/nvswitch-manager/pkg/credentials/vault.go
+++ b/nvswitch-manager/pkg/credentials/vault.go
@@ -157,7 +157,7 @@ func (m *VaultCredentialManager) getNVOSCredentialKey(mac net.HardwareAddr) stri
 	return fmt.Sprintf("%s/%s/%s", nvosCredentialPath, strings.ToUpper(mac.String()), nvosCredentialSuffix)
 }
 
-func (m *VaultCredentialManager) get(ctx context.Context, key string) (*credential.Credential, error) {
+func (m *VaultCredentialManager) get(_ context.Context, key string) (*credential.Credential, error) {
 	secret, err := m.client.Logical().Read(key)
 	if err != nil {
 		return nil, fmt.Errorf("vault read at %q: %w", key, err)
@@ -166,7 +166,7 @@ func (m *VaultCredentialManager) get(ctx context.Context, key string) (*credenti
 		return nil, fmt.Errorf("vault path %q: %w", key, errCredentialNotFound)
 	}
 
-	credData, ok := secret.Data["data"].(map[string]interface{})
+	credData, ok := secret.Data["data"].(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("unexpected secret data format at vault path %q", key)
 	}
@@ -183,7 +183,7 @@ func (m *VaultCredentialManager) get(ctx context.Context, key string) (*credenti
 	return cred, nil
 }
 
-func (m *VaultCredentialManager) put(ctx context.Context, key string, cred *credential.Credential) error {
+func (m *VaultCredentialManager) put(_ context.Context, key string, cred *credential.Credential) error {
 	if cred == nil || !cred.IsValid() {
 		return fmt.Errorf("valid credential not specified to Vault Manager")
 	}
@@ -196,25 +196,25 @@ func (m *VaultCredentialManager) put(ctx context.Context, key string, cred *cred
 	return err
 }
 
-func (m *VaultCredentialManager) delete(ctx context.Context, key string) error {
+func (m *VaultCredentialManager) delete(_ context.Context, key string) error {
 	_, err := m.client.Logical().Delete(key)
 	return err
 }
 
-func credentialToMap(cred *credential.Credential) map[string]interface{} {
+func credentialToMap(cred *credential.Credential) map[string]any {
 	if cred == nil {
 		return nil
 	}
-	return map[string]interface{}{
-		"UsernamePassword": map[string]interface{}{
+	return map[string]any{
+		"UsernamePassword": map[string]any{
 			"username": cred.User,
 			"password": cred.Password.Value,
 		},
 	}
 }
 
-func credentialFromMap(data map[string]interface{}) (*credential.Credential, error) {
-	nested, ok := data["UsernamePassword"].(map[string]interface{})
+func credentialFromMap(data map[string]any) (*credential.Credential, error) {
+	nested, ok := data["UsernamePassword"].(map[string]any)
 	if !ok {
 		return nil, errors.New("missing or invalid UsernamePassword field")
 	}
@@ -320,7 +320,7 @@ func (m *VaultCredentialManager) Keys(ctx context.Context) ([]net.HardwareAddr, 
 		return nil, errors.New("no credentials found")
 	}
 
-	keys, ok := secret.Data["keys"].([]interface{})
+	keys, ok := secret.Data["keys"].([]any)
 	if !ok {
 		return nil, errors.New("unexpected data format")
 	}

--- a/nvswitch-manager/pkg/firmwaremanager/manager.go
+++ b/nvswitch-manager/pkg/firmwaremanager/manager.go
@@ -193,7 +193,11 @@ func (m *FirmwareManager) QueueUpdate(
 
 	for i, name := range componentNames {
 		component := nvswitch.Component(strings.ToUpper(name))
+
 		compDef := pkg.GetComponent(name)
+		if compDef == nil {
+			return nil, fmt.Errorf("component definition is `nil` for %s", name)
+		}
 
 		strategy := Strategy(compDef.Strategy)
 		if !strategy.IsValid() {
@@ -216,16 +220,28 @@ func (m *FirmwareManager) QueueUpdate(
 			update.VersionFrom = currentVersion
 		}
 
-		// Save to database
-		if err := m.store.Save(ctx, update); err != nil {
-			return nil, fmt.Errorf("failed to queue update for %s: %w", component, err)
-		}
-
-		log.Infof("Queued firmware update: id=%s, switch=%s, component=%s, strategy=%s, version=%s->%s, seq=%d",
-			update.ID, switchUUID, component, strategy, update.VersionFrom, update.VersionTo, update.SequenceOrder)
-
+		// Append to update list. This is to avoid partial writes to the store.
 		updates = append(updates, update)
 		prevID = &update.ID
+	}
+
+	// Save to database.
+	//
+	// NOTE: `SaveAll` uses a transaction which removes the risks of partial changes
+	// in the store if error happens.
+	if err := m.store.SaveAll(ctx, updates); err != nil {
+		compStrs := make([]string, len(updates))
+		for i, update := range updates {
+			compStrs[i] = string(update.Component)
+		}
+
+		return nil, fmt.Errorf("failed to queue updates for %s: %w", strings.Join(compStrs, ", "), err)
+	}
+
+	// Logging after all updates are successfully stored.
+	for _, update := range updates {
+		log.Infof("Queued firmware update: id=%s, switch=%s, component=%s, strategy=%s, version=%s->%s, seq=%d",
+			update.ID, switchUUID, update.Component, update.Strategy, update.VersionFrom, update.VersionTo, update.SequenceOrder)
 	}
 
 	return updates, nil

--- a/nvswitch-manager/pkg/firmwaremanager/store.go
+++ b/nvswitch-manager/pkg/firmwaremanager/store.go
@@ -37,6 +37,9 @@ type UpdateStore interface {
 	// Save persists a firmware update (insert or update).
 	Save(ctx context.Context, update *FirmwareUpdate) error
 
+	// SaveAll persists all firmware updates (insert or update) in a single transaction.
+	SaveAll(ctx context.Context, updates []*FirmwareUpdate) error
+
 	// Get retrieves a firmware update by ID.
 	Get(ctx context.Context, id uuid.UUID) (*FirmwareUpdate, error)
 

--- a/nvswitch-manager/pkg/firmwaremanager/store.go
+++ b/nvswitch-manager/pkg/firmwaremanager/store.go
@@ -38,6 +38,12 @@ type UpdateStore interface {
 	Save(ctx context.Context, update *FirmwareUpdate) error
 
 	// SaveAll persists all firmware updates (insert or update) in a single transaction.
+	// If any insert fails the entire batch is rolled back.
+	//
+	// All entries in updates must be non-nil. Nil validation is the caller's
+	// responsibility — this is an internal interface and nil entries indicate a
+	// programming error, not a runtime condition. Silently skipping or partially
+	// saving nil entries would mask bugs rather than surface them.
 	SaveAll(ctx context.Context, updates []*FirmwareUpdate) error
 
 	// Get retrieves a firmware update by ID.

--- a/nvswitch-manager/pkg/firmwaremanager/store_inmemory.go
+++ b/nvswitch-manager/pkg/firmwaremanager/store_inmemory.go
@@ -60,6 +60,7 @@ func (s *InMemoryUpdateStore) Save(ctx context.Context, update *FirmwareUpdate) 
 }
 
 // SaveAll persists all firmware updates (insert or update) in a single transaction.
+// If any insert fails the entire batch is rolled back.
 func (s *InMemoryUpdateStore) SaveAll(ctx context.Context, updates []*FirmwareUpdate) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/nvswitch-manager/pkg/firmwaremanager/store_inmemory.go
+++ b/nvswitch-manager/pkg/firmwaremanager/store_inmemory.go
@@ -59,6 +59,21 @@ func (s *InMemoryUpdateStore) Save(ctx context.Context, update *FirmwareUpdate) 
 	return nil
 }
 
+// SaveAll persists all firmware updates (insert or update) in a single transaction.
+func (s *InMemoryUpdateStore) SaveAll(ctx context.Context, updates []*FirmwareUpdate) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Deep copy to avoid external mutations
+	for _, update := range updates {
+		stored := *update
+		stored.UpdatedAt = time.Now()
+		s.updates[update.ID] = &stored
+	}
+
+	return nil
+}
+
 // Get retrieves a firmware update by ID.
 func (s *InMemoryUpdateStore) Get(ctx context.Context, id uuid.UUID) (*FirmwareUpdate, error) {
 	s.mu.RLock()

--- a/nvswitch-manager/pkg/firmwaremanager/store_inmemory_test.go
+++ b/nvswitch-manager/pkg/firmwaremanager/store_inmemory_test.go
@@ -1,0 +1,382 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package firmwaremanager_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/infra-controller-rest/nvswitch-manager/pkg/firmwaremanager"
+	"github.com/NVIDIA/infra-controller-rest/nvswitch-manager/pkg/objects/nvswitch"
+)
+
+func makeUpdate(switchUUID uuid.UUID, component nvswitch.Component) *firmwaremanager.FirmwareUpdate {
+	return firmwaremanager.NewFirmwareUpdate(switchUUID, component, "1.0.0", firmwaremanager.StrategyRedfish, "1.0.1")
+}
+
+func TestInMemory_SaveAll_Empty(t *testing.T) {
+	store := firmwaremanager.NewInMemoryUpdateStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.SaveAll(ctx, nil))
+	require.NoError(t, store.SaveAll(ctx, []*firmwaremanager.FirmwareUpdate{}))
+}
+
+func TestInMemory_SaveAll_PersistsAll(t *testing.T) {
+	store := firmwaremanager.NewInMemoryUpdateStore()
+	ctx := context.Background()
+	switchUUID := uuid.New()
+
+	update1 := makeUpdate(switchUUID, nvswitch.BMC)
+	update2 := makeUpdate(switchUUID, nvswitch.BIOS)
+
+	require.NoError(t, store.SaveAll(ctx, []*firmwaremanager.FirmwareUpdate{update1, update2}))
+
+	_, err := store.Get(ctx, update1.ID)
+	require.NoError(t, err)
+	_, err = store.Get(ctx, update2.ID)
+	require.NoError(t, err)
+}
+
+func TestInMemory_SaveAll_Upsert(t *testing.T) {
+	store := firmwaremanager.NewInMemoryUpdateStore()
+	ctx := context.Background()
+	update := makeUpdate(uuid.New(), nvswitch.BMC)
+
+	require.NoError(t, store.SaveAll(ctx, []*firmwaremanager.FirmwareUpdate{update}))
+
+	update.SetState(firmwaremanager.StateCompleted)
+	require.NoError(t, store.SaveAll(ctx, []*firmwaremanager.FirmwareUpdate{update}))
+
+	got, err := store.Get(ctx, update.ID)
+	require.NoError(t, err)
+	assert.Equal(t, firmwaremanager.StateCompleted, got.State)
+}
+
+func TestInMemory_GetPendingUpdates(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("queued_no_predecessor_returned", func(t *testing.T) {
+		store := firmwaremanager.NewInMemoryUpdateStore()
+		update := makeUpdate(uuid.New(), nvswitch.BMC)
+		require.NoError(t, store.Save(ctx, update))
+
+		pending, err := store.GetPendingUpdates(ctx, 10)
+		require.NoError(t, err)
+		require.Len(t, pending, 1)
+		assert.Equal(t, update.ID, pending[0].ID)
+	})
+
+	t.Run("queued_after_pred_finishes", func(t *testing.T) {
+		store := firmwaremanager.NewInMemoryUpdateStore()
+		switchUUID := uuid.New()
+
+		pred := makeUpdate(switchUUID, nvswitch.BMC)
+		pred.SetState(firmwaremanager.StateCompleted)
+		require.NoError(t, store.Save(ctx, pred))
+
+		next := makeUpdate(switchUUID, nvswitch.BIOS)
+		next.WithSequencing(nil, 2, &pred.ID)
+		require.NoError(t, store.Save(ctx, next))
+
+		pending, err := store.GetPendingUpdates(ctx, 10)
+		require.NoError(t, err)
+		ids := make([]uuid.UUID, len(pending))
+		for i, p := range pending {
+			ids[i] = p.ID
+		}
+		assert.Contains(t, ids, next.ID)
+	})
+
+	t.Run("queued_while_pred_in_progress", func(t *testing.T) {
+		store := firmwaremanager.NewInMemoryUpdateStore()
+		switchUUID := uuid.New()
+
+		pred := makeUpdate(switchUUID, nvswitch.BMC) // still QUEUED
+		require.NoError(t, store.Save(ctx, pred))
+
+		next := makeUpdate(switchUUID, nvswitch.BIOS)
+		next.WithSequencing(nil, 2, &pred.ID)
+		require.NoError(t, store.Save(ctx, next))
+
+		pending, err := store.GetPendingUpdates(ctx, 10)
+		require.NoError(t, err)
+		require.Len(t, pending, 1)
+		assert.Equal(t, pred.ID, pending[0].ID)
+	})
+
+	t.Run("active_update_returned", func(t *testing.T) {
+		store := firmwaremanager.NewInMemoryUpdateStore()
+		update := makeUpdate(uuid.New(), nvswitch.BMC)
+		update.SetState(firmwaremanager.StateInstall)
+		require.NoError(t, store.Save(ctx, update))
+
+		pending, err := store.GetPendingUpdates(ctx, 10)
+		require.NoError(t, err)
+		require.Len(t, pending, 1)
+		assert.Equal(t, update.ID, pending[0].ID)
+	})
+
+	t.Run("terminal_update_not_returned", func(t *testing.T) {
+		store := firmwaremanager.NewInMemoryUpdateStore()
+		for _, state := range []firmwaremanager.UpdateState{
+			firmwaremanager.StateCompleted,
+			firmwaremanager.StateFailed,
+			firmwaremanager.StateCancelled,
+		} {
+			u := makeUpdate(uuid.New(), nvswitch.BMC)
+			u.SetState(state)
+			require.NoError(t, store.Save(ctx, u))
+		}
+
+		pending, err := store.GetPendingUpdates(ctx, 10)
+		require.NoError(t, err)
+		assert.Empty(t, pending)
+	})
+
+	t.Run("respects_limit", func(t *testing.T) {
+		store := firmwaremanager.NewInMemoryUpdateStore()
+		switchUUID := uuid.New()
+		for _, comp := range []nvswitch.Component{nvswitch.BMC, nvswitch.BIOS, nvswitch.CPLD} {
+			require.NoError(t, store.Save(ctx, makeUpdate(switchUUID, comp)))
+		}
+
+		pending, err := store.GetPendingUpdates(ctx, 2)
+		require.NoError(t, err)
+		assert.Len(t, pending, 2)
+	})
+}
+
+func TestInMemory_GetLatestBundleBySwitch(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns_only_latest_bundle_not_older_ones", func(t *testing.T) {
+		store := firmwaremanager.NewInMemoryUpdateStore()
+		switchUUID := uuid.New()
+
+		oldBundleID := uuid.New()
+		old1 := makeUpdate(switchUUID, nvswitch.BMC)
+		old1.BundleUpdateID = &oldBundleID
+		old1.CreatedAt = time.Now().Add(-time.Second)
+		require.NoError(t, store.Save(ctx, old1))
+
+		newBundleID := uuid.New()
+		new1 := makeUpdate(switchUUID, nvswitch.BMC)
+		new2 := makeUpdate(switchUUID, nvswitch.BIOS)
+		new1.WithSequencing(&newBundleID, 1, nil)
+		new2.WithSequencing(&newBundleID, 2, &new1.ID)
+		require.NoError(t, store.SaveAll(ctx, []*firmwaremanager.FirmwareUpdate{new1, new2}))
+
+		got, err := store.GetLatestBundleBySwitch(ctx, switchUUID)
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+		ids := []uuid.UUID{got[0].ID, got[1].ID}
+		assert.Contains(t, ids, new1.ID)
+		assert.Contains(t, ids, new2.ID)
+	})
+
+	t.Run("single_component_returns_only_latest", func(t *testing.T) {
+		store := firmwaremanager.NewInMemoryUpdateStore()
+		switchUUID := uuid.New()
+
+		old := makeUpdate(switchUUID, nvswitch.BMC)
+		old.CreatedAt = time.Now().Add(-time.Second)
+		require.NoError(t, store.Save(ctx, old))
+
+		newer := makeUpdate(switchUUID, nvswitch.BMC)
+		require.NoError(t, store.Save(ctx, newer))
+
+		got, err := store.GetLatestBundleBySwitch(ctx, switchUUID)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, newer.ID, got[0].ID)
+	})
+}
+
+func TestInMemory_GetActive(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns_non_terminal_update", func(t *testing.T) {
+		store := firmwaremanager.NewInMemoryUpdateStore()
+		switchUUID := uuid.New()
+		update := makeUpdate(switchUUID, nvswitch.BMC)
+		require.NoError(t, store.Save(ctx, update))
+
+		got, err := store.GetActive(ctx, switchUUID, nvswitch.BMC)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, update.ID, got.ID)
+	})
+
+	t.Run("returns_nil_for_terminal_update", func(t *testing.T) {
+		store := firmwaremanager.NewInMemoryUpdateStore()
+		switchUUID := uuid.New()
+		update := makeUpdate(switchUUID, nvswitch.BMC)
+		update.SetState(firmwaremanager.StateCompleted)
+		require.NoError(t, store.Save(ctx, update))
+
+		got, err := store.GetActive(ctx, switchUUID, nvswitch.BMC)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("does_not_return_different_component", func(t *testing.T) {
+		store := firmwaremanager.NewInMemoryUpdateStore()
+		switchUUID := uuid.New()
+		update := makeUpdate(switchUUID, nvswitch.BMC)
+		require.NoError(t, store.Save(ctx, update))
+
+		got, err := store.GetActive(ctx, switchUUID, nvswitch.BIOS)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+}
+
+func TestInMemory_GetAnyActiveForSwitch(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns_active_update_for_switch", func(t *testing.T) {
+		store := firmwaremanager.NewInMemoryUpdateStore()
+		switchUUID := uuid.New()
+		update := makeUpdate(switchUUID, nvswitch.BMC)
+		require.NoError(t, store.Save(ctx, update))
+
+		got, err := store.GetAnyActiveForSwitch(ctx, switchUUID)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, switchUUID, got.SwitchUUID)
+	})
+
+	t.Run("returns_nil_when_all_terminal", func(t *testing.T) {
+		store := firmwaremanager.NewInMemoryUpdateStore()
+		switchUUID := uuid.New()
+		update := makeUpdate(switchUUID, nvswitch.BMC)
+		update.SetState(firmwaremanager.StateFailed)
+		require.NoError(t, store.Save(ctx, update))
+
+		got, err := store.GetAnyActiveForSwitch(ctx, switchUUID)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("does_not_return_different_switch", func(t *testing.T) {
+		store := firmwaremanager.NewInMemoryUpdateStore()
+		update := makeUpdate(uuid.New(), nvswitch.BMC)
+		require.NoError(t, store.Save(ctx, update))
+
+		got, err := store.GetAnyActiveForSwitch(ctx, uuid.New())
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+}
+
+func TestInMemory_CancelRemainingInBundle(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("cancels_queued_updates_after_sequence", func(t *testing.T) {
+		store := firmwaremanager.NewInMemoryUpdateStore()
+		switchUUID := uuid.New()
+		bundleID := uuid.New()
+
+		u1 := makeUpdate(switchUUID, nvswitch.BMC)
+		u1.WithSequencing(&bundleID, 1, nil)
+		u2 := makeUpdate(switchUUID, nvswitch.BIOS)
+		u2.WithSequencing(&bundleID, 2, &u1.ID)
+		u3 := makeUpdate(switchUUID, nvswitch.CPLD)
+		u3.WithSequencing(&bundleID, 3, &u2.ID)
+		require.NoError(t, store.SaveAll(ctx, []*firmwaremanager.FirmwareUpdate{u1, u2, u3}))
+
+		cancelled, err := store.CancelRemainingInBundle(ctx, bundleID, 1, nvswitch.BMC)
+		require.NoError(t, err)
+		assert.Equal(t, 2, cancelled)
+
+		got2, err := store.Get(ctx, u2.ID)
+		require.NoError(t, err)
+		assert.Equal(t, firmwaremanager.StateCancelled, got2.State)
+
+		got3, err := store.Get(ctx, u3.ID)
+		require.NoError(t, err)
+		assert.Equal(t, firmwaremanager.StateCancelled, got3.State)
+	})
+
+	t.Run("does_not_cancel_non_queued_updates", func(t *testing.T) {
+		store := firmwaremanager.NewInMemoryUpdateStore()
+		switchUUID := uuid.New()
+		bundleID := uuid.New()
+
+		u1 := makeUpdate(switchUUID, nvswitch.BMC)
+		u1.WithSequencing(&bundleID, 1, nil)
+		u2 := makeUpdate(switchUUID, nvswitch.BIOS)
+		u2.WithSequencing(&bundleID, 2, &u1.ID)
+		u2.SetState(firmwaremanager.StateInstall) // already active, not QUEUED
+		require.NoError(t, store.SaveAll(ctx, []*firmwaremanager.FirmwareUpdate{u1, u2}))
+
+		cancelled, err := store.CancelRemainingInBundle(ctx, bundleID, 1, nvswitch.BMC)
+		require.NoError(t, err)
+		assert.Equal(t, 0, cancelled)
+
+		got2, err := store.Get(ctx, u2.ID)
+		require.NoError(t, err)
+		assert.Equal(t, firmwaremanager.StateInstall, got2.State) // unchanged
+	})
+
+	t.Run("does_not_affect_other_bundles", func(t *testing.T) {
+		store := firmwaremanager.NewInMemoryUpdateStore()
+		switchUUID := uuid.New()
+		bundleA, bundleB := uuid.New(), uuid.New()
+
+		uA := makeUpdate(switchUUID, nvswitch.BMC)
+		uA.WithSequencing(&bundleA, 1, nil)
+		uB := makeUpdate(switchUUID, nvswitch.BIOS)
+		uB.WithSequencing(&bundleB, 1, nil)
+		require.NoError(t, store.SaveAll(ctx, []*firmwaremanager.FirmwareUpdate{uA, uB}))
+
+		_, err := store.CancelRemainingInBundle(ctx, bundleA, 0, nvswitch.BMC)
+		require.NoError(t, err)
+
+		gotB, err := store.Get(ctx, uB.ID)
+		require.NoError(t, err)
+		assert.Equal(t, firmwaremanager.StateQueued, gotB.State) // bundleB unaffected
+	})
+}
+
+func TestInMemory_Delete(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("deletes_existing_record", func(t *testing.T) {
+		store := firmwaremanager.NewInMemoryUpdateStore()
+		update := makeUpdate(uuid.New(), nvswitch.BMC)
+		require.NoError(t, store.Save(ctx, update))
+
+		require.NoError(t, store.Delete(ctx, update.ID))
+
+		_, err := store.Get(ctx, update.ID)
+		require.ErrorIs(t, err, firmwaremanager.ErrUpdateNotFound)
+	})
+
+	t.Run("errors_on_not_found", func(t *testing.T) {
+		store := firmwaremanager.NewInMemoryUpdateStore()
+		err := store.Delete(ctx, uuid.New())
+		require.ErrorIs(t, err, firmwaremanager.ErrUpdateNotFound)
+	})
+}

--- a/nvswitch-manager/pkg/firmwaremanager/store_postgres.go
+++ b/nvswitch-manager/pkg/firmwaremanager/store_postgres.go
@@ -118,13 +118,10 @@ func fromModel(m *FirmwareUpdateModel) *FirmwareUpdate {
 	}
 }
 
-// Save persists a firmware update (insert or update).
-func (s *PostgresUpdateStore) Save(ctx context.Context, update *FirmwareUpdate) error {
-	update.UpdatedAt = time.Now()
-	model := toModel(update)
-
-	_, err := s.db.NewInsert().
-		Model(model).
+// upsertModels executes a bulk upsert for the given models using db (either *bun.DB or bun.Tx).
+func upsertModels(ctx context.Context, db bun.IDB, models []*FirmwareUpdateModel) error {
+	_, err := db.NewInsert().
+		Model(&models).
 		On("CONFLICT (id) DO UPDATE").
 		Set("state = EXCLUDED.state").
 		Set("version_from = EXCLUDED.version_from").
@@ -135,8 +132,33 @@ func (s *PostgresUpdateStore) Save(ctx context.Context, update *FirmwareUpdate) 
 		Set("last_checked_at = EXCLUDED.last_checked_at").
 		Set("updated_at = EXCLUDED.updated_at").
 		Exec(ctx)
-
 	return err
+}
+
+// Save persists a firmware update (insert or update).
+func (s *PostgresUpdateStore) Save(ctx context.Context, update *FirmwareUpdate) error {
+	update.UpdatedAt = time.Now()
+	return upsertModels(ctx, s.db, []*FirmwareUpdateModel{toModel(update)})
+}
+
+// SaveAll persists all firmware updates (insert or update) in a single transaction.
+// If any insert fails the entire batch is rolled back.
+func (s *PostgresUpdateStore) SaveAll(ctx context.Context, updates []*FirmwareUpdate) error {
+	if len(updates) == 0 {
+		return nil
+	}
+
+	return s.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		now := time.Now()
+
+		models := make([]*FirmwareUpdateModel, len(updates))
+		for i, update := range updates {
+			update.UpdatedAt = now
+			models[i] = toModel(update)
+		}
+
+		return upsertModels(ctx, tx, models)
+	})
 }
 
 // Get retrieves a firmware update by ID.
@@ -192,7 +214,7 @@ func (s *PostgresUpdateStore) GetPendingUpdates(ctx context.Context, limit int) 
 		Model(&queuedModels).
 		Where("state = ?", StateQueued).
 		Where(`(
-			predecessor_id IS NULL 
+			predecessor_id IS NULL
 			OR predecessor_id IN (SELECT id FROM firmware_update WHERE state = ?)
 		)`, StateCompleted).
 		OrderExpr("sequence_order ASC, created_at ASC").

--- a/nvswitch-manager/pkg/firmwaremanager/store_postgres_test.go
+++ b/nvswitch-manager/pkg/firmwaremanager/store_postgres_test.go
@@ -1,0 +1,499 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package firmwaremanager_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/infra-controller-rest/nvswitch-manager/pkg/db"
+	"github.com/NVIDIA/infra-controller-rest/nvswitch-manager/pkg/db/migrations"
+	"github.com/NVIDIA/infra-controller-rest/nvswitch-manager/pkg/db/postgres"
+	"github.com/NVIDIA/infra-controller-rest/nvswitch-manager/pkg/db/testutil"
+	"github.com/NVIDIA/infra-controller-rest/nvswitch-manager/pkg/firmwaremanager"
+	"github.com/NVIDIA/infra-controller-rest/nvswitch-manager/pkg/objects/nvswitch"
+)
+
+func skipIfNoDatabase(t *testing.T) {
+	t.Helper()
+	if os.Getenv("DB_PORT") == "" {
+		t.Skip("DB_PORT not set - skipping integration test")
+	}
+}
+
+func setupPostgresStore(t *testing.T) (*firmwaremanager.PostgresUpdateStore, *postgres.Postgres, func()) {
+	t.Helper()
+	ctx := context.Background()
+
+	dbConf, err := db.BuildDBConfigFromEnv()
+	require.NoError(t, err)
+
+	pg, err := testutil.CreateTestDB(ctx, t, dbConf)
+	require.NoError(t, err)
+
+	require.NoError(t, migrations.Migrate(ctx, pg))
+
+	store := firmwaremanager.NewPostgresUpdateStore(pg.DB())
+	return store, pg, func() { pg.Close(ctx) }
+}
+
+// insertTestNVSwitch inserts a minimal nvswitch row to satisfy the FK constraint on firmware_update.
+func insertTestNVSwitch(t *testing.T, pg *postgres.Postgres, bmcMAC, nvosMAC, bmcIP, nvosIP string) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+
+	_, err := pg.DB().NewRaw(`
+		INSERT INTO nvswitch (uuid, vendor, bmc_mac_address, bmc_ip_address, nvos_mac_address, nvos_ip_address)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, id, 1, bmcMAC, bmcIP, nvosMAC, nvosIP).Exec(context.Background())
+
+	require.NoError(t, err)
+
+	return id
+}
+
+func TestIntegration_SaveAll_PersistsAll(t *testing.T) {
+	skipIfNoDatabase(t)
+
+	ctx := context.Background()
+	store, pg, cleanup := setupPostgresStore(t)
+	defer cleanup()
+
+	switchUUID := insertTestNVSwitch(t, pg, "aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02", "10.0.0.1", "10.0.0.2")
+	update1 := makeUpdate(switchUUID, nvswitch.BMC)
+	update2 := makeUpdate(switchUUID, nvswitch.BIOS)
+
+	require.NoError(t, store.SaveAll(ctx, []*firmwaremanager.FirmwareUpdate{update1, update2}))
+
+	_, err := store.Get(ctx, update1.ID)
+	require.NoError(t, err)
+
+	_, err = store.Get(ctx, update2.ID)
+	require.NoError(t, err)
+}
+
+func TestIntegration_SaveAll_Upsert(t *testing.T) {
+	skipIfNoDatabase(t)
+
+	ctx := context.Background()
+	store, pg, cleanup := setupPostgresStore(t)
+	defer cleanup()
+
+	switchUUID := insertTestNVSwitch(t, pg, "aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02", "10.0.0.1", "10.0.0.2")
+	update1 := makeUpdate(switchUUID, nvswitch.BMC)
+	update2 := makeUpdate(switchUUID, nvswitch.BIOS)
+
+	require.NoError(t, store.SaveAll(ctx, []*firmwaremanager.FirmwareUpdate{update1, update2}))
+
+	update1.SetState(firmwaremanager.StateCompleted)
+	update2.SetState(firmwaremanager.StateFailed)
+	require.NoError(t, store.SaveAll(ctx, []*firmwaremanager.FirmwareUpdate{update1, update2}))
+
+	got1, err := store.Get(ctx, update1.ID)
+	require.NoError(t, err)
+	assert.Equal(t, firmwaremanager.StateCompleted, got1.State)
+	assert.Equal(t, nvswitch.BMC, got1.Component)
+
+	got2, err := store.Get(ctx, update2.ID)
+	require.NoError(t, err)
+	assert.Equal(t, firmwaremanager.StateFailed, got2.State)
+	assert.Equal(t, nvswitch.BIOS, got2.Component)
+}
+
+// TestIntegration_SaveAll_RollbackOnFailure verifies that SaveAll is atomic: if any
+// record in the batch fails to persist, the entire batch is rolled back.
+//
+// The FK constraint on firmware_update.switch_uuid → nvswitch.uuid is used to force
+// a failure on the second record (orphanUUID has no nvswitch row). The test then
+// confirms that the first record was also not persisted.
+func TestIntegration_SaveAll_RollbackOnFailure(t *testing.T) {
+	skipIfNoDatabase(t)
+
+	ctx := context.Background()
+	store, pg, cleanup := setupPostgresStore(t)
+	defer cleanup()
+
+	validUUID := insertTestNVSwitch(t, pg, "aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02", "10.0.0.1", "10.0.0.2")
+	orphanUUID := uuid.New() // no nvswitch row → triggers FK violation
+
+	update1 := makeUpdate(validUUID, nvswitch.BMC)
+	update2 := makeUpdate(orphanUUID, nvswitch.BMC)
+
+	err := store.SaveAll(ctx, []*firmwaremanager.FirmwareUpdate{update1, update2})
+	require.Error(t, err, "SaveAll should fail due to FK violation on update2")
+
+	_, err = store.Get(ctx, update1.ID)
+	require.ErrorIs(t, err, firmwaremanager.ErrUpdateNotFound, "update1 must not be persisted after rollback")
+}
+
+func TestIntegration_GetPendingUpdates(t *testing.T) {
+	skipIfNoDatabase(t)
+
+	ctx := context.Background()
+
+	t.Run("queued_no_predecessor_returned", func(t *testing.T) {
+		store, pg, cleanup := setupPostgresStore(t)
+		defer cleanup()
+		switchUUID := insertTestNVSwitch(t, pg, "aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02", "10.0.0.1", "10.0.0.2")
+		update := makeUpdate(switchUUID, nvswitch.BMC)
+		require.NoError(t, store.Save(ctx, update))
+
+		pending, err := store.GetPendingUpdates(ctx, 10)
+		require.NoError(t, err)
+		require.Len(t, pending, 1)
+		assert.Equal(t, update.ID, pending[0].ID)
+	})
+
+	t.Run("queued_after_pred_finishes", func(t *testing.T) {
+		store, pg, cleanup := setupPostgresStore(t)
+		defer cleanup()
+		switchUUID := insertTestNVSwitch(t, pg, "aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02", "10.0.0.1", "10.0.0.2")
+
+		pred := makeUpdate(switchUUID, nvswitch.BMC)
+		pred.SetState(firmwaremanager.StateCompleted)
+		require.NoError(t, store.Save(ctx, pred))
+
+		next := makeUpdate(switchUUID, nvswitch.BIOS)
+		next.WithSequencing(nil, 2, &pred.ID)
+		require.NoError(t, store.Save(ctx, next))
+
+		pending, err := store.GetPendingUpdates(ctx, 10)
+		require.NoError(t, err)
+		ids := make([]uuid.UUID, len(pending))
+		for i, p := range pending {
+			ids[i] = p.ID
+		}
+		assert.Contains(t, ids, next.ID)
+	})
+
+	t.Run("queued_while_pred_in_progress", func(t *testing.T) {
+		store, pg, cleanup := setupPostgresStore(t)
+		defer cleanup()
+		switchUUID := insertTestNVSwitch(t, pg, "aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02", "10.0.0.1", "10.0.0.2")
+
+		pred := makeUpdate(switchUUID, nvswitch.BMC) // still QUEUED
+		require.NoError(t, store.Save(ctx, pred))
+
+		next := makeUpdate(switchUUID, nvswitch.BIOS)
+		next.WithSequencing(nil, 2, &pred.ID)
+		require.NoError(t, store.Save(ctx, next))
+
+		pending, err := store.GetPendingUpdates(ctx, 10)
+		require.NoError(t, err)
+		require.Len(t, pending, 1)
+		assert.Equal(t, pred.ID, pending[0].ID)
+	})
+
+	t.Run("active_update_returned", func(t *testing.T) {
+		store, pg, cleanup := setupPostgresStore(t)
+		defer cleanup()
+		switchUUID := insertTestNVSwitch(t, pg, "aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02", "10.0.0.1", "10.0.0.2")
+		update := makeUpdate(switchUUID, nvswitch.BMC)
+		update.SetState(firmwaremanager.StateInstall)
+		require.NoError(t, store.Save(ctx, update))
+
+		pending, err := store.GetPendingUpdates(ctx, 10)
+		require.NoError(t, err)
+		require.Len(t, pending, 1)
+		assert.Equal(t, update.ID, pending[0].ID)
+	})
+
+	t.Run("terminal_update_not_returned", func(t *testing.T) {
+		store, pg, cleanup := setupPostgresStore(t)
+		defer cleanup()
+		switchUUID := insertTestNVSwitch(t, pg, "aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02", "10.0.0.1", "10.0.0.2")
+
+		for _, state := range []firmwaremanager.UpdateState{
+			firmwaremanager.StateCompleted,
+			firmwaremanager.StateFailed,
+			firmwaremanager.StateCancelled,
+		} {
+			u := makeUpdate(switchUUID, nvswitch.BMC)
+			u.SetState(state)
+			require.NoError(t, store.Save(ctx, u))
+		}
+
+		pending, err := store.GetPendingUpdates(ctx, 10)
+		require.NoError(t, err)
+		assert.Empty(t, pending)
+	})
+
+	t.Run("respects_limit", func(t *testing.T) {
+		store, pg, cleanup := setupPostgresStore(t)
+		defer cleanup()
+		switchUUID := insertTestNVSwitch(t, pg, "aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02", "10.0.0.1", "10.0.0.2")
+
+		for _, comp := range []nvswitch.Component{nvswitch.BMC, nvswitch.BIOS, nvswitch.CPLD} {
+			require.NoError(t, store.Save(ctx, makeUpdate(switchUUID, comp)))
+		}
+
+		pending, err := store.GetPendingUpdates(ctx, 2)
+		require.NoError(t, err)
+		assert.Len(t, pending, 2)
+	})
+}
+
+func TestIntegration_GetLatestBundleBySwitch(t *testing.T) {
+	skipIfNoDatabase(t)
+
+	ctx := context.Background()
+
+	t.Run("returns_only_latest_bundle_not_older_ones", func(t *testing.T) {
+		store, pg, cleanup := setupPostgresStore(t)
+		defer cleanup()
+		switchUUID := insertTestNVSwitch(t, pg, "aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02", "10.0.0.1", "10.0.0.2")
+
+		oldBundleID := uuid.New()
+		old1 := makeUpdate(switchUUID, nvswitch.BMC)
+		old1.BundleUpdateID = &oldBundleID
+		old1.CreatedAt = time.Now().Add(-time.Second)
+		require.NoError(t, store.Save(ctx, old1))
+
+		newBundleID := uuid.New()
+		new1 := makeUpdate(switchUUID, nvswitch.BMC)
+		new2 := makeUpdate(switchUUID, nvswitch.BIOS)
+		new1.WithSequencing(&newBundleID, 1, nil)
+		new2.WithSequencing(&newBundleID, 2, &new1.ID)
+		require.NoError(t, store.SaveAll(ctx, []*firmwaremanager.FirmwareUpdate{new1, new2}))
+
+		got, err := store.GetLatestBundleBySwitch(ctx, switchUUID)
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+		ids := []uuid.UUID{got[0].ID, got[1].ID}
+		assert.Contains(t, ids, new1.ID)
+		assert.Contains(t, ids, new2.ID)
+	})
+
+	t.Run("single_component_returns_only_latest", func(t *testing.T) {
+		store, pg, cleanup := setupPostgresStore(t)
+		defer cleanup()
+		switchUUID := insertTestNVSwitch(t, pg, "aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02", "10.0.0.1", "10.0.0.2")
+
+		old := makeUpdate(switchUUID, nvswitch.BMC)
+		old.CreatedAt = time.Now().Add(-time.Second)
+		require.NoError(t, store.Save(ctx, old))
+
+		newer := makeUpdate(switchUUID, nvswitch.BMC)
+		require.NoError(t, store.Save(ctx, newer))
+
+		got, err := store.GetLatestBundleBySwitch(ctx, switchUUID)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, newer.ID, got[0].ID)
+	})
+}
+
+func TestIntegration_GetActive(t *testing.T) {
+	skipIfNoDatabase(t)
+
+	ctx := context.Background()
+
+	t.Run("returns_non_terminal_update", func(t *testing.T) {
+		store, pg, cleanup := setupPostgresStore(t)
+		defer cleanup()
+		switchUUID := insertTestNVSwitch(t, pg, "aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02", "10.0.0.1", "10.0.0.2")
+		update := makeUpdate(switchUUID, nvswitch.BMC)
+		require.NoError(t, store.Save(ctx, update))
+
+		got, err := store.GetActive(ctx, switchUUID, nvswitch.BMC)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, update.ID, got.ID)
+	})
+
+	t.Run("returns_nil_for_terminal_update", func(t *testing.T) {
+		store, pg, cleanup := setupPostgresStore(t)
+		defer cleanup()
+		switchUUID := insertTestNVSwitch(t, pg, "aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02", "10.0.0.1", "10.0.0.2")
+		update := makeUpdate(switchUUID, nvswitch.BMC)
+		update.SetState(firmwaremanager.StateCompleted)
+		require.NoError(t, store.Save(ctx, update))
+
+		got, err := store.GetActive(ctx, switchUUID, nvswitch.BMC)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("does_not_return_different_component", func(t *testing.T) {
+		store, pg, cleanup := setupPostgresStore(t)
+		defer cleanup()
+		switchUUID := insertTestNVSwitch(t, pg, "aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02", "10.0.0.1", "10.0.0.2")
+		update := makeUpdate(switchUUID, nvswitch.BMC)
+		require.NoError(t, store.Save(ctx, update))
+
+		got, err := store.GetActive(ctx, switchUUID, nvswitch.BIOS)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+}
+
+func TestIntegration_GetAnyActiveForSwitch(t *testing.T) {
+	skipIfNoDatabase(t)
+
+	ctx := context.Background()
+
+	t.Run("returns_active_update_for_switch", func(t *testing.T) {
+		store, pg, cleanup := setupPostgresStore(t)
+		defer cleanup()
+		switchUUID := insertTestNVSwitch(t, pg, "aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02", "10.0.0.1", "10.0.0.2")
+		update := makeUpdate(switchUUID, nvswitch.BMC)
+		require.NoError(t, store.Save(ctx, update))
+
+		got, err := store.GetAnyActiveForSwitch(ctx, switchUUID)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, switchUUID, got.SwitchUUID)
+	})
+
+	t.Run("returns_nil_when_all_terminal", func(t *testing.T) {
+		store, pg, cleanup := setupPostgresStore(t)
+		defer cleanup()
+		switchUUID := insertTestNVSwitch(t, pg, "aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02", "10.0.0.1", "10.0.0.2")
+		update := makeUpdate(switchUUID, nvswitch.BMC)
+		update.SetState(firmwaremanager.StateFailed)
+		require.NoError(t, store.Save(ctx, update))
+
+		got, err := store.GetAnyActiveForSwitch(ctx, switchUUID)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("does_not_return_different_switch", func(t *testing.T) {
+		store, pg, cleanup := setupPostgresStore(t)
+		defer cleanup()
+		switchUUID := insertTestNVSwitch(t, pg, "aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02", "10.0.0.1", "10.0.0.2")
+		update := makeUpdate(switchUUID, nvswitch.BMC)
+		require.NoError(t, store.Save(ctx, update))
+
+		otherSwitch := insertTestNVSwitch(t, pg, "bb:cc:dd:ee:ff:01", "bb:cc:dd:ee:ff:02", "10.0.1.1", "10.0.1.2")
+		got, err := store.GetAnyActiveForSwitch(ctx, otherSwitch)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+}
+
+func TestIntegration_CancelRemainingInBundle(t *testing.T) {
+	skipIfNoDatabase(t)
+
+	ctx := context.Background()
+
+	t.Run("cancels_queued_updates_after_sequence", func(t *testing.T) {
+		store, pg, cleanup := setupPostgresStore(t)
+		defer cleanup()
+		switchUUID := insertTestNVSwitch(t, pg, "aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02", "10.0.0.1", "10.0.0.2")
+		bundleID := uuid.New()
+
+		u1 := makeUpdate(switchUUID, nvswitch.BMC)
+		u1.WithSequencing(&bundleID, 1, nil)
+		u2 := makeUpdate(switchUUID, nvswitch.BIOS)
+		u2.WithSequencing(&bundleID, 2, &u1.ID)
+		u3 := makeUpdate(switchUUID, nvswitch.CPLD)
+		u3.WithSequencing(&bundleID, 3, &u2.ID)
+		require.NoError(t, store.SaveAll(ctx, []*firmwaremanager.FirmwareUpdate{u1, u2, u3}))
+
+		cancelled, err := store.CancelRemainingInBundle(ctx, bundleID, 1, nvswitch.BMC)
+		require.NoError(t, err)
+		assert.Equal(t, 2, cancelled)
+
+		got2, err := store.Get(ctx, u2.ID)
+		require.NoError(t, err)
+		assert.Equal(t, firmwaremanager.StateCancelled, got2.State)
+
+		got3, err := store.Get(ctx, u3.ID)
+		require.NoError(t, err)
+		assert.Equal(t, firmwaremanager.StateCancelled, got3.State)
+	})
+
+	t.Run("does_not_cancel_non_queued_updates", func(t *testing.T) {
+		store, pg, cleanup := setupPostgresStore(t)
+		defer cleanup()
+		switchUUID := insertTestNVSwitch(t, pg, "aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02", "10.0.0.1", "10.0.0.2")
+		bundleID := uuid.New()
+
+		u1 := makeUpdate(switchUUID, nvswitch.BMC)
+		u1.WithSequencing(&bundleID, 1, nil)
+		u2 := makeUpdate(switchUUID, nvswitch.BIOS)
+		u2.WithSequencing(&bundleID, 2, &u1.ID)
+		u2.SetState(firmwaremanager.StateInstall) // already active, not QUEUED
+		require.NoError(t, store.SaveAll(ctx, []*firmwaremanager.FirmwareUpdate{u1, u2}))
+
+		cancelled, err := store.CancelRemainingInBundle(ctx, bundleID, 1, nvswitch.BMC)
+		require.NoError(t, err)
+		assert.Equal(t, 0, cancelled)
+
+		got2, err := store.Get(ctx, u2.ID)
+		require.NoError(t, err)
+		assert.Equal(t, firmwaremanager.StateInstall, got2.State) // unchanged
+	})
+
+	t.Run("does_not_affect_other_bundles", func(t *testing.T) {
+		store, pg, cleanup := setupPostgresStore(t)
+		defer cleanup()
+		switchUUID := insertTestNVSwitch(t, pg, "aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02", "10.0.0.1", "10.0.0.2")
+		bundleA, bundleB := uuid.New(), uuid.New()
+
+		uA := makeUpdate(switchUUID, nvswitch.BMC)
+		uA.WithSequencing(&bundleA, 1, nil)
+		uB := makeUpdate(switchUUID, nvswitch.BIOS)
+		uB.WithSequencing(&bundleB, 1, nil)
+		require.NoError(t, store.SaveAll(ctx, []*firmwaremanager.FirmwareUpdate{uA, uB}))
+
+		_, err := store.CancelRemainingInBundle(ctx, bundleA, 0, nvswitch.BMC)
+		require.NoError(t, err)
+
+		gotB, err := store.Get(ctx, uB.ID)
+		require.NoError(t, err)
+		assert.Equal(t, firmwaremanager.StateQueued, gotB.State) // bundleB unaffected
+	})
+}
+
+func TestIntegration_Delete(t *testing.T) {
+	skipIfNoDatabase(t)
+
+	ctx := context.Background()
+
+	t.Run("deletes_existing_record", func(t *testing.T) {
+		store, pg, cleanup := setupPostgresStore(t)
+		defer cleanup()
+		switchUUID := insertTestNVSwitch(t, pg, "aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02", "10.0.0.1", "10.0.0.2")
+		update := makeUpdate(switchUUID, nvswitch.BMC)
+		require.NoError(t, store.Save(ctx, update))
+
+		require.NoError(t, store.Delete(ctx, update.ID))
+
+		_, err := store.Get(ctx, update.ID)
+		require.ErrorIs(t, err, firmwaremanager.ErrUpdateNotFound)
+	})
+
+	// Unlike InMemoryUpdateStore which returns ErrUpdateNotFound, the postgres
+	// implementation silently succeeds when deleting a non-existent record
+	// because it does not check RowsAffected.
+	t.Run("no_error_on_not_found", func(t *testing.T) {
+		store, _, cleanup := setupPostgresStore(t)
+		defer cleanup()
+
+		err := store.Delete(ctx, uuid.New())
+		require.NoError(t, err)
+	})
+}

--- a/nvswitch-manager/pkg/firmwaremanager/strategy_script.go
+++ b/nvswitch-manager/pkg/firmwaremanager/strategy_script.go
@@ -246,7 +246,7 @@ func (s *ScriptStrategy) resolveToken(token string, tray *nvswitch.NVSwitchTray)
 
 // pollScriptProcess checks the status of a running script process without blocking.
 // Uses syscall.Wait4 with WNOHANG to poll process status.
-func (s *ScriptStrategy) pollScriptProcess(ctx context.Context, update *FirmwareUpdate) StepOutcome {
+func (s *ScriptStrategy) pollScriptProcess(_ context.Context, update *FirmwareUpdate) StepOutcome {
 	execCtx := update.ExecContext
 	pid := execCtx.PID
 

--- a/nvswitch-manager/pkg/firmwaremanager/strategy_ssh.go
+++ b/nvswitch-manager/pkg/firmwaremanager/strategy_ssh.go
@@ -189,7 +189,7 @@ func (s *SSHStrategy) executePowerCycle(ctx context.Context, update *FirmwareUpd
 // executeWaitReachable waits for the NVOS to become reachable.
 // This is async-aware: returns Wait while unreachable, Transition when reachable.
 // After becoming reachable, waits for PostReachabilityDelay to allow services to start.
-func (s *SSHStrategy) executeWaitReachable(ctx context.Context, update *FirmwareUpdate, tray *nvswitch.NVSwitchTray) StepOutcome {
+func (s *SSHStrategy) executeWaitReachable(_ context.Context, update *FirmwareUpdate, tray *nvswitch.NVSwitchTray) StepOutcome {
 	// Initialize or retrieve exec context
 	execCtx := update.ExecContext
 	if execCtx == nil {
@@ -474,7 +474,7 @@ func (s *SSHStrategy) executeInstall(ctx context.Context, update *FirmwareUpdate
 }
 
 // handleRebootWait handles the async wait for NVOS reboot completion.
-func (s *SSHStrategy) handleRebootWait(ctx context.Context, update *FirmwareUpdate, tray *nvswitch.NVSwitchTray, execCtx *ExecContext) StepOutcome {
+func (s *SSHStrategy) handleRebootWait(_ context.Context, update *FirmwareUpdate, tray *nvswitch.NVSwitchTray, execCtx *ExecContext) StepOutcome {
 	// Check for timeout
 	if time.Now().After(execCtx.DeadlineAt) {
 		return Failed(fmt.Errorf("timeout waiting for NVOS reboot"))
@@ -583,7 +583,7 @@ func (s *SSHStrategy) GetCurrentVersion(ctx context.Context, tray *nvswitch.NVSw
 		}
 		// Parse CPLD version from output
 		// Format varies, look for "CPLD1" line
-		for _, line := range strings.Split(output, "\n") {
+		for line := range strings.SplitSeq(output, "\n") {
 			if strings.Contains(line, "CPLD1") {
 				fields := strings.Fields(line)
 				if len(fields) >= 2 {
@@ -599,7 +599,7 @@ func (s *SSHStrategy) GetCurrentVersion(ctx context.Context, tray *nvswitch.NVSw
 			return "", fmt.Errorf("failed to get NVOS version: %w", err)
 		}
 		// Parse version from output
-		for _, line := range strings.Split(output, "\n") {
+		for line := range strings.SplitSeq(output, "\n") {
 			if strings.Contains(line, "version") {
 				fields := strings.Fields(line)
 				if len(fields) >= 2 {


### PR DESCRIPTION
## Description

`QueueUpdate` previously saved each firmware update to the store one at a time inside the loop, leaving the store partially written if any save failed mid-batch. This adds `SaveAll` to UpdateStore, which persists all updates in a single transaction so the batch either fully commits or rolls back. A nil guard on `compDef` is added to catch missing component definitions before any writes occur, and logging is deferred until after all saves succeed.

Minor cleanup: `interface{}` to `any` in vault.go, unused ctx parameters to _, and strings.Split to strings.SplitSeq in strategy_ssh.go.

## Type of Change

- [ ] **Feature** - New feature or functionality (feat:)
- [x] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected

- [ ] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [x] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)

## Breaking Changes

- [ ] This PR contains breaking changes

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes