### PR TITLE
fix: Require at least one filter for ExpectedRack DeleteAll

### DIFF
--- a/db/pkg/db/model/expectedrack.go
+++ b/db/pkg/db/model/expectedrack.go
@@ -577,8 +577,10 @@ func (erd ExpectedRackSQLDAO) Delete(ctx context.Context, tx *db.Tx, expectedRac
 	return nil
 }
 
-// DeleteAll deletes all ExpectedRacks matching the given filter (typically scoped by site)
-// Error is returned only if there is a db error
+// DeleteAll deletes all ExpectedRacks matching the given filter (typically
+// scoped by site). Callers must supply at least one filter; an empty filter
+// is rejected with db.ErrInvalidParams to prevent wiping the entire table.
+// Error is returned only if there is a db error or no filter was supplied.
 func (erd ExpectedRackSQLDAO) DeleteAll(ctx context.Context, tx *db.Tx, filter ExpectedRackFilterInput) error {
 	// Create a child span and set the attributes for current request
 	ctx, expectedRackDAOSpan := erd.tracerSpan.CreateChildInCurrentContext(ctx, "ExpectedRackDAO.DeleteAll")
@@ -618,9 +620,10 @@ func (erd ExpectedRackSQLDAO) DeleteAll(ctx context.Context, tx *db.Tx, filter E
 		}
 	}
 
-	// bun requires an explicit WHERE clause for bulk DELETE; gate unscoped deletes behind WHERE TRUE.
+	// Make sure at least one filter was provided; don't allow someone
+	// to delete all expected racks across all sites.
 	if !hasFilter {
-		query = query.Where("TRUE")
+		return db.ErrInvalidParams
 	}
 
 	_, err := query.Exec(ctx)

--- a/db/pkg/db/model/expectedrack_test.go
+++ b/db/pkg/db/model/expectedrack_test.go
@@ -860,16 +860,17 @@ func TestExpectedRackDAO_DeleteAll(t *testing.T) {
 	// Reset for the unscoped case
 	testExpectedRackSetupSchema(t, dbSession)
 
-	t.Run("DeleteAll without filter wipes everything", func(t *testing.T) {
-		_, _, _, _ = testExpectedRackDAOCreateExpectedRacks(ctx, t, dbSession)
+	t.Run("DeleteAll without filter is rejected", func(t *testing.T) {
+		expectedRacks, _, _, _ := testExpectedRackDAOCreateExpectedRacks(ctx, t, dbSession)
 
 		err := erd.DeleteAll(ctx, nil, ExpectedRackFilterInput{})
-		assert.NoError(t, err)
+		assert.ErrorIs(t, err, db.ErrInvalidParams)
 
+		// Records must be untouched after the rejection.
 		got, total, err := erd.GetAll(ctx, nil, ExpectedRackFilterInput{}, paginator.PageInput{}, nil)
 		assert.NoError(t, err)
-		assert.Equal(t, 0, len(got))
-		assert.Equal(t, 0, total)
+		assert.Equal(t, len(expectedRacks), len(got))
+		assert.Equal(t, len(expectedRacks), total)
 	})
 }
 


### PR DESCRIPTION
## Description

Require at least one filter be set for deleting all `ExpectedRack` entries, ensuring we don't drop all `ExpectedRack` entries across all sites.

Tests updated.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [x] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [ ] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [x] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
