### PR TITLE
chore: Finish RLA → Flow rename in site-agent default and handler tests

### DIFF
--- a/api/pkg/api/handler/rack_test.go
+++ b/api/pkg/api/handler/rack_test.go
@@ -163,7 +163,7 @@ func TestGetRackHandler_Handle(t *testing.T) {
 	_, site, _ := testRackSetupTestData(t, dbSession, org)
 
 	// Create a site without Flow enabled
-	siteNoRLA := &cdbm.Site{
+	siteNoFlow := &cdbm.Site{
 		ID:                       uuid.New(),
 		Name:                     "test-site-no-flow",
 		Org:                      org,
@@ -171,7 +171,7 @@ func TestGetRackHandler_Handle(t *testing.T) {
 		Status:                   cdbm.SiteStatusRegistered,
 		Config:                   &cdbm.SiteConfig{},
 	}
-	_, err := dbSession.DB.NewInsert().Model(siteNoRLA).Exec(context.Background())
+	_, err := dbSession.DB.NewInsert().Model(siteNoFlow).Exec(context.Background())
 	assert.Nil(t, err)
 
 	// Create provider user
@@ -223,7 +223,7 @@ func TestGetRackHandler_Handle(t *testing.T) {
 			user:   providerUser,
 			rackID: rackID,
 			queryParams: map[string]string{
-				"siteId": siteNoRLA.ID.String(),
+				"siteId": siteNoFlow.ID.String(),
 			},
 			expectedStatus: http.StatusPreconditionFailed,
 			wantErr:        true,
@@ -345,7 +345,7 @@ func TestGetAllRackHandler_Handle(t *testing.T) {
 	_, site, _ := testRackSetupTestData(t, dbSession, org)
 
 	// Create a site without Flow enabled
-	siteNoRLA := &cdbm.Site{
+	siteNoFlow := &cdbm.Site{
 		ID:                       uuid.New(),
 		Name:                     "test-site-no-flow",
 		Org:                      org,
@@ -353,7 +353,7 @@ func TestGetAllRackHandler_Handle(t *testing.T) {
 		Status:                   cdbm.SiteStatusRegistered,
 		Config:                   &cdbm.SiteConfig{},
 	}
-	_, err := dbSession.DB.NewInsert().Model(siteNoRLA).Exec(context.Background())
+	_, err := dbSession.DB.NewInsert().Model(siteNoFlow).Exec(context.Background())
 	assert.Nil(t, err)
 
 	// Create provider user
@@ -512,7 +512,7 @@ func TestGetAllRackHandler_Handle(t *testing.T) {
 			reqOrg: org,
 			user:   providerUser,
 			queryParams: map[string]string{
-				"siteId": siteNoRLA.ID.String(),
+				"siteId": siteNoFlow.ID.String(),
 			},
 			mockResponse:   nil,
 			expectedStatus: http.StatusPreconditionFailed,
@@ -644,7 +644,7 @@ func TestValidateRackHandler_Handle(t *testing.T) {
 	_, site, _ := testRackSetupTestData(t, dbSession, org)
 
 	// Create a site without Flow enabled
-	siteNoRLA := &cdbm.Site{
+	siteNoFlow := &cdbm.Site{
 		ID:                       uuid.New(),
 		Name:                     "test-site-no-flow",
 		Org:                      org,
@@ -652,7 +652,7 @@ func TestValidateRackHandler_Handle(t *testing.T) {
 		Status:                   cdbm.SiteStatusRegistered,
 		Config:                   &cdbm.SiteConfig{},
 	}
-	_, err := dbSession.DB.NewInsert().Model(siteNoRLA).Exec(context.Background())
+	_, err := dbSession.DB.NewInsert().Model(siteNoFlow).Exec(context.Background())
 	assert.Nil(t, err)
 
 	// Create provider user
@@ -727,7 +727,7 @@ func TestValidateRackHandler_Handle(t *testing.T) {
 			user:   providerUser,
 			rackID: rackID,
 			queryParams: map[string]string{
-				"siteId": siteNoRLA.ID.String(),
+				"siteId": siteNoFlow.ID.String(),
 			},
 			mockResponse:   nil,
 			expectedStatus: http.StatusPreconditionFailed,
@@ -849,7 +849,7 @@ func TestValidateRacksHandler_Handle(t *testing.T) {
 	_, site, _ := testRackSetupTestData(t, dbSession, org)
 
 	// Create a site without Flow enabled
-	siteNoRLA := &cdbm.Site{
+	siteNoFlow := &cdbm.Site{
 		ID:                       uuid.New(),
 		Name:                     "test-site-no-flow",
 		Org:                      org,
@@ -857,7 +857,7 @@ func TestValidateRacksHandler_Handle(t *testing.T) {
 		Status:                   cdbm.SiteStatusRegistered,
 		Config:                   &cdbm.SiteConfig{},
 	}
-	_, err := dbSession.DB.NewInsert().Model(siteNoRLA).Exec(context.Background())
+	_, err := dbSession.DB.NewInsert().Model(siteNoFlow).Exec(context.Background())
 	assert.Nil(t, err)
 
 	providerUser := testRackBuildUser(t, dbSession, "provider-user-validate-racks", org, []string{authz.ProviderAdminRole})
@@ -962,7 +962,7 @@ func TestValidateRacksHandler_Handle(t *testing.T) {
 			reqOrg: org,
 			user:   providerUser,
 			queryParams: map[string]string{
-				"siteId": siteNoRLA.ID.String(),
+				"siteId": siteNoFlow.ID.String(),
 			},
 			expectedStatus: http.StatusPreconditionFailed,
 		},

--- a/api/pkg/api/handler/task_test.go
+++ b/api/pkg/api/handler/task_test.go
@@ -56,7 +56,7 @@ func TestGetTaskHandler_Handle(t *testing.T) {
 	org := "test-org"
 	_, site, _ := testRackSetupTestData(t, dbSession, org)
 
-	siteNoRLA := &cdbm.Site{
+	siteNoFlow := &cdbm.Site{
 		ID:                       uuid.New(),
 		Name:                     "test-site-no-flow",
 		Org:                      org,
@@ -64,7 +64,7 @@ func TestGetTaskHandler_Handle(t *testing.T) {
 		Status:                   cdbm.SiteStatusRegistered,
 		Config:                   &cdbm.SiteConfig{},
 	}
-	_, err := dbSession.DB.NewInsert().Model(siteNoRLA).Exec(context.Background())
+	_, err := dbSession.DB.NewInsert().Model(siteNoFlow).Exec(context.Background())
 	assert.Nil(t, err)
 
 	providerUser := testRackBuildUser(t, dbSession, "provider-user-task-get", org, []string{authz.ProviderAdminRole})
@@ -123,7 +123,7 @@ func TestGetTaskHandler_Handle(t *testing.T) {
 			user:     providerUser,
 			taskUUID: taskUUID,
 			queryParams: map[string]string{
-				"siteId": siteNoRLA.ID.String(),
+				"siteId": siteNoFlow.ID.String(),
 			},
 			expectedStatus: http.StatusPreconditionFailed,
 		},
@@ -225,7 +225,7 @@ func TestCancelTaskHandler_Handle(t *testing.T) {
 	org := "test-org"
 	_, site, _ := testRackSetupTestData(t, dbSession, org)
 
-	siteNoRLA := &cdbm.Site{
+	siteNoFlow := &cdbm.Site{
 		ID:                       uuid.New(),
 		Name:                     "test-site-no-flow-cancel",
 		Org:                      org,
@@ -233,7 +233,7 @@ func TestCancelTaskHandler_Handle(t *testing.T) {
 		Status:                   cdbm.SiteStatusRegistered,
 		Config:                   &cdbm.SiteConfig{},
 	}
-	_, err := dbSession.DB.NewInsert().Model(siteNoRLA).Exec(context.Background())
+	_, err := dbSession.DB.NewInsert().Model(siteNoFlow).Exec(context.Background())
 	assert.Nil(t, err)
 
 	providerUser := testRackBuildUser(t, dbSession, "provider-user-task-cancel", org, []string{authz.ProviderAdminRole})
@@ -279,7 +279,7 @@ func TestCancelTaskHandler_Handle(t *testing.T) {
 			reqOrg:         org,
 			user:           providerUser,
 			taskUUID:       taskUUID,
-			body:           model.APICancelTaskRequest{SiteID: siteNoRLA.ID.String()},
+			body:           model.APICancelTaskRequest{SiteID: siteNoFlow.ID.String()},
 			expectedStatus: http.StatusPreconditionFailed,
 		},
 		{

--- a/api/pkg/api/handler/tray_test.go
+++ b/api/pkg/api/handler/tray_test.go
@@ -181,7 +181,7 @@ func TestGetTrayHandler_Handle(t *testing.T) {
 	_, site, _ := testTraySetupTestData(t, dbSession, org)
 
 	// Create a site without Flow enabled
-	siteNoRLA := &cdbm.Site{
+	siteNoFlow := &cdbm.Site{
 		ID:                       uuid.New(),
 		Name:                     "test-site-no-flow",
 		Org:                      org,
@@ -189,7 +189,7 @@ func TestGetTrayHandler_Handle(t *testing.T) {
 		Status:                   cdbm.SiteStatusRegistered,
 		Config:                   &cdbm.SiteConfig{},
 	}
-	_, err := dbSession.DB.NewInsert().Model(siteNoRLA).Exec(context.Background())
+	_, err := dbSession.DB.NewInsert().Model(siteNoFlow).Exec(context.Background())
 	assert.Nil(t, err)
 
 	// Create provider user
@@ -239,7 +239,7 @@ func TestGetTrayHandler_Handle(t *testing.T) {
 			user:   providerUser,
 			trayID: trayID,
 			queryParams: map[string]string{
-				"siteId": siteNoRLA.ID.String(),
+				"siteId": siteNoFlow.ID.String(),
 			},
 			expectedStatus: http.StatusPreconditionFailed,
 			wantErr:        true,
@@ -365,7 +365,7 @@ func TestGetAllTrayHandler_Handle(t *testing.T) {
 	_, site, _ := testTraySetupTestData(t, dbSession, org)
 
 	// Create a site without Flow enabled
-	siteNoRLA := &cdbm.Site{
+	siteNoFlow := &cdbm.Site{
 		ID:                       uuid.New(),
 		Name:                     "test-site-no-flow",
 		Org:                      org,
@@ -373,7 +373,7 @@ func TestGetAllTrayHandler_Handle(t *testing.T) {
 		Status:                   cdbm.SiteStatusRegistered,
 		Config:                   &cdbm.SiteConfig{},
 	}
-	_, err := dbSession.DB.NewInsert().Model(siteNoRLA).Exec(context.Background())
+	_, err := dbSession.DB.NewInsert().Model(siteNoFlow).Exec(context.Background())
 	assert.Nil(t, err)
 
 	// Create provider user
@@ -520,7 +520,7 @@ func TestGetAllTrayHandler_Handle(t *testing.T) {
 			reqOrg: org,
 			user:   providerUser,
 			queryParams: map[string]string{
-				"siteId": siteNoRLA.ID.String(),
+				"siteId": siteNoFlow.ID.String(),
 			},
 			mockResponse:   nil,
 			expectedStatus: http.StatusPreconditionFailed,
@@ -724,7 +724,7 @@ func TestValidateTrayHandler_Handle(t *testing.T) {
 	_, site, _ := testTraySetupTestData(t, dbSession, org)
 
 	// Create a site without Flow enabled
-	siteNoRLA := &cdbm.Site{
+	siteNoFlow := &cdbm.Site{
 		ID:                       uuid.New(),
 		Name:                     "test-site-no-flow",
 		Org:                      org,
@@ -732,7 +732,7 @@ func TestValidateTrayHandler_Handle(t *testing.T) {
 		Status:                   cdbm.SiteStatusRegistered,
 		Config:                   &cdbm.SiteConfig{},
 	}
-	_, err := dbSession.DB.NewInsert().Model(siteNoRLA).Exec(context.Background())
+	_, err := dbSession.DB.NewInsert().Model(siteNoFlow).Exec(context.Background())
 	assert.Nil(t, err)
 
 	providerUser := testTrayBuildUser(t, dbSession, "provider-user-validate-tray", org, []string{authz.ProviderAdminRole})
@@ -808,7 +808,7 @@ func TestValidateTrayHandler_Handle(t *testing.T) {
 			user:   providerUser,
 			trayID: trayID,
 			queryParams: map[string]string{
-				"siteId": siteNoRLA.ID.String(),
+				"siteId": siteNoFlow.ID.String(),
 			},
 			expectedStatus: http.StatusPreconditionFailed,
 		},
@@ -928,7 +928,7 @@ func TestValidateTraysHandler_Handle(t *testing.T) {
 	_, site, _ := testTraySetupTestData(t, dbSession, org)
 
 	// Create a site without Flow enabled
-	siteNoRLA := &cdbm.Site{
+	siteNoFlow := &cdbm.Site{
 		ID:                       uuid.New(),
 		Name:                     "test-site-no-flow",
 		Org:                      org,
@@ -936,7 +936,7 @@ func TestValidateTraysHandler_Handle(t *testing.T) {
 		Status:                   cdbm.SiteStatusRegistered,
 		Config:                   &cdbm.SiteConfig{},
 	}
-	_, err := dbSession.DB.NewInsert().Model(siteNoRLA).Exec(context.Background())
+	_, err := dbSession.DB.NewInsert().Model(siteNoFlow).Exec(context.Background())
 	assert.Nil(t, err)
 
 	providerUser := testTrayBuildUser(t, dbSession, "provider-user-validate-trays", org, []string{authz.ProviderAdminRole})
@@ -1114,7 +1114,7 @@ func TestValidateTraysHandler_Handle(t *testing.T) {
 			reqOrg: org,
 			user:   providerUser,
 			queryParams: map[string]string{
-				"siteId": siteNoRLA.ID.String(),
+				"siteId": siteNoFlow.ID.String(),
 			},
 			expectedStatus: http.StatusPreconditionFailed,
 		},

--- a/site-agent/pkg/components/config/config_manager.go
+++ b/site-agent/pkg/components/config/config_manager.go
@@ -123,7 +123,7 @@ func NewElektraConfig(utMode bool) *conftypes.Config {
 	// Flow config
 	flag.StringVar(&conf.Flow.Address, "flowAddress", os.Getenv("FLOW_ADDRESS"), "Flow Address")
 	if conf.Flow.Address == "" {
-		conf.Flow.Address = "rla.rla.svc.cluster.local:50051"
+		conf.Flow.Address = "flow.flow.svc.cluster.local:50051"
 	}
 	flowSecOpt, err := strconv.Atoi(os.Getenv("FLOW_SEC_OPT"))
 	if err != nil {


### PR DESCRIPTION
## Description 
- `site-agent` Flow address default still pointed at the old `rla.rla.svc.cluster.local:50051` k8s service. The deployment side has now been migrated to `flow.flow.svc.cluster.local:50051`, so update the default to match. The flag, env var (`FLOW_ADDRESS`), and config field were already renamed; only the fallback string was left.
- `rack_test.go`, `tray_test.go`, and `task_test.go` still used a `siteNoRLA` local variable while the surrounding comments and test names ("Flow not enabled on site", `test-site-no-flow`) had already been updated. Rename to `siteNoFlow` for consistency.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [x] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [ ] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [x] **Flow** - Flow service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
