### PR TITLE
refactor: Add component manager descriptor catalog

### DIFF
--- a/flow/docs/component-manager-architecture.md
+++ b/flow/docs/component-manager-architecture.md
@@ -88,13 +88,20 @@ type ManagerFactory func(providers *providerapi.ProviderRegistry) (ComponentMana
 
 Factory functions create component manager instances. They receive the `ProviderRegistry` to retrieve any required providers.
 
-### Registry
+### Catalog and Registry
 
-The `Registry` stores factories and active managers:
-- `RegisterFactory()` - Register a factory for a component type + implementation name
-- `Initialize()` - Create managers based on configuration
+The `Catalog` stores validated descriptors for implementations compiled into a
+service binary:
+- `NewCatalog()` - Validate descriptors and index them by component type and
+  implementation
+- `ListImplementations()` - List supported implementations by component type
+
+The `Registry` stores active managers selected from a catalog:
+- `NewRegistry()` - Create managers based on configuration and the supplied
+  catalog
 - `GetManager()` - Retrieve active manager for a component type, returning a
   descriptive error when the registry is not configured or no manager is active
+- `GetDescriptor()` - Retrieve the descriptor selected for a component type
 - `FindManager()` - Probe for an active manager, returning nil when absent
 
 ## Directory Structure
@@ -279,9 +286,14 @@ func Factory(providers *providerapi.ProviderRegistry) (componentmanager.Componen
     return New(provider.Client()), nil
 }
 
-// Register registers this implementation with the registry.
-func Register(registry *componentmanager.Registry) {
-    registry.RegisterFactory(devicetypes.ComponentTypeCompute, ImplementationName, Factory)
+// Descriptor returns this implementation's descriptor.
+func Descriptor() componentmanager.Descriptor {
+    return componentmanager.Descriptor{
+        Type:              devicetypes.ComponentTypeCompute,
+        Implementation:    ImplementationName,
+        RequiredProviders: []string{myapiprovider.ProviderName},
+        Factory:           Factory,
+    }
 }
 
 // Type returns the component type.
@@ -315,11 +327,12 @@ import (
     myimpl "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/compute/myimpl"
 )
 
-func serviceComponentManagerRegistrars(config cmconfig.Config) ([]componentManagerRegistrar, error) {
-    return []componentManagerRegistrar{
-        // ... existing registrations ...
-        myimpl.Register, // Add new implementation
-    }, nil
+func serviceCatalog(config cmconfig.Config) (componentmanager.Catalog, error) {
+    descriptors := []componentmanager.Descriptor{
+        // ... existing descriptors ...
+        myimpl.Descriptor(), // Add new implementation
+    }
+    return componentmanager.NewCatalog(descriptors)
 }
 ```
 
@@ -350,7 +363,7 @@ To add an entirely new component type (e.g., `gpu`):
 
 1. Add the type to `pkg/common/devicetypes/component.go`
 2. Create implementation(s) under `internal/task/componentmanager/gpu/<impl>/`
-3. Update the mock in `internal/task/componentmanager/mock/mock.go` to include it in `RegisterAll()`
+3. Update the mock in `internal/task/componentmanager/mock/mock.go` to include a descriptor for it
 4. Update configuration parsing to recognize the new type
 
 ---

--- a/flow/internal/task/componentmanager/builtin/component_manager_factories.go
+++ b/flow/internal/task/componentmanager/builtin/component_manager_factories.go
@@ -35,8 +35,6 @@ import (
 	nicoprovider "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/providers/nico"
 )
 
-type componentManagerRegistrar func(*componentmanager.Registry)
-
 // NewComponentManagerRegistry creates the component manager registry for the
 // Flow service using all component manager implementations compiled into the
 // binary.
@@ -44,17 +42,17 @@ func NewComponentManagerRegistry(
 	config cmconfig.Config,
 	providers *providerapi.ProviderRegistry,
 ) (*componentmanager.Registry, error) {
-	registry := componentmanager.NewRegistry()
-
-	if err := registerServiceComponentManagers(registry, config); err != nil {
+	catalog, err := serviceCatalog(config)
+	if err != nil {
 		return nil, err
 	}
 
-	if err := registry.Initialize(config, providers); err != nil {
+	registry, err := componentmanager.NewRegistry(catalog, config, providers)
+	if err != nil {
 		return nil, fmt.Errorf("initialize component managers: %w", err)
 	}
 
-	impls := registry.ListRegisteredImplementations()
+	impls := catalog.ListImplementations()
 	for compType, names := range impls {
 		log.Debug().
 			Str("component_type", compType.String()).
@@ -65,45 +63,38 @@ func NewComponentManagerRegistry(
 	return registry, nil
 }
 
-// registerServiceComponentManagers registers all component manager factories
-// supported by the Flow service. Add a new compiled-in component manager here
-// when adding a service-supported implementation.
-func registerServiceComponentManagers(
-	registry *componentmanager.Registry,
+// serviceCatalog builds the component manager catalog for the flow service.
+// The catalog contains the descriptors for all the built-in component
+// managers supported by the flow service.
+func serviceCatalog(
 	config cmconfig.Config,
-) error {
-	registrars, err := serviceComponentManagerRegistrars(config)
-	if err != nil {
-		return err
-	}
-
-	for _, registrar := range registrars {
-		registrar(registry)
-	}
-	return nil
-}
-
-// serviceComponentManagerRegistrars returns all component manager factory
-// registrars supported by the Flow service. Add a new compiled-in component
-// manager here when adding a service-supported implementation.
-func serviceComponentManagerRegistrars(
-	config cmconfig.Config,
-) ([]componentManagerRegistrar, error) {
+) (componentmanager.Catalog, error) {
 	computePowerDelay, err := nicoComputePowerDelay(config)
 	if err != nil {
-		return nil, err
+		return componentmanager.Catalog{}, err
 	}
 
-	return []componentManagerRegistrar{
-		func(registry *componentmanager.Registry) {
-			computenico.Register(registry, computePowerDelay)
-		},
-		nvlswitchnico.Register,
-		nvlswitchnsm.Register,
-		powershelfnico.Register,
-		powershelfpsm.Register,
-		mock.RegisterAll,
-	}, nil
+	// Add all component manager descriptors supported by the flow service.
+	descriptors := []componentmanager.Descriptor{
+		computenico.Descriptor(computePowerDelay),
+		nvlswitchnico.Descriptor(),
+		nvlswitchnsm.Descriptor(),
+		powershelfnico.Descriptor(),
+		powershelfpsm.Descriptor(),
+	}
+
+	// Add all mock component manager descriptors.
+	descriptors = append(descriptors, mock.Descriptors()...)
+
+	catalog, err := componentmanager.NewCatalog(descriptors)
+	if err != nil {
+		return componentmanager.Catalog{}, fmt.Errorf(
+			"build component manager catalog: %w",
+			err,
+		)
+	}
+
+	return catalog, nil
 }
 
 func nicoComputePowerDelay(config cmconfig.Config) (time.Duration, error) {

--- a/flow/internal/task/componentmanager/builtin/component_manager_factories_test.go
+++ b/flow/internal/task/componentmanager/builtin/component_manager_factories_test.go
@@ -27,10 +27,17 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager"
+	computenico "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/compute/nico"
 	cmconfig "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/config"
 	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/mock"
+	nvlswitchnico "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/nvlswitch/nico"
+	nvlswitchnsm "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/nvlswitch/nvswitchmanager"
+	powershelfnico "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/powershelf/nico"
+	powershelfpsm "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/powershelf/psm"
 	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/providerapi"
 	nicoprovider "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/providers/nico"
+	nsmprovider "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/providers/nvswitchmanager"
+	psmprovider "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/providers/psm"
 	"github.com/NVIDIA/infra-controller-rest/flow/pkg/common/devicetypes"
 )
 
@@ -68,6 +75,152 @@ func TestNewComponentManagerRegistryInitializesBuiltInMockManagers(t *testing.T)
 		require.NoError(t, err)
 		assert.Equal(t, componentType, manager.Type())
 	}
+}
+
+func TestNewComponentManagerRegistryRejectsImplementationForWrongType(t *testing.T) {
+	config := cmconfig.Config{
+		ComponentManagers: map[devicetypes.ComponentType]string{
+			devicetypes.ComponentTypeCompute: nvlswitchnsm.ImplementationName,
+		},
+	}
+
+	registry, err := NewComponentManagerRegistry(
+		config,
+		providerapi.NewProviderRegistry(),
+	)
+
+	require.Nil(t, registry)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, componentmanager.ErrUnknownComponentManagerImplementation))
+
+	var implErr componentmanager.UnknownComponentManagerImplementationError
+	require.True(t, errors.As(err, &implErr))
+	assert.Equal(t, devicetypes.ComponentTypeCompute, implErr.ComponentType)
+	assert.Equal(t, nvlswitchnsm.ImplementationName, implErr.Implementation)
+	assert.ElementsMatch(
+		t,
+		[]string{computenico.ImplementationName, mock.ImplementationName},
+		implErr.Available,
+	)
+	assert.Equal(
+		t,
+		[]devicetypes.ComponentType{devicetypes.ComponentTypeNVLSwitch},
+		implErr.RegisteredFor,
+	)
+}
+
+func TestServiceCatalog(t *testing.T) {
+	catalog, err := serviceCatalog(cmconfig.Config{})
+
+	require.NoError(t, err)
+
+	implementations := catalog.ListImplementations()
+	assert.Equal(
+		t,
+		[]string{mock.ImplementationName, computenico.ImplementationName},
+		implementations[devicetypes.ComponentTypeCompute],
+	)
+	assert.Equal(
+		t,
+		[]string{
+			mock.ImplementationName,
+			nvlswitchnico.ImplementationName,
+			nvlswitchnsm.ImplementationName,
+		},
+		implementations[devicetypes.ComponentTypeNVLSwitch],
+	)
+	assert.Equal(
+		t,
+		[]string{
+			mock.ImplementationName,
+			powershelfnico.ImplementationName,
+			powershelfpsm.ImplementationName,
+		},
+		implementations[devicetypes.ComponentTypePowerShelf],
+	)
+
+	assert.Equal(
+		t,
+		[]string{nicoprovider.ProviderName},
+		requireDescriptor(
+			t,
+			catalog,
+			devicetypes.ComponentTypeCompute,
+			computenico.ImplementationName,
+		).RequiredProviders,
+	)
+	assert.Equal(
+		t,
+		[]string{nicoprovider.ProviderName},
+		requireDescriptor(
+			t,
+			catalog,
+			devicetypes.ComponentTypeNVLSwitch,
+			nvlswitchnico.ImplementationName,
+		).RequiredProviders,
+	)
+	assert.Equal(
+		t,
+		[]string{nsmprovider.ProviderName},
+		requireDescriptor(
+			t,
+			catalog,
+			devicetypes.ComponentTypeNVLSwitch,
+			nvlswitchnsm.ImplementationName,
+		).RequiredProviders,
+	)
+	assert.Equal(
+		t,
+		[]string{nicoprovider.ProviderName},
+		requireDescriptor(
+			t,
+			catalog,
+			devicetypes.ComponentTypePowerShelf,
+			powershelfnico.ImplementationName,
+		).RequiredProviders,
+	)
+	assert.Equal(
+		t,
+		[]string{psmprovider.ProviderName},
+		requireDescriptor(
+			t,
+			catalog,
+			devicetypes.ComponentTypePowerShelf,
+			powershelfpsm.ImplementationName,
+		).RequiredProviders,
+	)
+	assert.Empty(t, requireDescriptor(
+		t,
+		catalog,
+		devicetypes.ComponentTypeCompute,
+		mock.ImplementationName,
+	).RequiredProviders)
+	assert.Empty(t, requireDescriptor(
+		t,
+		catalog,
+		devicetypes.ComponentTypeNVLSwitch,
+		mock.ImplementationName,
+	).RequiredProviders)
+	assert.Empty(t, requireDescriptor(
+		t,
+		catalog,
+		devicetypes.ComponentTypePowerShelf,
+		mock.ImplementationName,
+	).RequiredProviders)
+}
+
+func requireDescriptor(
+	t *testing.T,
+	catalog componentmanager.Catalog,
+	componentType devicetypes.ComponentType,
+	implementation string,
+) componentmanager.Descriptor {
+	t.Helper()
+
+	descriptor, ok := catalog.Get(componentType, implementation)
+	require.True(t, ok)
+	require.NotNil(t, descriptor.Factory)
+	return descriptor
 }
 
 func TestNicoComputePowerDelayUsesProviderConfig(t *testing.T) {

--- a/flow/internal/task/componentmanager/componentmanager.go
+++ b/flow/internal/task/componentmanager/componentmanager.go
@@ -19,9 +19,9 @@ package componentmanager
 
 import (
 	"context"
+	"slices"
+	"strings"
 	"sync"
-
-	"github.com/rs/zerolog/log"
 
 	cmconfig "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/config"
 	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/providerapi"
@@ -81,83 +81,162 @@ type FirmwareConsistencyChecker interface {
 // It receives a ProviderRegistry from which it can retrieve the providers it needs.
 type ManagerFactory func(providers *providerapi.ProviderRegistry) (ComponentManager, error)
 
-// Registry maintains a collection of component manager factories and active managers.
-// It allows dynamic registration and selection of implementations per component type.
-type Registry struct {
-	mu        sync.RWMutex
-	factories map[devicetypes.ComponentType]map[string]ManagerFactory // type -> impl_name -> factory
-	active    map[devicetypes.ComponentType]ComponentManager          // type -> active manager
+// Descriptor describes a component manager implementation registered in
+// this process. The descriptor identity is Type plus Implementation; provider
+// names stay separate because one manager can require multiple providers and
+// one provider can serve multiple component manager implementations.
+type Descriptor struct {
+	Type              devicetypes.ComponentType
+	Implementation    string
+	RequiredProviders []string
+	Factory           ManagerFactory
 }
 
-// NewRegistry creates a new Registry instance.
-func NewRegistry() *Registry {
-	return &Registry{
-		factories: make(map[devicetypes.ComponentType]map[string]ManagerFactory),
-		active:    make(map[devicetypes.ComponentType]ComponentManager),
+// Catalog contains the component manager implementations supported by a
+// particular binary. Service-specific packages such as builtin own the list of
+// descriptors that goes into a catalog.
+type Catalog struct {
+	descriptors map[devicetypes.ComponentType]map[string]Descriptor // type -> impl_name -> descriptor
+}
+
+// NewCatalog validates descriptors and indexes them by component type and
+// implementation.
+func NewCatalog(descriptors []Descriptor) (Catalog, error) {
+	catalog := Catalog{
+		descriptors: make(map[devicetypes.ComponentType]map[string]Descriptor),
 	}
+
+	for _, descriptor := range descriptors {
+		descriptor, err := descriptor.normalize()
+		if err != nil {
+			return Catalog{}, err
+		}
+
+		if _, ok := catalog.descriptors[descriptor.Type]; !ok {
+			catalog.descriptors[descriptor.Type] = make(map[string]Descriptor)
+		}
+
+		if _, exists := catalog.descriptors[descriptor.Type][descriptor.Implementation]; exists {
+			return Catalog{}, DuplicateDescriptorError{
+				ComponentType:  descriptor.Type,
+				Implementation: descriptor.Implementation,
+			}
+		}
+
+		catalog.descriptors[descriptor.Type][descriptor.Implementation] = descriptor
+	}
+
+	return catalog, nil
 }
 
-// RegisterFactory registers a factory for a specific component type and implementation name.
-// Returns false if a factory with the same type and name already exists.
-func (r *Registry) RegisterFactory(
+// Get returns the descriptor for a component type and implementation.
+func (c Catalog) Get(
 	componentType devicetypes.ComponentType,
-	implName string,
-	factory ManagerFactory,
-) bool {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	if _, ok := r.factories[componentType]; !ok {
-		r.factories[componentType] = make(map[string]ManagerFactory)
+	implementation string,
+) (Descriptor, bool) {
+	descriptors := c.descriptors[componentType]
+	if descriptors == nil {
+		return Descriptor{}, false
 	}
 
-	if _, exists := r.factories[componentType][implName]; exists {
-		log.Warn().
-			Str("component_type", devicetypes.ComponentTypeToString(componentType)).
-			Str("impl_name", implName).
-			Msg("Factory already registered, skipping")
-		return false
-	}
-
-	r.factories[componentType][implName] = factory
-	log.Debug().
-		Str("component_type", devicetypes.ComponentTypeToString(componentType)).
-		Str("impl_name", implName).
-		Msg("Registered component manager factory")
-	return true
+	descriptor, ok := descriptors[implementation]
+	return descriptor, ok
 }
 
-// Initialize creates and activates component managers based on the provided configuration.
-// The config maps component types to implementation names.
-func (r *Registry) Initialize(
+// Implementations returns the implementations registered for a component type.
+func (c Catalog) Implementations(
+	componentType devicetypes.ComponentType,
+) []string {
+	return descriptorImplementationNames(c.descriptors[componentType])
+}
+
+// ListImplementations returns all registered implementation names by component
+// type.
+func (c Catalog) ListImplementations() map[devicetypes.ComponentType][]string {
+	result := make(map[devicetypes.ComponentType][]string)
+	for componentType, descriptors := range c.descriptors {
+		result[componentType] = descriptorImplementationNames(descriptors)
+	}
+	return result
+}
+
+func (c Catalog) componentTypesForImplementation(
+	implementation string,
+) []devicetypes.ComponentType {
+	types := make([]devicetypes.ComponentType, 0)
+	for componentType, descriptors := range c.descriptors {
+		if _, ok := descriptors[implementation]; ok {
+			types = append(types, componentType)
+		}
+	}
+	slices.Sort(types)
+	return types
+}
+
+type activeManager struct {
+	descriptor Descriptor
+	manager    ComponentManager
+}
+
+// Registry maintains the active component managers selected from a catalog.
+type Registry struct {
+	mu     sync.RWMutex
+	active map[devicetypes.ComponentType]activeManager
+}
+
+// NewRegistry creates and initializes a Registry from the supplied catalog and
+// component manager configuration.
+func NewRegistry(
+	catalog Catalog,
+	config cmconfig.Config,
+	providers *providerapi.ProviderRegistry,
+) (*Registry, error) {
+	registry := &Registry{
+		active: make(map[devicetypes.ComponentType]activeManager),
+	}
+
+	if err := registry.initialize(catalog, config, providers); err != nil {
+		return nil, err
+	}
+
+	return registry, nil
+}
+
+func (r *Registry) initialize(
+	catalog Catalog,
 	config cmconfig.Config,
 	providers *providerapi.ProviderRegistry,
 ) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	activeManagers := make(
+		map[devicetypes.ComponentType]activeManager,
+		len(config.ComponentManagers),
+	)
 
 	for componentType, implName := range config.ComponentManagers {
-		factories, ok := r.factories[componentType]
+		descriptor, ok := catalog.Get(componentType, implName)
 		if !ok {
+			available := catalog.Implementations(componentType)
+			if len(available) == 0 {
+				return ComponentManagerFactoryNotRegisteredError{
+					ComponentType: componentType,
+				}
+			}
+
+			return UnknownComponentManagerImplementationError{
+				ComponentType:  componentType,
+				Implementation: implName,
+				Available:      available,
+				RegisteredFor:  catalog.componentTypesForImplementation(implName),
+			}
+		}
+
+		if descriptor.Factory == nil {
 			return ComponentManagerFactoryNotRegisteredError{
 				ComponentType: componentType,
 			}
 		}
 
-		factory, ok := factories[implName]
-		if !ok {
-			available := make([]string, 0, len(factories))
-			for name := range factories {
-				available = append(available, name)
-			}
-			return UnknownComponentManagerImplementationError{
-				ComponentType:  componentType,
-				Implementation: implName,
-				Available:      available,
-			}
-		}
-
-		manager, err := factory(providers)
+		manager, err := descriptor.Factory(providers)
 		if err != nil {
 			return ManagerCreationError{
 				ComponentType:  componentType,
@@ -166,12 +245,15 @@ func (r *Registry) Initialize(
 			}
 		}
 
-		r.active[componentType] = manager
-		log.Info().
-			Str("component_type", devicetypes.ComponentTypeToString(componentType)).
-			Str("impl_name", implName).
-			Msg("Initialized component manager")
+		activeManagers[componentType] = activeManager{
+			descriptor: descriptor,
+			manager:    manager,
+		}
 	}
+
+	r.mu.Lock()
+	r.active = activeManagers
+	r.mu.Unlock()
 
 	return nil
 }
@@ -188,7 +270,7 @@ func (r *Registry) FindManager(
 
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.active[componentType]
+	return r.active[componentType].manager
 }
 
 // GetManager returns the active manager for the specified component type.
@@ -204,12 +286,32 @@ func (r *Registry) GetManager(
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	manager := r.active[componentType]
-	if manager == nil {
+	active := r.active[componentType]
+	if active.manager == nil {
 		return nil, ManagerNotConfiguredError{ComponentType: componentType}
 	}
 
-	return manager, nil
+	return active.manager, nil
+}
+
+// GetDescriptor returns the descriptor selected for the specified component
+// type.
+func (r *Registry) GetDescriptor(
+	componentType devicetypes.ComponentType,
+) (Descriptor, error) {
+	if r == nil {
+		return Descriptor{}, ErrRegistryNotConfigured
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	active, ok := r.active[componentType]
+	if !ok {
+		return Descriptor{}, ManagerNotConfiguredError{ComponentType: componentType}
+	}
+
+	return active.descriptor, nil
 }
 
 // GetAllManagers returns all active managers.
@@ -218,24 +320,59 @@ func (r *Registry) GetAllManagers() []ComponentManager {
 	defer r.mu.RUnlock()
 
 	managers := make([]ComponentManager, 0, len(r.active))
-	for _, manager := range r.active {
-		managers = append(managers, manager)
+	for _, active := range r.active {
+		managers = append(managers, active.manager)
 	}
 	return managers
 }
 
-// ListRegisteredImplementations returns a map of component types to their registered implementation names.
-func (r *Registry) ListRegisteredImplementations() map[devicetypes.ComponentType][]string {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
-	result := make(map[devicetypes.ComponentType][]string)
-	for componentType, factories := range r.factories {
-		names := make([]string, 0, len(factories))
-		for name := range factories {
-			names = append(names, name)
+func (d Descriptor) normalize() (Descriptor, error) {
+	if d.Type == devicetypes.ComponentTypeUnknown {
+		return Descriptor{}, UnknownComponentTypeError{
+			Name: devicetypes.ComponentTypeToString(d.Type),
 		}
-		result[componentType] = names
 	}
-	return result
+
+	d.Implementation = strings.TrimSpace(d.Implementation)
+	if d.Implementation == "" {
+		return Descriptor{}, ComponentManagerImplementationNameEmptyError{
+			ComponentType: d.Type,
+		}
+	}
+
+	if d.Factory == nil {
+		return Descriptor{}, ComponentManagerFactoryNotConfiguredError{
+			ComponentType:  d.Type,
+			Implementation: d.Implementation,
+		}
+	}
+
+	requiredProviders := make([]string, 0, len(d.RequiredProviders))
+	seen := make(map[string]struct{}, len(d.RequiredProviders))
+	for _, name := range d.RequiredProviders {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			return Descriptor{}, providerapi.ErrProviderNameEmpty
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		requiredProviders = append(requiredProviders, name)
+	}
+	slices.Sort(requiredProviders)
+	d.RequiredProviders = requiredProviders
+
+	return d, nil
+}
+
+func descriptorImplementationNames(
+	descriptors map[string]Descriptor,
+) []string {
+	names := make([]string, 0, len(descriptors))
+	for name := range descriptors {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
 }

--- a/flow/internal/task/componentmanager/componentmanager_test.go
+++ b/flow/internal/task/componentmanager/componentmanager_test.go
@@ -18,6 +18,7 @@
 package componentmanager
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -25,8 +26,163 @@ import (
 
 	cmconfig "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/config"
 	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/providerapi"
+	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/executor/temporalworkflow/common"
+	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/operations"
 	"github.com/NVIDIA/infra-controller-rest/flow/pkg/common/devicetypes"
 )
+
+type testManager struct {
+	componentType devicetypes.ComponentType
+}
+
+func (m testManager) Type() devicetypes.ComponentType {
+	return m.componentType
+}
+
+func (m testManager) InjectExpectation(
+	context.Context,
+	common.Target,
+	operations.InjectExpectationTaskInfo,
+) error {
+	return nil
+}
+
+func (m testManager) PowerControl(
+	context.Context,
+	common.Target,
+	operations.PowerControlTaskInfo,
+) error {
+	return nil
+}
+
+func (m testManager) GetPowerStatus(
+	context.Context,
+	common.Target,
+) (map[string]operations.PowerStatus, error) {
+	return nil, nil
+}
+
+func (m testManager) FirmwareControl(
+	context.Context,
+	common.Target,
+	operations.FirmwareControlTaskInfo,
+) error {
+	return nil
+}
+
+func (m testManager) GetFirmwareStatus(
+	context.Context,
+	common.Target,
+) (map[string]operations.FirmwareUpdateStatus, error) {
+	return nil, nil
+}
+
+func managerFactory(
+	componentType devicetypes.ComponentType,
+) ManagerFactory {
+	return func(*providerapi.ProviderRegistry) (ComponentManager, error) {
+		return testManager{componentType: componentType}, nil
+	}
+}
+
+func TestNewCatalog(t *testing.T) {
+	catalog, err := NewCatalog([]Descriptor{
+		{
+			Type:              devicetypes.ComponentTypeCompute,
+			Implementation:    " custom ",
+			RequiredProviders: []string{" beta ", "alpha", "beta"},
+			Factory:           managerFactory(devicetypes.ComponentTypeCompute),
+		},
+	})
+
+	require.NoError(t, err)
+
+	descriptor, ok := catalog.Get(devicetypes.ComponentTypeCompute, "custom")
+	require.True(t, ok)
+	require.Equal(t, devicetypes.ComponentTypeCompute, descriptor.Type)
+	require.Equal(t, "custom", descriptor.Implementation)
+	require.Equal(t, []string{"alpha", "beta"}, descriptor.RequiredProviders)
+	require.NotNil(t, descriptor.Factory)
+
+	require.Equal(
+		t,
+		[]string{"custom"},
+		catalog.Implementations(devicetypes.ComponentTypeCompute),
+	)
+}
+
+func TestNewCatalogRejectsDuplicate(t *testing.T) {
+	descriptor := Descriptor{
+		Type:           devicetypes.ComponentTypeCompute,
+		Implementation: "custom",
+		Factory:        managerFactory(devicetypes.ComponentTypeCompute),
+	}
+
+	_, err := NewCatalog([]Descriptor{descriptor, descriptor})
+
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrDuplicateDescriptor))
+
+	var duplicateErr DuplicateDescriptorError
+	require.True(t, errors.As(err, &duplicateErr))
+	require.Equal(t, devicetypes.ComponentTypeCompute, duplicateErr.ComponentType)
+	require.Equal(t, "custom", duplicateErr.Implementation)
+}
+
+func TestNewCatalogValidation(t *testing.T) {
+	factory := managerFactory(devicetypes.ComponentTypeCompute)
+
+	tests := []struct {
+		name       string
+		descriptor Descriptor
+		wantErr    error
+	}{
+		{
+			name: "unknown component type",
+			descriptor: Descriptor{
+				Type:           devicetypes.ComponentTypeUnknown,
+				Implementation: "custom",
+				Factory:        factory,
+			},
+			wantErr: ErrUnknownComponentType,
+		},
+		{
+			name: "empty implementation",
+			descriptor: Descriptor{
+				Type:    devicetypes.ComponentTypeCompute,
+				Factory: factory,
+			},
+			wantErr: ErrComponentManagerImplementationNameEmpty,
+		},
+		{
+			name: "nil factory",
+			descriptor: Descriptor{
+				Type:           devicetypes.ComponentTypeCompute,
+				Implementation: "custom",
+			},
+			wantErr: ErrComponentManagerFactoryNotConfigured,
+		},
+		{
+			name: "empty required provider",
+			descriptor: Descriptor{
+				Type:              devicetypes.ComponentTypeCompute,
+				Implementation:    "custom",
+				RequiredProviders: []string{" "},
+				Factory:           factory,
+			},
+			wantErr: ErrProviderNameEmpty,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewCatalog([]Descriptor{tt.descriptor})
+
+			require.Error(t, err)
+			require.True(t, errors.Is(err, tt.wantErr))
+		})
+	}
+}
 
 func TestRegistryGetManager(t *testing.T) {
 	t.Run("nil registry", func(t *testing.T) {
@@ -40,7 +196,12 @@ func TestRegistryGetManager(t *testing.T) {
 	})
 
 	t.Run("missing active manager", func(t *testing.T) {
-		registry := NewRegistry()
+		registry, err := NewRegistry(
+			Catalog{},
+			cmconfig.Config{},
+			providerapi.NewProviderRegistry(),
+		)
+		require.NoError(t, err)
 
 		manager, err := registry.GetManager(devicetypes.ComponentTypeCompute)
 
@@ -54,15 +215,45 @@ func TestRegistryGetManager(t *testing.T) {
 	})
 }
 
-func TestRegistryInitializeErrors(t *testing.T) {
-	t.Run("factory not registered", func(t *testing.T) {
-		registry := NewRegistry()
+func TestRegistryGetDescriptor(t *testing.T) {
+	catalog, err := NewCatalog([]Descriptor{
+		{
+			Type:           devicetypes.ComponentTypeCompute,
+			Implementation: "custom",
+			Factory:        managerFactory(devicetypes.ComponentTypeCompute),
+		},
+	})
+	require.NoError(t, err)
 
-		err := registry.Initialize(cmconfig.Config{
+	registry, err := NewRegistry(
+		catalog,
+		cmconfig.Config{
 			ComponentManagers: map[devicetypes.ComponentType]string{
-				devicetypes.ComponentTypeCompute: "mock",
+				devicetypes.ComponentTypeCompute: "custom",
 			},
-		}, providerapi.NewProviderRegistry())
+		},
+		providerapi.NewProviderRegistry(),
+	)
+	require.NoError(t, err)
+
+	descriptor, err := registry.GetDescriptor(devicetypes.ComponentTypeCompute)
+
+	require.NoError(t, err)
+	require.Equal(t, devicetypes.ComponentTypeCompute, descriptor.Type)
+	require.Equal(t, "custom", descriptor.Implementation)
+}
+
+func TestNewRegistryErrors(t *testing.T) {
+	t.Run("factory not registered", func(t *testing.T) {
+		_, err := NewRegistry(
+			Catalog{},
+			cmconfig.Config{
+				ComponentManagers: map[devicetypes.ComponentType]string{
+					devicetypes.ComponentTypeCompute: "mock",
+				},
+			},
+			providerapi.NewProviderRegistry(),
+		)
 
 		require.Error(t, err)
 		require.True(t, errors.Is(err, ErrComponentManagerFactoryNotRegistered))
@@ -73,20 +264,24 @@ func TestRegistryInitializeErrors(t *testing.T) {
 	})
 
 	t.Run("unknown implementation", func(t *testing.T) {
-		registry := NewRegistry()
-		registry.RegisterFactory(
-			devicetypes.ComponentTypeCompute,
-			"known",
-			func(*providerapi.ProviderRegistry) (ComponentManager, error) {
-				return nil, nil
+		catalog, err := NewCatalog([]Descriptor{
+			{
+				Type:           devicetypes.ComponentTypeCompute,
+				Implementation: "known",
+				Factory:        managerFactory(devicetypes.ComponentTypeCompute),
 			},
-		)
+		})
+		require.NoError(t, err)
 
-		err := registry.Initialize(cmconfig.Config{
-			ComponentManagers: map[devicetypes.ComponentType]string{
-				devicetypes.ComponentTypeCompute: "missing",
+		_, err = NewRegistry(
+			catalog,
+			cmconfig.Config{
+				ComponentManagers: map[devicetypes.ComponentType]string{
+					devicetypes.ComponentTypeCompute: "missing",
+				},
 			},
-		}, providerapi.NewProviderRegistry())
+			providerapi.NewProviderRegistry(),
+		)
 
 		require.Error(t, err)
 		require.True(t, errors.Is(err, ErrUnknownComponentManagerImplementation))
@@ -98,22 +293,66 @@ func TestRegistryInitializeErrors(t *testing.T) {
 		require.ElementsMatch(t, []string{"known"}, implErr.Available)
 	})
 
-	t.Run("manager creation failed", func(t *testing.T) {
-		rootErr := errors.New("boom")
-		registry := NewRegistry()
-		registry.RegisterFactory(
-			devicetypes.ComponentTypeCompute,
-			"broken",
-			func(*providerapi.ProviderRegistry) (ComponentManager, error) {
-				return nil, rootErr
+	t.Run("implementation registered for another type", func(t *testing.T) {
+		catalog, err := NewCatalog([]Descriptor{
+			{
+				Type:           devicetypes.ComponentTypeCompute,
+				Implementation: "nico",
+				Factory:        managerFactory(devicetypes.ComponentTypeCompute),
 			},
+			{
+				Type:           devicetypes.ComponentTypeNVLSwitch,
+				Implementation: "nvswitchmanager",
+				Factory:        managerFactory(devicetypes.ComponentTypeNVLSwitch),
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = NewRegistry(
+			catalog,
+			cmconfig.Config{
+				ComponentManagers: map[devicetypes.ComponentType]string{
+					devicetypes.ComponentTypeCompute: "nvswitchmanager",
+				},
+			},
+			providerapi.NewProviderRegistry(),
 		)
 
-		err := registry.Initialize(cmconfig.Config{
-			ComponentManagers: map[devicetypes.ComponentType]string{
-				devicetypes.ComponentTypeCompute: "broken",
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrUnknownComponentManagerImplementation))
+
+		var implErr UnknownComponentManagerImplementationError
+		require.True(t, errors.As(err, &implErr))
+		require.Equal(t, devicetypes.ComponentTypeCompute, implErr.ComponentType)
+		require.Equal(t, "nvswitchmanager", implErr.Implementation)
+		require.Equal(t, []string{"nico"}, implErr.Available)
+		require.Equal(t, []devicetypes.ComponentType{
+			devicetypes.ComponentTypeNVLSwitch,
+		}, implErr.RegisteredFor)
+	})
+
+	t.Run("manager creation failed", func(t *testing.T) {
+		rootErr := errors.New("boom")
+		catalog, err := NewCatalog([]Descriptor{
+			{
+				Type:           devicetypes.ComponentTypeCompute,
+				Implementation: "broken",
+				Factory: func(*providerapi.ProviderRegistry) (ComponentManager, error) {
+					return nil, rootErr
+				},
 			},
-		}, providerapi.NewProviderRegistry())
+		})
+		require.NoError(t, err)
+
+		_, err = NewRegistry(
+			catalog,
+			cmconfig.Config{
+				ComponentManagers: map[devicetypes.ComponentType]string{
+					devicetypes.ComponentTypeCompute: "broken",
+				},
+			},
+			providerapi.NewProviderRegistry(),
+		)
 
 		require.Error(t, err)
 		require.True(t, errors.Is(err, ErrManagerCreationFailed))
@@ -136,7 +375,12 @@ func TestRegistryFindManager(t *testing.T) {
 	})
 
 	t.Run("missing active manager", func(t *testing.T) {
-		registry := NewRegistry()
+		registry, err := NewRegistry(
+			Catalog{},
+			cmconfig.Config{},
+			providerapi.NewProviderRegistry(),
+		)
+		require.NoError(t, err)
 
 		manager := registry.FindManager(devicetypes.ComponentTypeCompute)
 

--- a/flow/internal/task/componentmanager/compute/nico/nico.go
+++ b/flow/internal/task/componentmanager/compute/nico/nico.go
@@ -64,9 +64,9 @@ func New(nicoClient nicoapi.Client, powerDelay time.Duration) *Manager {
 	}
 }
 
-// Register registers the NICo compute manager factory with the given registry.
-// powerDelay is the inter-component stagger for power control calls.
-func Register(registry *componentmanager.Registry, powerDelay time.Duration) {
+// Descriptor returns the NICo compute manager descriptor. powerDelay is the
+// inter-component stagger for power control calls.
+func Descriptor(powerDelay time.Duration) componentmanager.Descriptor {
 	factory := func(
 		providerRegistry *providerapi.ProviderRegistry,
 	) (componentmanager.ComponentManager, error) {
@@ -81,7 +81,12 @@ func Register(registry *componentmanager.Registry, powerDelay time.Duration) {
 		}
 		return New(provider.Client(), powerDelay), nil
 	}
-	registry.RegisterFactory(devicetypes.ComponentTypeCompute, ImplementationName, factory)
+	return componentmanager.Descriptor{
+		Type:              devicetypes.ComponentTypeCompute,
+		Implementation:    ImplementationName,
+		RequiredProviders: []string{nicoprovider.ProviderName},
+		Factory:           factory,
+	}
 }
 
 // Type returns the component type this manager handles.

--- a/flow/internal/task/componentmanager/errors.go
+++ b/flow/internal/task/componentmanager/errors.go
@@ -40,6 +40,14 @@ var (
 	// registered for a component type.
 	ErrComponentManagerFactoryNotRegistered = errors.New("component manager factory is not registered")
 
+	// ErrComponentManagerFactoryNotConfigured reports that a descriptor was
+	// registered without a factory.
+	ErrComponentManagerFactoryNotConfigured = errors.New("component manager factory is not configured")
+
+	// ErrDuplicateDescriptor reports duplicate descriptor
+	// registration for the same component type and implementation.
+	ErrDuplicateDescriptor = errors.New("duplicate component manager descriptor")
+
 	// ErrUnknownComponentManagerImplementation reports that the configured
 	// implementation name is not registered for a component type.
 	ErrUnknownComponentManagerImplementation = errors.New("unknown component manager implementation")
@@ -139,23 +147,74 @@ func (e ComponentManagerFactoryNotRegisteredError) Is(target error) bool {
 	return target == ErrComponentManagerFactoryNotRegistered
 }
 
+// ComponentManagerFactoryNotConfiguredError includes the descriptor identity
+// that has no factory.
+type ComponentManagerFactoryNotConfiguredError struct {
+	ComponentType  devicetypes.ComponentType
+	Implementation string
+}
+
+func (e ComponentManagerFactoryNotConfiguredError) Error() string {
+	return fmt.Sprintf(
+		"factory is not configured for component type %s with implementation %q",
+		devicetypes.ComponentTypeToString(e.ComponentType),
+		e.Implementation,
+	)
+}
+
+func (e ComponentManagerFactoryNotConfiguredError) Is(target error) bool {
+	return target == ErrComponentManagerFactoryNotConfigured
+}
+
+// DuplicateDescriptorError includes the duplicate descriptor identity.
+type DuplicateDescriptorError struct {
+	ComponentType  devicetypes.ComponentType
+	Implementation string
+}
+
+func (e DuplicateDescriptorError) Error() string {
+	return fmt.Sprintf(
+		"duplicate component manager descriptor for component type %s with implementation %q",
+		devicetypes.ComponentTypeToString(e.ComponentType),
+		e.Implementation,
+	)
+}
+
+func (e DuplicateDescriptorError) Is(target error) bool {
+	return target == ErrDuplicateDescriptor
+}
+
 // UnknownComponentManagerImplementationError includes the implementation name
 // that was requested and the implementations that were available.
 type UnknownComponentManagerImplementationError struct {
 	ComponentType  devicetypes.ComponentType
 	Implementation string
 	Available      []string
+	RegisteredFor  []devicetypes.ComponentType
 }
 
 func (e UnknownComponentManagerImplementationError) Error() string {
 	available := append([]string(nil), e.Available...)
 	sort.Strings(available)
-	return fmt.Sprintf(
+	msg := fmt.Sprintf(
 		"unknown implementation '%s' for component type %s, available: %v",
 		e.Implementation,
 		devicetypes.ComponentTypeToString(e.ComponentType),
 		available,
 	)
+	if len(e.RegisteredFor) == 0 {
+		return msg
+	}
+
+	registeredFor := make([]string, 0, len(e.RegisteredFor))
+	for _, componentType := range e.RegisteredFor {
+		registeredFor = append(
+			registeredFor,
+			devicetypes.ComponentTypeToString(componentType),
+		)
+	}
+	sort.Strings(registeredFor)
+	return fmt.Sprintf("%s; registered for component types: %v", msg, registeredFor)
 }
 
 func (e UnknownComponentManagerImplementationError) Is(target error) bool {

--- a/flow/internal/task/componentmanager/mock/mock.go
+++ b/flow/internal/task/componentmanager/mock/mock.go
@@ -67,15 +67,28 @@ func FactoryFor(componentType devicetypes.ComponentType) componentmanager.Manage
 	}
 }
 
-// RegisterAll registers mock factories for all component types.
-func RegisterAll(registry *componentmanager.Registry) {
+// DescriptorFor returns a mock manager descriptor for the specified component
+// type.
+func DescriptorFor(componentType devicetypes.ComponentType) componentmanager.Descriptor {
+	return componentmanager.Descriptor{
+		Type:           componentType,
+		Implementation: ImplementationName,
+		Factory:        FactoryFor(componentType),
+	}
+}
+
+// Descriptors returns mock descriptors for all component types currently
+// supported by the RLA service.
+func Descriptors() []componentmanager.Descriptor {
+	descriptors := make([]componentmanager.Descriptor, 0, 3)
 	for _, ct := range []devicetypes.ComponentType{
 		devicetypes.ComponentTypeCompute,
 		devicetypes.ComponentTypeNVLSwitch,
 		devicetypes.ComponentTypePowerShelf,
 	} {
-		registry.RegisterFactory(ct, ImplementationName, FactoryFor(ct))
+		descriptors = append(descriptors, DescriptorFor(ct))
 	}
+	return descriptors
 }
 
 // Type returns the component type this manager handles.

--- a/flow/internal/task/componentmanager/nvlswitch/nico/nico.go
+++ b/flow/internal/task/componentmanager/nvlswitch/nico/nico.go
@@ -66,9 +66,14 @@ func Factory(providerRegistry *providerapi.ProviderRegistry) (componentmanager.C
 	return New(provider.Client()), nil
 }
 
-// Register registers the NICo NVLSwitch manager factory with the given registry.
-func Register(registry *componentmanager.Registry) {
-	registry.RegisterFactory(devicetypes.ComponentTypeNVLSwitch, ImplementationName, Factory)
+// Descriptor returns the NICo NVLSwitch manager descriptor.
+func Descriptor() componentmanager.Descriptor {
+	return componentmanager.Descriptor{
+		Type:              devicetypes.ComponentTypeNVLSwitch,
+		Implementation:    ImplementationName,
+		RequiredProviders: []string{nicoprovider.ProviderName},
+		Factory:           Factory,
+	}
 }
 
 // Type returns the component type this manager handles.

--- a/flow/internal/task/componentmanager/nvlswitch/nvswitchmanager/nvswitchmanager.go
+++ b/flow/internal/task/componentmanager/nvlswitch/nvswitchmanager/nvswitchmanager.go
@@ -63,9 +63,14 @@ func Factory(providerRegistry *providerapi.ProviderRegistry) (componentmanager.C
 	return New(provider.Client()), nil
 }
 
-// Register registers the NV-Switch Manager NVLSwitch manager factory with the given registry.
-func Register(registry *componentmanager.Registry) {
-	registry.RegisterFactory(devicetypes.ComponentTypeNVLSwitch, ImplementationName, Factory)
+// Descriptor returns the NV-Switch Manager NVLSwitch manager descriptor.
+func Descriptor() componentmanager.Descriptor {
+	return componentmanager.Descriptor{
+		Type:              devicetypes.ComponentTypeNVLSwitch,
+		Implementation:    ImplementationName,
+		RequiredProviders: []string{nsmprovider.ProviderName},
+		Factory:           Factory,
+	}
 }
 
 // Type returns the component type this manager handles.

--- a/flow/internal/task/componentmanager/powershelf/nico/nico.go
+++ b/flow/internal/task/componentmanager/powershelf/nico/nico.go
@@ -59,9 +59,14 @@ func Factory(providerRegistry *providerapi.ProviderRegistry) (componentmanager.C
 	return New(provider.Client()), nil
 }
 
-// Register registers the NICo PowerShelf manager factory with the given registry.
-func Register(registry *componentmanager.Registry) {
-	registry.RegisterFactory(devicetypes.ComponentTypePowerShelf, ImplementationName, Factory)
+// Descriptor returns the NICo PowerShelf manager descriptor.
+func Descriptor() componentmanager.Descriptor {
+	return componentmanager.Descriptor{
+		Type:              devicetypes.ComponentTypePowerShelf,
+		Implementation:    ImplementationName,
+		RequiredProviders: []string{nicoprovider.ProviderName},
+		Factory:           Factory,
+	}
 }
 
 func (m *Manager) Type() devicetypes.ComponentType {

--- a/flow/internal/task/componentmanager/powershelf/psm/psm.go
+++ b/flow/internal/task/componentmanager/powershelf/psm/psm.go
@@ -66,9 +66,14 @@ func Factory(
 	return New(provider.Client()), nil
 }
 
-// Register registers the PSM PowerShelf manager factory with the given registry.
-func Register(registry *componentmanager.Registry) {
-	registry.RegisterFactory(devicetypes.ComponentTypePowerShelf, ImplementationName, Factory)
+// Descriptor returns the PSM PowerShelf manager descriptor.
+func Descriptor() componentmanager.Descriptor {
+	return componentmanager.Descriptor{
+		Type:              devicetypes.ComponentTypePowerShelf,
+		Implementation:    ImplementationName,
+		RequiredProviders: []string{psmprovider.ProviderName},
+		Factory:           Factory,
+	}
 }
 
 // Type returns the component type this manager handles.

--- a/flow/internal/task/executor/temporalworkflow/activity/activity_test.go
+++ b/flow/internal/task/executor/temporalworkflow/activity/activity_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager"
+	cmconfig "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/config"
+	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/providerapi"
 	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/executor/temporalworkflow/common"
 	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/operations"
 	"github.com/NVIDIA/infra-controller-rest/flow/pkg/common/devicetypes"
@@ -43,7 +45,14 @@ func TestActivitiesReturnErrorWhenComponentManagerRegistryIsMissing(t *testing.T
 }
 
 func TestActivitiesReturnErrorWhenComponentManagerIsMissing(t *testing.T) {
-	acts := New(nil, componentmanager.NewRegistry())
+	registry, err := componentmanager.NewRegistry(
+		componentmanager.Catalog{},
+		cmconfig.Config{},
+		providerapi.NewProviderRegistry(),
+	)
+	require.NoError(t, err)
+
+	acts := New(nil, registry)
 
 	for name, call := range activityCallsForMissingManagerTest(t, acts) {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
- Introduce component manager descriptors and a validated catalog for built-in implementations. The registry now keeps only active descriptor and manager selections while builtin owns the hard-coded service catalog.
- Remove the old manager registration helpers in favor of Descriptor constructors and update component manager docs and tests around catalog-driven initialization.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [x] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [ ] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [x] **RLA** - RLA service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
