### PR TITLE
chore: Rename default Flow config path rlaconfig.yaml -> flowconfig.yaml

### DIFF
--- a/flow/internal/config/config.go
+++ b/flow/internal/config/config.go
@@ -28,7 +28,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const defaultLocation = "/etc/flow/rlaconfig.yaml"
+const defaultLocation = "/etc/flow/flowconfig.yaml"
 
 // Config is a set of configuration operations that will be read from an environment specific config file
 type Config struct {


### PR DESCRIPTION
## Description
Finishes the RLA -> Flow rebrand inside flow/. The default Flow service config location was missed by #520 and was still pointing at /etc/flow/rlaconfig.yaml.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [x] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [ ] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [x] **Flow** - Flow service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
