### PR TITLE
chore: Apply the ToProto modeling convention to InstanceType

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,6 +258,95 @@ predictable and every entity has the same surface:
 cover request-shape conversion, and `(*cdbm.Vpc).ToDeletionRequestProto`
 stays on the entity because there's no API request body for delete.
 
+`InstanceType` is the reference for everything else under this rollout
+(typed-slice validation, typed-map proto behavior, ozzo composition,
+shared conversion helpers): `(*cdbm.InstanceType).ToProto/FromProto`
++ `(*InstanceType).AttachCapabilities` on the entity,
+`APIMachineCapabilities` + `APIMachineCapability` for the list/element
+split, `cdbm.Labels` for the typed map, and
+`common/pkg/util.IntPtrToUint32Ptr` for shared casts.
+
+### Validate cooperates with ToProto
+
+`Validate` and `ToProto` work as a pair: `Validate` enforces every rule
+the wire format relies on, and `ToProto` is a pure mapper that trusts
+the result. The conventions below are how the rules are organised.
+
+1. **Prefer ozzo's built-in rules.** `validation.Required`,
+   `validation.Min`, `validation.Max`, `validation.In`,
+   `validation.Length`, `validation.By`, `validation.Each` compose
+   cleanly inside `validation.ValidateStruct`. Custom helpers like a
+   `validateXBounds(value, name)` free function are usually
+   unnecessary — reach for them only when no built-in fits.
+2. **List-level rules live on a typed slice.** When a request carries
+   a slice and needs both per-element rules and rules that span
+   elements (uniqueness, ordering, cross-element constraints), define
+   `type APIXs []APIX` with its own `Validate()` that calls
+   `validation.Validate(s, validation.Each())` to delegate per-element
+   checks and then enforces the list-level rules. The parent struct
+   wires it up with a single `validation.Field(&parent.Xs)`; ozzo
+   discovers the typed slice's `Validate` via the Validatable
+   interface. See `(APIMachineCapabilities).Validate` for the
+   canonical shape.
+3. **Cross-field rules use named methods via `validation.By`.** When a
+   check spans multiple fields on the same struct, pull it out as a
+   named method on the type and reference it with
+   `validation.By(t.validateX)`. Avoid inline anonymous closures —
+   named methods are discoverable, individually testable, and the
+   `Validate` body reads like a high-level outline of the rules. See
+   `(APIMachineCapability).validateDeviceType` and
+   `validateInactiveDevices`.
+4. **Validators that compose with `validation.By` take `interface{}`.**
+   Helpers used across structs (e.g. `util.ValidateLabels`,
+   `util.ValidateNameCharacters`) match ozzo's `RuleFunc` signature
+   `func(value interface{}) error`, so they drop into
+   `validation.Field(&t.Field, validation.By(util.ValidateX))`
+   directly. Internal type assertion handles the concrete type.
+
+### Named types own their proto behavior
+
+A `map`, `slice`, or other primitive composite that represents a
+domain concept with conversion needs gets a named type with methods,
+not a free function. The receiver-method form keeps the call site
+discoverable (`t.Field.ToProto()` / `t.Field.FromProto(...)`) and
+makes the type the single home for all related behavior. Free
+functions like `LabelsToProto(m map[string]string)` or
+`LabelsFromProtoMetadata(md *Metadata) Labels` are an anti-pattern —
+make the value typed and put the method on it.
+
+`FromProto` on a leaf named type is a pointer-receiver method that
+mutates the receiver in place, mirroring the entity-level
+`(*T).FromProto` shape. A `nil` input clears the receiver to its
+zero value so callers can distinguish "no data reported" from "data
+explicitly cleared." Reach the method on a struct field with
+`t.Field.FromProto(...)` — which requires the field itself to use
+the named type, not the underlying primitive. Entity struct fields
+that round-trip with the proto should be typed accordingly (e.g.
+`Labels Labels` instead of `Labels map[string]string`); CreateInput
+/ UpdateInput shapes that don't call `FromProto` themselves may stay
+on the underlying primitive until they need it.
+
+- `db/pkg/db/model.Labels` (`type Labels map[string]string` with
+  `(Labels).ToProto() []*cwssaws.Label` and
+  `(*Labels).FromProto([]*cwssaws.Label)`) is the reference for
+  map-shaped values that round-trip with workflow `Metadata.Labels`.
+  Entity callers reach it via `entity.Labels.FromProto(proto.Metadata.GetLabels())`
+  — the proto getter is nil-safe and returns `nil` for missing
+  metadata, which the method translates into a `nil` receiver.
+- `APIMachineCapabilities` (`type APIMachineCapabilities
+  []APIMachineCapability` with `(APIMachineCapabilities).Validate()`)
+  is the reference for slice-shaped values that own list-level rules.
+
+### Shared conversion helpers live in `common/pkg/util`
+
+Helpers that convert primitive types (`*int` ↔ `*uint32`, etc.) and
+have no entity association live in `common/pkg/util/converter.go`,
+not in entity-specific files. Under the ToProto / FromProto
+convention they are trusted casts: the bounds checks live in
+`Validate` upstream of them, so the helpers do not return errors and
+do not log warnings — anything that needs to fail belongs in
+`Validate`. `common/pkg/util.IntPtrToUint32Ptr` is the reference.
+
 ### Database transactions
 
 Handler code that touches the database uses the closure-based transaction

--- a/api/pkg/api/handler/instancetype.go
+++ b/api/pkg/api/handler/instancetype.go
@@ -45,15 +45,12 @@ import (
 	cwu "github.com/NVIDIA/infra-controller-rest/workflow/pkg/util"
 
 	"github.com/NVIDIA/infra-controller-rest/api/internal/config"
-	"github.com/NVIDIA/infra-controller-rest/api/pkg/api/handler/util"
 	"github.com/NVIDIA/infra-controller-rest/api/pkg/api/handler/util/common"
 	"github.com/NVIDIA/infra-controller-rest/api/pkg/api/model"
-	mutil "github.com/NVIDIA/infra-controller-rest/api/pkg/api/model/util"
 	"github.com/NVIDIA/infra-controller-rest/api/pkg/api/pagination"
 	sc "github.com/NVIDIA/infra-controller-rest/api/pkg/client/site"
 	auth "github.com/NVIDIA/infra-controller-rest/auth/pkg/authorization"
 	cutil "github.com/NVIDIA/infra-controller-rest/common/pkg/util"
-	cwssaws "github.com/NVIDIA/infra-controller-rest/workflow-schema/schema/site-agent/workflows/v1"
 	"github.com/NVIDIA/infra-controller-rest/workflow/pkg/queue"
 )
 
@@ -246,7 +243,7 @@ func (cith CreateInstanceTypeHandler) Handle(c echo.Context) error {
 		}
 
 		// Get Machine capabilities for the Instance Type
-		mcs, _, derr = mcDAO.GetAll(ctx, tx, nil, []uuid.UUID{it.ID}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, cdb.GetIntPtr(pagination.MaxPageSize), nil)
+		mcs, _, derr = mcDAO.GetAll(ctx, tx, nil, []uuid.UUID{it.ID}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
 		if derr != nil {
 			logger.Error().Err(derr).Msg("error retrieving Machine capabilities for Instance Type")
 			return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve Machine capabilities for Instance Type", nil)
@@ -259,147 +256,21 @@ func (cith CreateInstanceTypeHandler) Handle(c echo.Context) error {
 			return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
 		}
 
-		id := it.ID.String()
-		createInstanceTypeRequest := &cwssaws.CreateInstanceTypeRequest{
-			Id: &id,
-		}
+		// Attach the loaded capabilities to the entity so
+		// `apiRequest.ToProto(it)` can serialise them. The entity owns
+		// the Index-sort that NICo's update semantics require; per-cap
+		// wire mapping lives on `(*MachineCapability).ToProto` and the
+		// type / device-type / numeric-bounds rules were enforced by
+		// `apiRequest.Validate`.
+		it.AttachCapabilities(mcs)
 
-		capabilities := make([]*cwssaws.InstanceTypeMachineCapabilityFilterAttributes, len(mcs))
-
-		// Sort the capabilities list.  NICo will deny later updates
-		// if an InstanceType is associated with machines and a change
-		// in capabilities is attempted, so we'll sort here and
-		// in the update handler so that users can update metadata
-		// as long as capabilities are the same, and order matters.
-		slices.SortFunc(mcs, func(a, b cdbm.MachineCapability) int {
-			if a.Index < b.Index {
-				return -1
-			}
-
-			if a.Index > b.Index {
-				return 1
-			}
-
-			return 0
-		})
-
-		for i, machineCap := range mcs {
-			count, derr := util.GetIntPtrToUint32Ptr(machineCap.Count)
-			if derr != nil {
-				logger.Error().Err(derr).Msg("invalid Count value for MachineCapability")
-				return cutil.NewAPIError(http.StatusInternalServerError, "Invalid Count value for MachineCapability", nil)
-			}
-
-			cores, derr := util.GetIntPtrToUint32Ptr(machineCap.Cores)
-			if derr != nil {
-				logger.Error().Err(derr).Msg("invalid Cores value for MachineCapability")
-				return cutil.NewAPIError(http.StatusInternalServerError, "Invalid Cores value for MachineCapability", nil)
-			}
-
-			threads, derr := util.GetIntPtrToUint32Ptr(machineCap.Threads)
-			if derr != nil {
-				logger.Error().Err(derr).Msg("invalid Threads value for MachineCapability")
-				return cutil.NewAPIError(http.StatusInternalServerError, "Invalid Threads value for MachineCapability", nil)
-			}
-
-			var capType cwssaws.MachineCapabilityType
-
-			switch machineCap.Type {
-			case cdbm.MachineCapabilityTypeCPU:
-				capType = cwssaws.MachineCapabilityType_CAP_TYPE_CPU
-			case cdbm.MachineCapabilityTypeMemory:
-				capType = cwssaws.MachineCapabilityType_CAP_TYPE_MEMORY
-			case cdbm.MachineCapabilityTypeGPU:
-				capType = cwssaws.MachineCapabilityType_CAP_TYPE_GPU
-			case cdbm.MachineCapabilityTypeStorage:
-				capType = cwssaws.MachineCapabilityType_CAP_TYPE_STORAGE
-			case cdbm.MachineCapabilityTypeNetwork:
-				capType = cwssaws.MachineCapabilityType_CAP_TYPE_NETWORK
-			case cdbm.MachineCapabilityTypeInfiniBand:
-				capType = cwssaws.MachineCapabilityType_CAP_TYPE_INFINIBAND
-			case cdbm.MachineCapabilityTypeDPU:
-				capType = cwssaws.MachineCapabilityType_CAP_TYPE_DPU
-			default:
-				logger.Error().Msg("unsupported MachineCapabilityType requested")
-				return cutil.NewAPIError(http.StatusInternalServerError, "Unsupported MachineCapabilityType requested", nil)
-			}
-
-			// Validate device type for network capabilities
-			var deviceType *cwssaws.MachineCapabilityDeviceType
-			if machineCap.DeviceType != nil {
-				switch machineCap.Type {
-				case cdbm.MachineCapabilityTypeNetwork:
-					// For Network Capability, we only support DPU
-					if *machineCap.DeviceType != cdbm.MachineCapabilityDeviceTypeDPU {
-						logger.Error().Str("Device Type", *machineCap.DeviceType).Msg("unsupported Device Type specified for Network Capability")
-						return cutil.NewAPIError(http.StatusBadRequest, "Unsupported Device Type specified for Network Capability "+*machineCap.DeviceType, nil)
-					}
-					deviceType = cwssaws.MachineCapabilityDeviceType_MACHINE_CAPABILITY_DEVICE_TYPE_DPU.Enum()
-				case cdbm.MachineCapabilityTypeGPU:
-					// For GPU Capability, we only support NVLink
-					if *machineCap.DeviceType != cdbm.MachineCapabilityDeviceTypeNVLink {
-						logger.Error().Str("Device Type", *machineCap.DeviceType).Msg("unsupported Device Type specified for GPU Capability")
-						return cutil.NewAPIError(http.StatusBadRequest, "Unsupported Device Type specified for GPU Capability "+*machineCap.DeviceType, nil)
-					}
-					deviceType = cwssaws.MachineCapabilityDeviceType_MACHINE_CAPABILITY_DEVICE_TYPE_NVLINK.Enum()
-				default:
-					logger.Error().Str("Capability Type", machineCap.Type).Str("Device Type", *machineCap.DeviceType).Msg("unsupported Device Type specified for Capability Type")
-					return cutil.NewAPIError(http.StatusBadRequest, fmt.Sprintf("Unsupported Device Type: %s specified for Capability type %s", *machineCap.DeviceType, machineCap.Type), nil)
-				}
-			}
-
-			var inactiveDevices *cwssaws.Uint32List
-
-			if machineCap.InactiveDevices != nil {
-				if machineCap.Type != cdbm.MachineCapabilityTypeInfiniBand {
-					logger.Error().Str("Capability Type", machineCap.Type).Msg("InactiveDevices specified for non-InfiniBand Capability Type")
-					return cutil.NewAPIError(http.StatusBadRequest, "InactiveDevices specified for non-InfiniBand Capability Type", nil)
-				}
-
-				inactiveDevices = &cwssaws.Uint32List{}
-				for _, inactiveDevice := range machineCap.InactiveDevices {
-					inactiveDevices.Items = append(inactiveDevices.Items, uint32(inactiveDevice))
-				}
-			}
-
-			capabilities[i] = &cwssaws.InstanceTypeMachineCapabilityFilterAttributes{
-				CapabilityType:   capType,
-				Name:             &machineCap.Name,
-				Frequency:        machineCap.Frequency,
-				Capacity:         machineCap.Capacity,
-				Vendor:           machineCap.Vendor,
-				Count:            count,
-				HardwareRevision: machineCap.HardwareRevision,
-				Cores:            cores,
-				Threads:          threads,
-				InactiveDevices:  inactiveDevices,
-				DeviceType:       deviceType,
-			}
-		}
-
-		createInstanceTypeRequest.InstanceTypeAttributes = &cwssaws.InstanceTypeAttributes{
-			DesiredCapabilities: capabilities,
-		}
+		createInstanceTypeRequest := apiRequest.ToProto(it)
 
 		workflowOptions := temporalClient.StartWorkflowOptions{
 			ID:                       "instance-type-create-" + it.ID.String(),
 			TaskQueue:                queue.SiteTaskQueue,
 			WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
 		}
-
-		// InstanceType metadata info
-		metadata := &cwssaws.Metadata{
-			Name: it.Name,
-		}
-
-		// Include description if present
-		if it.Description != nil {
-			metadata.Description = *it.Description
-		}
-
-		metadata.Labels = mutil.ProtobufLabelsFromAPILabels(it.Labels)
-
-		createInstanceTypeRequest.Metadata = metadata
 
 		logger.Info().Msg("triggering InstanceType create workflow")
 
@@ -1280,7 +1151,7 @@ func (uith UpdateInstanceTypeHandler) Handle(c echo.Context) error {
 		}
 
 		// Get the most up-to-date capabilities for the instance type
-		mcs, _, derr = mcDAO.GetAll(ctx, tx, nil, []uuid.UUID{it.ID}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, cdb.GetIntPtr(pagination.MaxPageSize), nil)
+		mcs, _, derr = mcDAO.GetAll(ctx, tx, nil, []uuid.UUID{it.ID}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
 		if derr != nil {
 			logger.Error().Err(derr).Msg("error retrieving Machine capabilities for Instance Type")
 			return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve Machine capabilities for Instance Type", nil)
@@ -1303,150 +1174,29 @@ func (uith UpdateInstanceTypeHandler) Handle(c echo.Context) error {
 			return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
 		}
 
-		updateInstanceTypeRequest := &cwssaws.UpdateInstanceTypeRequest{
-			Id: it.ID.String(),
-		}
-
-		capabilities := make([]*cwssaws.InstanceTypeMachineCapabilityFilterAttributes, len(mcs))
-
-		// Sort the capabilities list.  NICo will deny updates
-		// if an InstanceType is associated with machines and a change
-		// in capabilities is attempted, and order matters.
-
+		// Sort the capabilities list and attach to the entity. NICo will
+		// deny updates if an InstanceType is associated with machines and
+		// a change in capabilities is attempted, and order matters. Once
+		// sorted, the slice is hung off `it.Capabilities` so
+		// `apiRequest.ToProto(it)` can read it via the entity's
+		// canonical `ToProto`; per-capability wire mapping lives on
+		// `(*MachineCapability).ToProto` and the type / device-type /
+		// numeric-bounds rules were enforced by `apiRequest.Validate`.
 		slices.SortFunc(mcs, func(a, b cdbm.MachineCapability) int {
-			if a.Index < b.Index {
-				return -1
-			}
-
-			if a.Index > b.Index {
-				return 1
-			}
-
-			return 0
+			return a.Index - b.Index
 		})
-
-		for i, machineCap := range mcs {
-
-			count, derr := util.GetIntPtrToUint32Ptr(machineCap.Count)
-			if derr != nil {
-				logger.Error().Err(derr).Msg("invalid Count value for MachineCapability")
-				return cutil.NewAPIError(http.StatusInternalServerError, "Invalid Count value for MachineCapability", nil)
-			}
-
-			cores, derr := util.GetIntPtrToUint32Ptr(machineCap.Cores)
-			if derr != nil {
-				logger.Error().Err(derr).Msg("invalid Cores value for MachineCapability")
-				return cutil.NewAPIError(http.StatusInternalServerError, "Invalid Cores value for MachineCapability", nil)
-			}
-
-			threads, derr := util.GetIntPtrToUint32Ptr(machineCap.Threads)
-			if derr != nil {
-				logger.Error().Err(derr).Msg("invalid Threads value for MachineCapability")
-				return cutil.NewAPIError(http.StatusInternalServerError, "Invalid Threads value for MachineCapability", nil)
-			}
-
-			var capType cwssaws.MachineCapabilityType
-
-			switch machineCap.Type {
-			case cdbm.MachineCapabilityTypeCPU:
-				capType = cwssaws.MachineCapabilityType_CAP_TYPE_CPU
-			case cdbm.MachineCapabilityTypeMemory:
-				capType = cwssaws.MachineCapabilityType_CAP_TYPE_MEMORY
-			case cdbm.MachineCapabilityTypeGPU:
-				capType = cwssaws.MachineCapabilityType_CAP_TYPE_GPU
-			case cdbm.MachineCapabilityTypeStorage:
-				capType = cwssaws.MachineCapabilityType_CAP_TYPE_STORAGE
-			case cdbm.MachineCapabilityTypeNetwork:
-				capType = cwssaws.MachineCapabilityType_CAP_TYPE_NETWORK
-			case cdbm.MachineCapabilityTypeInfiniBand:
-				capType = cwssaws.MachineCapabilityType_CAP_TYPE_INFINIBAND
-			case cdbm.MachineCapabilityTypeDPU:
-				capType = cwssaws.MachineCapabilityType_CAP_TYPE_DPU
-			default:
-				logger.Error().Msg("unsupported MachineCapabilityType requested")
-				return cutil.NewAPIError(http.StatusInternalServerError, "Unsupported MachineCapabilityType requested", nil)
-			}
-
-			// Update device type for network capabilities if provided
-			// Since we are validating the device type in the API model,
-			// we can safely set the device type to DPU for network capabilities
-			// as currently we only support DPU device type for network capabilities.
-			// Similarly, for GPU capabilities, we only support NVLink device type.
-			var deviceType *cwssaws.MachineCapabilityDeviceType
-			if machineCap.DeviceType != nil {
-				switch machineCap.Type {
-				case cdbm.MachineCapabilityTypeNetwork:
-					// For Network Capability, we only support DPU
-					if *machineCap.DeviceType != cdbm.MachineCapabilityDeviceTypeDPU {
-						logger.Error().Str("Device Type", *machineCap.DeviceType).Msg("unsupported Device Type specified for Network Capability")
-						return cutil.NewAPIError(http.StatusBadRequest, "Unsupported Device Type specified for Network Capability "+*machineCap.DeviceType, nil)
-					}
-					deviceType = cwssaws.MachineCapabilityDeviceType_MACHINE_CAPABILITY_DEVICE_TYPE_DPU.Enum()
-				case cdbm.MachineCapabilityTypeGPU:
-					// For GPU Capability, we only support NVLink
-					if *machineCap.DeviceType != cdbm.MachineCapabilityDeviceTypeNVLink {
-						logger.Error().Str("Device Type", *machineCap.DeviceType).Msg("unsupported Device Type specified for GPU Capability")
-						return cutil.NewAPIError(http.StatusBadRequest, "Unsupported Device Type specified for GPU Capability "+*machineCap.DeviceType, nil)
-					}
-					deviceType = cwssaws.MachineCapabilityDeviceType_MACHINE_CAPABILITY_DEVICE_TYPE_NVLINK.Enum()
-				default:
-					logger.Error().Str("Capability Type", machineCap.Type).Str("Device Type", *machineCap.DeviceType).Msg("unsupported Device Type specified for Capability Type")
-					return cutil.NewAPIError(http.StatusBadRequest, fmt.Sprintf("Unsupported Device Type: %s specified for Capability type %s", *machineCap.DeviceType, machineCap.Type), nil)
-				}
-			}
-
-			var inactiveDevices *cwssaws.Uint32List
-
-			if machineCap.InactiveDevices != nil {
-				if machineCap.Type != cdbm.MachineCapabilityTypeInfiniBand {
-					logger.Error().Str("Capability Type", machineCap.Type).Msg("InactiveDevices specified for non-InfiniBand Capability Type")
-					return cutil.NewAPIError(http.StatusBadRequest, "InactiveDevices specified for non-InfiniBand Capability Type", nil)
-				}
-
-				inactiveDevices = &cwssaws.Uint32List{}
-				for _, inactiveDevice := range machineCap.InactiveDevices {
-					inactiveDevices.Items = append(inactiveDevices.Items, uint32(inactiveDevice))
-				}
-			}
-
-			capabilities[i] = &cwssaws.InstanceTypeMachineCapabilityFilterAttributes{
-				CapabilityType:   capType,
-				Name:             &machineCap.Name,
-				Frequency:        machineCap.Frequency,
-				Capacity:         machineCap.Capacity,
-				Vendor:           machineCap.Vendor,
-				Count:            count,
-				HardwareRevision: machineCap.HardwareRevision,
-				Cores:            cores,
-				Threads:          threads,
-				InactiveDevices:  inactiveDevices,
-				DeviceType:       deviceType,
-			}
+		it.Capabilities = make([]*cdbm.MachineCapability, len(mcs))
+		for i := range mcs {
+			it.Capabilities[i] = &mcs[i]
 		}
 
-		updateInstanceTypeRequest.InstanceTypeAttributes = &cwssaws.InstanceTypeAttributes{
-			DesiredCapabilities: capabilities,
-		}
+		updateInstanceTypeRequest := apiRequest.ToProto(it)
 
 		workflowOptions := temporalClient.StartWorkflowOptions{
 			ID:                       "instance-type-update-" + it.ID.String(),
 			TaskQueue:                queue.SiteTaskQueue,
 			WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
 		}
-
-		// InstanceType metadata info
-		metadata := &cwssaws.Metadata{
-			Name: it.Name,
-		}
-
-		// Include description if present
-		if it.Description != nil {
-			metadata.Description = *it.Description
-		}
-
-		metadata.Labels = mutil.ProtobufLabelsFromAPILabels(it.Labels)
-
-		updateInstanceTypeRequest.Metadata = metadata
 
 		logger.Info().Msg("triggering InstanceType update workflow")
 
@@ -1710,9 +1460,7 @@ func (dith DeleteInstanceTypeHandler) Handle(c echo.Context) error {
 			return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
 		}
 
-		deleteInstanceTypeRequest := &cwssaws.DeleteInstanceTypeRequest{
-			Id: it.ID.String(),
-		}
+		deleteInstanceTypeRequest := it.ToDeletionRequestProto()
 
 		workflowOptions := temporalClient.StartWorkflowOptions{
 			ID:                       "instance-type-delete-" + it.ID.String(),

--- a/api/pkg/api/model/expectedmachine_test.go
+++ b/api/pkg/api/model/expectedmachine_test.go
@@ -318,7 +318,7 @@ func TestNewAPIExpectedMachine(t *testing.T) {
 			assert.Equal(t, tc.dbObj.BmcMacAddress, got.BmcMacAddress)
 			assert.Equal(t, tc.dbObj.ChassisSerialNumber, got.ChassisSerialNumber)
 			assert.Equal(t, tc.dbObj.FallbackDpuSerialNumbers, got.FallbackDPUSerialNumbers)
-			assert.Equal(t, tc.dbObj.Labels, got.Labels)
+			assert.Equal(t, map[string]string(tc.dbObj.Labels), got.Labels)
 			assert.Equal(t, tc.dbObj.Created, got.Created)
 			assert.Equal(t, tc.dbObj.Updated, got.Updated)
 		})
@@ -650,7 +650,7 @@ func TestNewAPIExpectedMachineEdgeCases(t *testing.T) {
 
 		got := NewAPIExpectedMachine(dbEM)
 		assert.NotNil(t, got)
-		assert.Equal(t, dbEM.Labels, got.Labels)
+		assert.Equal(t, map[string]string(dbEM.Labels), got.Labels)
 		assert.Equal(t, "nico-rest-api", got.Labels["app.kubernetes.io/name"])
 	})
 

--- a/api/pkg/api/model/expectedpowershelf_test.go
+++ b/api/pkg/api/model/expectedpowershelf_test.go
@@ -328,7 +328,7 @@ func TestNewAPIExpectedPowerShelf(t *testing.T) {
 			assert.Equal(t, tc.dbObj.BmcMacAddress, got.BmcMacAddress)
 			assert.Equal(t, tc.dbObj.ShelfSerialNumber, got.ShelfSerialNumber)
 			assert.Equal(t, tc.dbObj.BmcIpAddress, got.BmcIpAddress)
-			assert.Equal(t, tc.dbObj.Labels, got.Labels)
+			assert.Equal(t, map[string]string(tc.dbObj.Labels), got.Labels)
 			assert.Equal(t, tc.dbObj.Created, got.Created)
 			assert.Equal(t, tc.dbObj.Updated, got.Updated)
 		})
@@ -585,7 +585,7 @@ func TestNewAPIExpectedPowerShelfEdgeCases(t *testing.T) {
 
 		got := NewAPIExpectedPowerShelf(dbEPS)
 		assert.NotNil(t, got)
-		assert.Equal(t, dbEPS.Labels, got.Labels)
+		assert.Equal(t, map[string]string(dbEPS.Labels), got.Labels)
 		assert.Equal(t, "cloud-api", got.Labels["app.kubernetes.io/name"])
 	})
 

--- a/api/pkg/api/model/expectedswitch_test.go
+++ b/api/pkg/api/model/expectedswitch_test.go
@@ -327,7 +327,7 @@ func TestNewAPIExpectedSwitch(t *testing.T) {
 			assert.Equal(t, tc.dbObj.BmcMacAddress, got.BmcMacAddress)
 			assert.Equal(t, tc.dbObj.SwitchSerialNumber, got.SwitchSerialNumber)
 			assert.Equal(t, tc.dbObj.BmcIpAddress, got.BmcIpAddress)
-			assert.Equal(t, tc.dbObj.Labels, got.Labels)
+			assert.Equal(t, map[string]string(tc.dbObj.Labels), got.Labels)
 			assert.Equal(t, tc.dbObj.Created, got.Created)
 			assert.Equal(t, tc.dbObj.Updated, got.Updated)
 		})
@@ -577,7 +577,7 @@ func TestNewAPIExpectedSwitchEdgeCases(t *testing.T) {
 
 		got := NewAPIExpectedSwitch(dbES)
 		assert.NotNil(t, got)
-		assert.Equal(t, dbES.Labels, got.Labels)
+		assert.Equal(t, map[string]string(dbES.Labels), got.Labels)
 		assert.Equal(t, "cloud-api", got.Labels["app.kubernetes.io/name"])
 	})
 

--- a/api/pkg/api/model/instancetype.go
+++ b/api/pkg/api/model/instancetype.go
@@ -18,8 +18,6 @@
 package model
 
 import (
-	"errors"
-	"fmt"
 	"time"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
@@ -27,6 +25,7 @@ import (
 
 	"github.com/NVIDIA/infra-controller-rest/api/pkg/api/model/util"
 	cdbm "github.com/NVIDIA/infra-controller-rest/db/pkg/db/model"
+	cwssaws "github.com/NVIDIA/infra-controller-rest/workflow-schema/schema/site-agent/workflows/v1"
 )
 
 // APIInstanceTypeCreateRequest is the data structure to capture user request to create a new InstanceType
@@ -42,12 +41,12 @@ type APIInstanceTypeCreateRequest struct {
 	// ControllerMachineType is the Site Controller assigned Machine type
 	ControllerMachineType *string `json:"controllerMachineType"`
 	// MachineCapabilities is the list of Machine Capabilities to match
-	MachineCapabilities []APIMachineCapability `json:"machineCapabilities"`
+	MachineCapabilities APIMachineCapabilities `json:"machineCapabilities"`
 }
 
 // Validate ensure the values passed in request are acceptable
-func (itcr APIInstanceTypeCreateRequest) Validate() error {
-	err := validation.ValidateStruct(&itcr,
+func (itcr *APIInstanceTypeCreateRequest) Validate() error {
+	return validation.ValidateStruct(itcr,
 		validation.Field(&itcr.Name,
 			validation.Required.Error(validationErrorStringLength),
 			validation.By(util.ValidateNameCharacters),
@@ -57,53 +56,28 @@ func (itcr APIInstanceTypeCreateRequest) Validate() error {
 		validation.Field(&itcr.SiteID,
 			validation.Required.Error(validationErrorValueRequired),
 			validationis.UUID.Error(validationErrorInvalidUUID)),
+		validation.Field(&itcr.Labels, validation.By(util.ValidateLabels)),
+		validation.Field(&itcr.MachineCapabilities),
 	)
+}
 
-	if err != nil {
-		return err
+// ToProto builds the workflow request that asks a Site to create this
+// InstanceType. `it` is the just-persisted DB record with its
+// `Capabilities` slice pre-loaded by the handler; its `ToProto()` is
+// the source of the canonical wire fields (Id/Metadata/Attributes
+// including the desired-capabilities filter).
+//
+// The method trusts that the request has already been Validated. The
+// per-capability wire rules (device type / InactiveDevices / numeric
+// bounds) are enforced by `Validate` so this method stays a pure
+// mapper.
+func (itcr *APIInstanceTypeCreateRequest) ToProto(it *cdbm.InstanceType) *cwssaws.CreateInstanceTypeRequest {
+	itProto := it.ToProto()
+	return &cwssaws.CreateInstanceTypeRequest{
+		Id:                     &itProto.Id,
+		Metadata:               itProto.Metadata,
+		InstanceTypeAttributes: itProto.Attributes,
 	}
-
-	if err := util.ValidateLabels(itcr.Labels); err != nil {
-		return err
-	}
-
-	if itcr.MachineCapabilities != nil {
-		err = validation.Validate(itcr.MachineCapabilities)
-		if err != nil {
-			return err
-		}
-
-		mcNameMap := map[string]bool{}
-		for _, mc := range itcr.MachineCapabilities {
-			capKey := mc.Type + "-" + mc.Name
-
-			if !cdbm.MachineCapabilityTypeChoiceMap[mc.Type] {
-				return validation.Errors{
-					"machineCapabilities": errors.New("requested Capability type is not valid: " + mc.Type),
-				}
-			}
-
-			// Validate device type for network capabilities
-			if mc.Type == cdbm.MachineCapabilityTypeNetwork && mc.DeviceType != nil {
-				if !cdbm.MachineCapabilityDeviceTypeChoiceMap[*mc.DeviceType] {
-					return validation.Errors{
-						"machineCapabilities": errors.New("requested device type  `" + *mc.DeviceType + "`  for Capability type `" + mc.Type + "` is not valid"),
-					}
-				}
-			}
-
-			_, found := mcNameMap[capKey]
-			if found {
-				return validation.Errors{
-					"machineCapabilities": fmt.Errorf("requested Capability type `%s` cannot contain duplicate Capability name: %s", mc.Type, mc.Name),
-				}
-			}
-			mcNameMap[capKey] = true
-		}
-
-	}
-
-	return nil
 }
 
 // APIInstanceTypeUpdateRequest is the data structure to capture user request to update an Instance Type
@@ -115,63 +89,37 @@ type APIInstanceTypeUpdateRequest struct {
 	// Labels is the labels of the Instance Type
 	Labels map[string]string `json:"labels"`
 	// MachineCapabilities is the list of Machine Capabilities to match
-	MachineCapabilities []APIMachineCapability `json:"machineCapabilities"`
+	MachineCapabilities APIMachineCapabilities `json:"machineCapabilities"`
 }
 
 // Validate ensure the values passed in request are acceptable
-func (itur APIInstanceTypeUpdateRequest) Validate() error {
-	err := validation.ValidateStruct(&itur,
+func (itur *APIInstanceTypeUpdateRequest) Validate() error {
+	return validation.ValidateStruct(itur,
 		validation.Field(&itur.Name,
 			// length validation rule accepts empty string as valid, hence, required is needed
 			validation.When(itur.Name != nil, validation.Required.Error(validationErrorStringLength)),
 			validation.When(itur.Name != nil, validation.By(util.ValidateNameCharacters)),
 			validation.When(itur.Name != nil, validation.Length(2, 256).Error(validationErrorStringLength))),
+		validation.Field(&itur.Labels, validation.By(util.ValidateLabels)),
+		validation.Field(&itur.MachineCapabilities),
 	)
-	if err != nil {
-		return err
+}
+
+// ToProto builds the workflow request that pushes this Update's
+// merged-into-DB state to a Site. `it` is the post-merge DB record
+// with its `Capabilities` slice pre-loaded by the handler; its
+// `ToProto()` is the source of the canonical wire fields
+// (Id/Metadata/Attributes including desired-capabilities filter) so
+// unchanged fields stay populated.
+//
+// The method trusts that the request has already been Validated.
+func (itur *APIInstanceTypeUpdateRequest) ToProto(it *cdbm.InstanceType) *cwssaws.UpdateInstanceTypeRequest {
+	itProto := it.ToProto()
+	return &cwssaws.UpdateInstanceTypeRequest{
+		Id:                     itProto.Id,
+		Metadata:               itProto.Metadata,
+		InstanceTypeAttributes: itProto.Attributes,
 	}
-
-	if err := util.ValidateLabels(itur.Labels); err != nil {
-		return err
-	}
-
-	if itur.MachineCapabilities != nil {
-		err = validation.Validate(itur.MachineCapabilities)
-		if err != nil {
-			return err
-		}
-
-		mcNameMap := map[string]bool{}
-		for _, mc := range itur.MachineCapabilities {
-
-			capKey := mc.Type + "-" + mc.Name
-
-			if !cdbm.MachineCapabilityTypeChoiceMap[mc.Type] {
-				return validation.Errors{
-					"machineCapabilities": errors.New("requested Capability type is not valid: " + mc.Type),
-				}
-			}
-
-			// Validate device type for network capabilities
-			if mc.Type == cdbm.MachineCapabilityTypeNetwork && mc.DeviceType != nil {
-				if !cdbm.MachineCapabilityDeviceTypeChoiceMap[*mc.DeviceType] {
-					return validation.Errors{
-						"machineCapabilities": errors.New("requested device type  `" + *mc.DeviceType + "`  for Capability type `" + mc.Type + "` is not valid"),
-					}
-				}
-			}
-
-			_, found := mcNameMap[capKey]
-			if found {
-				return validation.Errors{
-					"machineCapabilities": fmt.Errorf("requested Capability type `%s` cannot contain duplicate Capability name: %s", mc.Type, mc.Name),
-				}
-			}
-			mcNameMap[capKey] = true
-		}
-	}
-
-	return nil
 }
 
 // APIInstanceType is the data structure to capture API representation of an Instance Type

--- a/api/pkg/api/model/instancetype_test.go
+++ b/api/pkg/api/model/instancetype_test.go
@@ -18,14 +18,17 @@
 package model
 
 import (
+	"math"
 	"reflect"
 	"testing"
 	"time"
 
 	cdb "github.com/NVIDIA/infra-controller-rest/db/pkg/db"
 	cdbm "github.com/NVIDIA/infra-controller-rest/db/pkg/db/model"
+	cwssaws "github.com/NVIDIA/infra-controller-rest/workflow-schema/schema/site-agent/workflows/v1"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewAPIInstanceType(t *testing.T) {
@@ -303,6 +306,141 @@ func TestAPIInstanceTypeCreateRequest_Validate(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "test invalid Instance Type create request - GPU capability requires NVLink device type",
+			fields: fields{
+				Name:   "test-name",
+				SiteID: uuid.New().String(),
+				MachineCapabilities: []APIMachineCapability{
+					{
+						Type:       cdbm.MachineCapabilityTypeGPU,
+						Name:       "gpu-0",
+						DeviceType: cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeDPU),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "test valid Instance Type create request - GPU + NVLink device type",
+			fields: fields{
+				Name:   "test-name",
+				SiteID: uuid.New().String(),
+				MachineCapabilities: []APIMachineCapability{
+					{
+						Type:       cdbm.MachineCapabilityTypeGPU,
+						Name:       "gpu-0",
+						DeviceType: cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test invalid Instance Type create request - device type on capability that does not allow one",
+			fields: fields{
+				Name:   "test-name",
+				SiteID: uuid.New().String(),
+				MachineCapabilities: []APIMachineCapability{
+					{
+						Type:       cdbm.MachineCapabilityTypeCPU,
+						Name:       "cpu-0",
+						DeviceType: cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeDPU),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "test invalid Instance Type create request - InactiveDevices on non-InfiniBand capability",
+			fields: fields{
+				Name:   "test-name",
+				SiteID: uuid.New().String(),
+				MachineCapabilities: []APIMachineCapability{
+					{
+						Type:            cdbm.MachineCapabilityTypeStorage,
+						Name:            "storage-0",
+						InactiveDevices: []int{1, 2},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "test valid Instance Type create request - InactiveDevices on InfiniBand capability",
+			fields: fields{
+				Name:   "test-name",
+				SiteID: uuid.New().String(),
+				MachineCapabilities: []APIMachineCapability{
+					{
+						Type:            cdbm.MachineCapabilityTypeInfiniBand,
+						Name:            "ib-0",
+						InactiveDevices: []int{1, 2},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test invalid Instance Type create request - InactiveDevices contains negative entry",
+			fields: fields{
+				Name:   "test-name",
+				SiteID: uuid.New().String(),
+				MachineCapabilities: []APIMachineCapability{
+					{
+						Type:            cdbm.MachineCapabilityTypeInfiniBand,
+						Name:            "ib-0",
+						InactiveDevices: []int{1, -1, 2},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "test invalid Instance Type create request - InactiveDevices entry exceeds uint32",
+			fields: fields{
+				Name:   "test-name",
+				SiteID: uuid.New().String(),
+				MachineCapabilities: []APIMachineCapability{
+					{
+						Type:            cdbm.MachineCapabilityTypeInfiniBand,
+						Name:            "ib-0",
+						InactiveDevices: []int{math.MaxUint32 + 1},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "test invalid Instance Type create request - Count exceeds uint32",
+			fields: fields{
+				Name:   "test-name",
+				SiteID: uuid.New().String(),
+				MachineCapabilities: []APIMachineCapability{
+					{
+						Type:  cdbm.MachineCapabilityTypeCPU,
+						Name:  "cpu-0",
+						Count: cdb.GetIntPtr(math.MaxUint32 + 1),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "test invalid Instance Type create request - Count is negative",
+			fields: fields{
+				Name:   "test-name",
+				SiteID: uuid.New().String(),
+				MachineCapabilities: []APIMachineCapability{
+					{
+						Type:  cdbm.MachineCapabilityTypeCPU,
+						Name:  "cpu-0",
+						Count: cdb.GetIntPtr(-1),
+					},
+				},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -364,4 +502,86 @@ func TestAPIInstanceTypeUpdateRequest_Validate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAPIInstanceTypeCreateRequest_ToProto(t *testing.T) {
+	id := uuid.New()
+	desc := "primary"
+
+	t.Run("derives id metadata and capabilities from the entity", func(t *testing.T) {
+		it := &cdbm.InstanceType{
+			ID:          id,
+			Name:        "small",
+			Description: &desc,
+			Labels:      map[string]string{"env": "prod"},
+			Capabilities: []*cdbm.MachineCapability{
+				{Type: cdbm.MachineCapabilityTypeCPU, Name: "cpu-0"},
+			},
+		}
+		itcr := APIInstanceTypeCreateRequest{}
+		req := itcr.ToProto(it)
+		require.NotNil(t, req)
+		require.NotNil(t, req.Id)
+		assert.Equal(t, id.String(), *req.Id)
+		require.NotNil(t, req.Metadata)
+		assert.Equal(t, "small", req.Metadata.Name)
+		assert.Equal(t, "primary", req.Metadata.Description)
+		require.Len(t, req.Metadata.Labels, 1)
+		assert.Equal(t, "env", req.Metadata.Labels[0].Key)
+		require.NotNil(t, req.Metadata.Labels[0].Value)
+		assert.Equal(t, "prod", *req.Metadata.Labels[0].Value)
+		require.NotNil(t, req.InstanceTypeAttributes)
+		require.Len(t, req.InstanceTypeAttributes.DesiredCapabilities, 1)
+		assert.Equal(t, cwssaws.MachineCapabilityType_CAP_TYPE_CPU,
+			req.InstanceTypeAttributes.DesiredCapabilities[0].CapabilityType)
+	})
+
+	t.Run("nil description, labels, and capabilities yield empty metadata + nil filter", func(t *testing.T) {
+		it := &cdbm.InstanceType{ID: id, Name: "small"}
+		itcr := APIInstanceTypeCreateRequest{}
+		req := itcr.ToProto(it)
+		require.NotNil(t, req)
+		assert.Equal(t, "", req.Metadata.Description)
+		assert.Nil(t, req.Metadata.Labels)
+		require.NotNil(t, req.InstanceTypeAttributes)
+		assert.Nil(t, req.InstanceTypeAttributes.DesiredCapabilities)
+	})
+}
+
+func TestAPIInstanceTypeUpdateRequest_ToProto(t *testing.T) {
+	id := uuid.New()
+	desc := "primary"
+
+	t.Run("derives id metadata from the post-merge entity, no caps yields nil filter", func(t *testing.T) {
+		it := &cdbm.InstanceType{
+			ID:          id,
+			Name:        "small",
+			Description: &desc,
+		}
+		itur := APIInstanceTypeUpdateRequest{}
+		req := itur.ToProto(it)
+		require.NotNil(t, req)
+		assert.Equal(t, id.String(), req.Id)
+		require.NotNil(t, req.Metadata)
+		assert.Equal(t, "small", req.Metadata.Name)
+		assert.Equal(t, "primary", req.Metadata.Description)
+		require.NotNil(t, req.InstanceTypeAttributes)
+		assert.Nil(t, req.InstanceTypeAttributes.DesiredCapabilities)
+	})
+
+	t.Run("populates capabilities from the entity when provided", func(t *testing.T) {
+		it := &cdbm.InstanceType{
+			ID:   id,
+			Name: "small",
+			Capabilities: []*cdbm.MachineCapability{
+				{Type: cdbm.MachineCapabilityTypeCPU, Name: "cpu-0"},
+			},
+		}
+		itur := APIInstanceTypeUpdateRequest{}
+		req := itur.ToProto(it)
+		require.NotNil(t, req.InstanceTypeAttributes)
+		require.Len(t, req.InstanceTypeAttributes.DesiredCapabilities, 1)
+		assert.Equal(t, cwssaws.MachineCapabilityType_CAP_TYPE_CPU,
+			req.InstanceTypeAttributes.DesiredCapabilities[0].CapabilityType)
+	})
 }

--- a/api/pkg/api/model/machinecapability.go
+++ b/api/pkg/api/model/machinecapability.go
@@ -18,7 +18,9 @@
 package model
 
 import (
+	"errors"
 	"fmt"
+	"math"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 
@@ -26,6 +28,31 @@ import (
 	cdbm "github.com/NVIDIA/infra-controller-rest/db/pkg/db/model"
 	cwma "github.com/NVIDIA/infra-controller-rest/workflow/pkg/activity/machine"
 )
+
+// APIMachineCapabilities is a typed slice that owns the list-level
+// rules across machine capabilities. It both delegates per-element
+// validation to `(APIMachineCapability).Validate` and enforces the
+// `(Type, Name)` uniqueness invariant the proto layer relies on.
+type APIMachineCapabilities []APIMachineCapability
+
+// Validate runs `APIMachineCapability.Validate` on each entry and then
+// enforces that no two entries share the same `(Type, Name)` pair.
+func (caps APIMachineCapabilities) Validate() error {
+	if err := validation.Validate([]APIMachineCapability(caps), validation.Each()); err != nil {
+		return err
+	}
+	seen := map[string]bool{}
+	for _, mc := range caps {
+		key := mc.Type + "-" + mc.Name
+		if seen[key] {
+			return validation.Errors{
+				"machineCapabilities": fmt.Errorf("requested Capability type `%s` cannot contain duplicate Capability name: %s", mc.Type, mc.Name),
+			}
+		}
+		seen[key] = true
+	}
+	return nil
+}
 
 // APIMachineCapability is the datastructure to capture API representation of a MachineCapability
 type APIMachineCapability struct {
@@ -53,14 +80,21 @@ type APIMachineCapability struct {
 	DeviceType *string `json:"deviceType,omitempty"`
 }
 
-// Validate ensure the values passed in request are acceptable
+// Validate ensures the values on a single capability are acceptable
+// and that the row will round-trip cleanly into the workflow proto.
+// Per-list concerns (e.g. duplicate `(Type, Name)` pairs across
+// capabilities) are enforced at the list level by
+// `APIMachineCapabilities.Validate`.
+//
+// `ToProto` trusts that this has run, so anything the proto cast or
+// downstream wire shape relies on belongs here.
 func (mc APIMachineCapability) Validate() error {
-	mctypes := make([]interface{}, 0)
-	for mctype, _ := range cdbm.MachineCapabilityTypeChoiceMap {
+	mctypes := make([]interface{}, 0, len(cdbm.MachineCapabilityTypeChoiceMap))
+	for mctype := range cdbm.MachineCapabilityTypeChoiceMap {
 		mctypes = append(mctypes, mctype)
 	}
 
-	err := validation.ValidateStruct(&mc,
+	return validation.ValidateStruct(&mc,
 		validation.Field(&mc.Type,
 			validation.Required.Error("type must be specified for each Machine Capability"),
 			validation.In(mctypes...).Error(fmt.Sprintf("invalid value: %v for Machine Capability type", mc.Type))),
@@ -68,9 +102,61 @@ func (mc APIMachineCapability) Validate() error {
 			validation.Required.Error("name must be specified for each Machine Capability"),
 			validation.By(util.ValidateNameCharacters),
 			validation.Length(2, 256).Error(validationErrorStringLength)),
+		validation.Field(&mc.Count,
+			validation.Min(0).Error(fmt.Sprintf("Count for capability %q must be non-negative", mc.Name)),
+			validation.Max(math.MaxUint32).Error(fmt.Sprintf("Count for capability %q must fit in uint32 (0..%d)", mc.Name, uint32(math.MaxUint32)))),
+		validation.Field(&mc.Cores,
+			validation.Min(0).Error(fmt.Sprintf("Cores for capability %q must be non-negative", mc.Name)),
+			validation.Max(math.MaxUint32).Error(fmt.Sprintf("Cores for capability %q must fit in uint32 (0..%d)", mc.Name, uint32(math.MaxUint32)))),
+		validation.Field(&mc.Threads,
+			validation.Min(0).Error(fmt.Sprintf("Threads for capability %q must be non-negative", mc.Name)),
+			validation.Max(math.MaxUint32).Error(fmt.Sprintf("Threads for capability %q must fit in uint32 (0..%d)", mc.Name, uint32(math.MaxUint32)))),
+		validation.Field(&mc.DeviceType, validation.By(mc.validateDeviceType)),
+		validation.Field(&mc.InactiveDevices, validation.By(mc.validateInactiveDevices)),
 	)
+}
 
-	return err
+// validateDeviceType enforces the Type/DeviceType compatibility rules:
+// Network capabilities require DPU, GPU capabilities require NVLink,
+// every other Type must not carry a DeviceType. A nil DeviceType is
+// always allowed.
+func (mc APIMachineCapability) validateDeviceType(value interface{}) error {
+	dt, ok := value.(*string)
+	if !ok || dt == nil {
+		return nil
+	}
+	switch mc.Type {
+	case cdbm.MachineCapabilityTypeNetwork:
+		if *dt != cdbm.MachineCapabilityDeviceTypeDPU {
+			return errors.New("Unsupported Device Type specified for Network Capability " + *dt)
+		}
+	case cdbm.MachineCapabilityTypeGPU:
+		if *dt != cdbm.MachineCapabilityDeviceTypeNVLink {
+			return errors.New("Unsupported Device Type specified for GPU Capability " + *dt)
+		}
+	default:
+		return fmt.Errorf("Unsupported Device Type: %s specified for Capability type %s", *dt, mc.Type)
+	}
+	return nil
+}
+
+// validateInactiveDevices enforces that InactiveDevices is only set on
+// InfiniBand capabilities and that each entry fits in the proto uint32
+// width before `MachineCapability.ToProto` casts it.
+func (mc APIMachineCapability) validateInactiveDevices(value interface{}) error {
+	ids, ok := value.([]int)
+	if !ok || len(ids) == 0 {
+		return nil
+	}
+	if mc.Type != cdbm.MachineCapabilityTypeInfiniBand {
+		return errors.New("InactiveDevices specified for non-InfiniBand Capability Type")
+	}
+	for i, id := range ids {
+		if id < 0 || id > math.MaxUint32 {
+			return fmt.Errorf("InactiveDevices[%d] for capability %q must fit in uint32 (0..%d)", i, mc.Name, uint32(math.MaxUint32))
+		}
+	}
+	return nil
 }
 
 // NewAPIMachineCapability accepts a DB layer MachineCapability object and returns an API object

--- a/api/pkg/api/model/util/validation.go
+++ b/api/pkg/api/model/util/validation.go
@@ -52,8 +52,19 @@ var (
 	ErrValidationLabelCount       = fmt.Errorf("up to %v key/value pairs can be specified in labels", LabelCountMax)
 )
 
-// ValidateLabels validates optional API label maps (count, keys, values). Returns nil when labels is nil.
-func ValidateLabels(labels map[string]string) error {
+// ValidateLabels validates optional API label maps (count, keys, values).
+// Signature matches ozzo's `validation.RuleFunc` so it can be used
+// directly inside a `validation.By(...)` call from a struct's `Validate`.
+// Returns nil when labels is nil; ignores values that aren't a
+// `map[string]string`.
+func ValidateLabels(value interface{}) error {
+	if value == nil {
+		return nil
+	}
+	labels, ok := value.(map[string]string)
+	if !ok {
+		return nil
+	}
 	if labels == nil {
 		return nil
 	}

--- a/common/pkg/util/converter.go
+++ b/common/pkg/util/converter.go
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package util
+
+// IntPtrToUint32Ptr converts a `*int` to a `*uint32`. nil in, nil out.
+// Callers must ensure the int sits in `[0, MaxUint32]`; the cast
+// otherwise silently wraps. Under the proto-conversion convention,
+// that bound is the responsibility of the request-side `Validate`
+// (which rejects negatives and overflow with a 400) on the
+// API-inbound path, or guaranteed by construction on the proto-inbound
+// path (where values originate from a proto `uint32` field).
+func IntPtrToUint32Ptr(i *int) *uint32 {
+	if i == nil {
+		return nil
+	}
+	u := uint32(*i) //nolint:gosec // bounded upstream by Validate / proto-source.
+	return &u
+}

--- a/db/pkg/db/model/common.go
+++ b/db/pkg/db/model/common.go
@@ -27,16 +27,45 @@ var protoJsonUnmarshalOptions = protojson.UnmarshalOptions{
 	DiscardUnknown: true,
 }
 
-// LabelsFromProtoMetadata converts a workflow Metadata's Labels list to a
-// string map. Returns nil when md is nil or md.Labels is nil; returns an
-// empty map (not nil) when Labels is non-nil but empty, so callers can
-// distinguish "no labels reported" from "labels explicitly cleared".
-func LabelsFromProtoMetadata(md *cwssaws.Metadata) map[string]string {
-	if md == nil || md.Labels == nil {
+// Labels is the canonical entity-side representation of a workflow
+// `Metadata.Labels` list — a key/value map that can be round-tripped
+// through `ToProto` / `FromProtoMetadata` without losing the empty
+// vs. nil distinction. Defining a named type lets us hang the proto
+// conversion on it as a method (`labels.ToProto()`) rather than
+// keeping a free function in this package.
+type Labels map[string]string
+
+// ToProto converts the labels into the workflow proto repeated Label
+// representation. Returns nil for a nil map; an empty map yields a
+// non-nil empty slice so callers can distinguish "labels explicitly
+// cleared" from "no labels at all".
+func (l Labels) ToProto() []*cwssaws.Label {
+	if l == nil {
 		return nil
 	}
-	result := map[string]string{}
-	for _, label := range md.Labels {
+	protoLabels := make([]*cwssaws.Label, 0, len(l))
+	for k, v := range l {
+		protoLabels = append(protoLabels, &cwssaws.Label{
+			Key:   k,
+			Value: &v,
+		})
+	}
+	return protoLabels
+}
+
+// FromProto populates the receiver from a workflow proto repeated Label
+// representation, mirroring `(Labels).ToProto()`. A nil input clears the
+// receiver to nil; a non-nil but empty input yields a non-nil empty map,
+// so callers can distinguish "no labels reported" from "labels explicitly
+// cleared". Entries with an empty key are skipped; a label with a nil
+// value resolves to an empty string.
+func (l *Labels) FromProto(protoLabels []*cwssaws.Label) {
+	if protoLabels == nil {
+		*l = nil
+		return
+	}
+	result := Labels{}
+	for _, label := range protoLabels {
 		if label == nil || label.Key == "" {
 			continue
 		}
@@ -46,5 +75,5 @@ func LabelsFromProtoMetadata(md *cwssaws.Metadata) map[string]string {
 		}
 		result[label.Key] = value
 	}
-	return result
+	*l = result
 }

--- a/db/pkg/db/model/common_test.go
+++ b/db/pkg/db/model/common_test.go
@@ -26,46 +26,37 @@ import (
 	cwssaws "github.com/NVIDIA/infra-controller-rest/workflow-schema/schema/site-agent/workflows/v1"
 )
 
-func TestLabelsFromProtoMetadata(t *testing.T) {
+func TestLabels_FromProto(t *testing.T) {
 	tests := []struct {
-		name string
-		md   *cwssaws.Metadata
-		want map[string]string
+		name        string
+		protoLabels []*cwssaws.Label
+		want        Labels
 	}{
 		{
-			name: "nil metadata",
-			md:   nil,
-			want: nil,
+			name:        "nil slice clears receiver",
+			protoLabels: nil,
+			want:        nil,
 		},
 		{
-			name: "nil labels slice",
-			md:   &cwssaws.Metadata{Labels: nil},
-			want: nil,
-		},
-		{
-			name: "empty labels slice",
-			md:   &cwssaws.Metadata{Labels: []*cwssaws.Label{}},
-			want: map[string]string{},
+			name:        "empty slice yields empty map",
+			protoLabels: []*cwssaws.Label{},
+			want:        Labels{},
 		},
 		{
 			name: "single label with value",
-			md: &cwssaws.Metadata{
-				Labels: []*cwssaws.Label{
-					{Key: "environment", Value: db.GetStrPtr("production")},
-				},
+			protoLabels: []*cwssaws.Label{
+				{Key: "environment", Value: db.GetStrPtr("production")},
 			},
-			want: map[string]string{"environment": "production"},
+			want: Labels{"environment": "production"},
 		},
 		{
 			name: "multiple labels",
-			md: &cwssaws.Metadata{
-				Labels: []*cwssaws.Label{
-					{Key: "environment", Value: db.GetStrPtr("production")},
-					{Key: "rack", Value: db.GetStrPtr("rack-1")},
-					{Key: "datacenter", Value: db.GetStrPtr("dc1")},
-				},
+			protoLabels: []*cwssaws.Label{
+				{Key: "environment", Value: db.GetStrPtr("production")},
+				{Key: "rack", Value: db.GetStrPtr("rack-1")},
+				{Key: "datacenter", Value: db.GetStrPtr("dc1")},
 			},
-			want: map[string]string{
+			want: Labels{
 				"environment": "production",
 				"rack":        "rack-1",
 				"datacenter":  "dc1",
@@ -73,37 +64,32 @@ func TestLabelsFromProtoMetadata(t *testing.T) {
 		},
 		{
 			name: "label with nil value yields empty string",
-			md: &cwssaws.Metadata{
-				Labels: []*cwssaws.Label{
-					{Key: "flag", Value: nil},
-				},
+			protoLabels: []*cwssaws.Label{
+				{Key: "flag", Value: nil},
 			},
-			want: map[string]string{"flag": ""},
+			want: Labels{"flag": ""},
 		},
 		{
 			name: "label with empty key is skipped",
-			md: &cwssaws.Metadata{
-				Labels: []*cwssaws.Label{
-					{Key: "", Value: db.GetStrPtr("value")},
-					{Key: "valid", Value: db.GetStrPtr("data")},
-				},
+			protoLabels: []*cwssaws.Label{
+				{Key: "", Value: db.GetStrPtr("value")},
+				{Key: "valid", Value: db.GetStrPtr("data")},
 			},
-			want: map[string]string{"valid": "data"},
+			want: Labels{"valid": "data"},
 		},
 		{
 			name: "nil label entry is skipped",
-			md: &cwssaws.Metadata{
-				Labels: []*cwssaws.Label{
-					nil,
-					{Key: "valid", Value: db.GetStrPtr("data")},
-				},
+			protoLabels: []*cwssaws.Label{
+				nil,
+				{Key: "valid", Value: db.GetStrPtr("data")},
 			},
-			want: map[string]string{"valid": "data"},
+			want: Labels{"valid": "data"},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := LabelsFromProtoMetadata(tc.md)
+			var got Labels
+			got.FromProto(tc.protoLabels)
 			if tc.want == nil {
 				assert.Nil(t, got)
 			} else {
@@ -111,4 +97,27 @@ func TestLabelsFromProtoMetadata(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestLabels_FromProto_OverwritesExistingReceiver verifies that the
+// method replaces the receiver wholesale, mirroring `ToProto` semantics:
+// pre-existing entries are not preserved across calls. The pointer
+// receiver makes the nil-input case observable (existing labels become
+// nil), which mirrors how the workflow `Metadata.Labels` round-trips a
+// "labels explicitly cleared" signal.
+func TestLabels_FromProto_OverwritesExistingReceiver(t *testing.T) {
+	t.Run("populated input replaces existing entries", func(t *testing.T) {
+		l := Labels{"stale": "value", "kept-key": "old"}
+		l.FromProto([]*cwssaws.Label{
+			{Key: "kept-key", Value: db.GetStrPtr("new")},
+			{Key: "fresh", Value: db.GetStrPtr("data")},
+		})
+		assert.Equal(t, Labels{"kept-key": "new", "fresh": "data"}, l)
+	})
+
+	t.Run("nil input clears existing entries", func(t *testing.T) {
+		l := Labels{"stale": "value"}
+		l.FromProto(nil)
+		assert.Nil(t, l)
+	})
 }

--- a/db/pkg/db/model/expectedmachine.go
+++ b/db/pkg/db/model/expectedmachine.go
@@ -61,30 +61,30 @@ var (
 type ExpectedMachine struct {
 	bun.BaseModel `bun:"table:expected_machine,alias:em"`
 
-	ID                       uuid.UUID         `bun:"id,pk"`
-	SiteID                   uuid.UUID         `bun:"site_id,type:uuid,notnull"`
-	Site                     *Site             `bun:"rel:belongs-to,join:site_id=id"`
-	BmcMacAddress            string            `bun:"bmc_mac_address,notnull"`
-	ChassisSerialNumber      string            `bun:"chassis_serial_number,notnull"`
-	SkuID                    *string           `bun:"sku_id"`
-	Sku                      *SKU              `bun:"rel:belongs-to,join:sku_id=id"`
-	MachineID                *string           `bun:"machine_id"`
-	Machine                  *Machine          `bun:"rel:belongs-to,join:machine_id=id"`
-	FallbackDpuSerialNumbers []string          `bun:"fallback_dpu_serial_numbers,array"`
-	BmcIpAddress             *string           `bun:"bmc_ip_address"`
-	RackID                   *string           `bun:"rack_id"`
-	Name                     *string           `bun:"name"`
-	Manufacturer             *string           `bun:"manufacturer"`
-	Model                    *string           `bun:"model"`
-	Description              *string           `bun:"description"`
-	FirmwareVersion          *string           `bun:"firmware_version"`
-	SlotID                   *int32            `bun:"slot_id"`
-	TrayIdx                  *int32            `bun:"tray_idx"`
-	HostID                   *int32            `bun:"host_id"`
-	Labels                   map[string]string `bun:"labels,type:jsonb"`
-	Created                  time.Time         `bun:"created,nullzero,notnull,default:current_timestamp"`
-	Updated                  time.Time         `bun:"updated,nullzero,notnull,default:current_timestamp"`
-	CreatedBy                uuid.UUID         `bun:"type:uuid,notnull"`
+	ID                       uuid.UUID `bun:"id,pk"`
+	SiteID                   uuid.UUID `bun:"site_id,type:uuid,notnull"`
+	Site                     *Site     `bun:"rel:belongs-to,join:site_id=id"`
+	BmcMacAddress            string    `bun:"bmc_mac_address,notnull"`
+	ChassisSerialNumber      string    `bun:"chassis_serial_number,notnull"`
+	SkuID                    *string   `bun:"sku_id"`
+	Sku                      *SKU      `bun:"rel:belongs-to,join:sku_id=id"`
+	MachineID                *string   `bun:"machine_id"`
+	Machine                  *Machine  `bun:"rel:belongs-to,join:machine_id=id"`
+	FallbackDpuSerialNumbers []string  `bun:"fallback_dpu_serial_numbers,array"`
+	BmcIpAddress             *string   `bun:"bmc_ip_address"`
+	RackID                   *string   `bun:"rack_id"`
+	Name                     *string   `bun:"name"`
+	Manufacturer             *string   `bun:"manufacturer"`
+	Model                    *string   `bun:"model"`
+	Description              *string   `bun:"description"`
+	FirmwareVersion          *string   `bun:"firmware_version"`
+	SlotID                   *int32    `bun:"slot_id"`
+	TrayIdx                  *int32    `bun:"tray_idx"`
+	HostID                   *int32    `bun:"host_id"`
+	Labels                   Labels    `bun:"labels,type:jsonb"`
+	Created                  time.Time `bun:"created,nullzero,notnull,default:current_timestamp"`
+	Updated                  time.Time `bun:"updated,nullzero,notnull,default:current_timestamp"`
+	CreatedBy                uuid.UUID `bun:"type:uuid,notnull"`
 }
 
 // ExpectedMachineCredentials carries the BMC credentials for one
@@ -196,7 +196,7 @@ func (em *ExpectedMachine) FromProto(proto *cwssaws.ExpectedMachine, linkedMachi
 	em.SlotID = proto.SlotId
 	em.TrayIdx = proto.TrayIdx
 	em.HostID = proto.HostId
-	em.Labels = LabelsFromProtoMetadata(proto.Metadata)
+	em.Labels.FromProto(proto.Metadata.GetLabels())
 }
 
 // ExpectedMachineCreateInput input parameters for Create method

--- a/db/pkg/db/model/expectedmachine_test.go
+++ b/db/pkg/db/model/expectedmachine_test.go
@@ -109,7 +109,7 @@ func TestExpectedMachine_FromProto(t *testing.T) {
 		assert.Equal(t, &slot, em.SlotID)
 		assert.Equal(t, &trayIdx, em.TrayIdx)
 		assert.Equal(t, &host, em.HostID)
-		assert.Equal(t, map[string]string{"env": "prod"}, em.Labels)
+		assert.Equal(t, Labels{"env": "prod"}, em.Labels)
 	})
 
 	t.Run("nil linkedMachineID leaves MachineID nil", func(t *testing.T) {
@@ -296,7 +296,7 @@ func TestExpectedMachineSQLDAO_Create(t *testing.T) {
 					assert.Equal(t, input.ChassisSerialNumber, em.ChassisSerialNumber)
 					assert.Equal(t, input.FallbackDpuSerialNumbers, em.FallbackDpuSerialNumbers)
 					assert.Equal(t, input.BmcIpAddress, em.BmcIpAddress)
-					assert.Equal(t, input.Labels, em.Labels)
+					assert.Equal(t, Labels(input.Labels), em.Labels)
 				}
 
 				if tc.verifyChildSpanner {
@@ -1021,7 +1021,7 @@ func TestExpectedMachineSQLDAO_Update(t *testing.T) {
 					assert.Equal(t, tc.input.FallbackDpuSerialNumbers, got.FallbackDpuSerialNumbers)
 				}
 				if tc.input.Labels != nil {
-					assert.Equal(t, tc.input.Labels, got.Labels)
+					assert.Equal(t, Labels(tc.input.Labels), got.Labels)
 				}
 
 				if tc.verifyChildSpanner {
@@ -1274,7 +1274,7 @@ func TestExpectedMachineSQLDAO_CreateMultiple(t *testing.T) {
 					assert.Equal(t, tc.inputs[i].BmcMacAddress, em.BmcMacAddress, "result order should match input order")
 					assert.Equal(t, tc.inputs[i].ChassisSerialNumber, em.ChassisSerialNumber)
 					assert.Equal(t, tc.inputs[i].FallbackDpuSerialNumbers, em.FallbackDpuSerialNumbers)
-					assert.Equal(t, tc.inputs[i].Labels, em.Labels)
+					assert.Equal(t, Labels(tc.inputs[i].Labels), em.Labels)
 					assert.NotZero(t, em.Created)
 					assert.NotZero(t, em.Updated)
 				}
@@ -1484,7 +1484,7 @@ func TestExpectedMachineSQLDAO_UpdateMultiple(t *testing.T) {
 						assert.Equal(t, tc.inputs[i].FallbackDpuSerialNumbers, em.FallbackDpuSerialNumbers)
 					}
 					if tc.inputs[i].Labels != nil {
-						assert.Equal(t, tc.inputs[i].Labels, em.Labels)
+						assert.Equal(t, Labels(tc.inputs[i].Labels), em.Labels)
 					}
 				}
 			}

--- a/db/pkg/db/model/expectedpowershelf.go
+++ b/db/pkg/db/model/expectedpowershelf.go
@@ -58,25 +58,25 @@ var (
 type ExpectedPowerShelf struct {
 	bun.BaseModel `bun:"table:expected_power_shelf,alias:eps"`
 
-	ID                uuid.UUID         `bun:"id,pk"`
-	SiteID            uuid.UUID         `bun:"site_id,type:uuid,notnull"`
-	Site              *Site             `bun:"rel:belongs-to,join:site_id=id"`
-	BmcMacAddress     string            `bun:"bmc_mac_address,notnull"`
-	ShelfSerialNumber string            `bun:"shelf_serial_number,notnull"`
-	BmcIpAddress      *string           `bun:"bmc_ip_address"`
-	RackID            *string           `bun:"rack_id"`
-	Name              *string           `bun:"name"`
-	Manufacturer      *string           `bun:"manufacturer"`
-	Model             *string           `bun:"model"`
-	Description       *string           `bun:"description"`
-	FirmwareVersion   *string           `bun:"firmware_version"`
-	SlotID            *int32            `bun:"slot_id"`
-	TrayIdx           *int32            `bun:"tray_idx"`
-	HostID            *int32            `bun:"host_id"`
-	Labels            map[string]string `bun:"labels,type:jsonb"`
-	Created           time.Time         `bun:"created,nullzero,notnull,default:current_timestamp"`
-	Updated           time.Time         `bun:"updated,nullzero,notnull,default:current_timestamp"`
-	CreatedBy         uuid.UUID         `bun:"type:uuid,notnull"`
+	ID                uuid.UUID `bun:"id,pk"`
+	SiteID            uuid.UUID `bun:"site_id,type:uuid,notnull"`
+	Site              *Site     `bun:"rel:belongs-to,join:site_id=id"`
+	BmcMacAddress     string    `bun:"bmc_mac_address,notnull"`
+	ShelfSerialNumber string    `bun:"shelf_serial_number,notnull"`
+	BmcIpAddress      *string   `bun:"bmc_ip_address"`
+	RackID            *string   `bun:"rack_id"`
+	Name              *string   `bun:"name"`
+	Manufacturer      *string   `bun:"manufacturer"`
+	Model             *string   `bun:"model"`
+	Description       *string   `bun:"description"`
+	FirmwareVersion   *string   `bun:"firmware_version"`
+	SlotID            *int32    `bun:"slot_id"`
+	TrayIdx           *int32    `bun:"tray_idx"`
+	HostID            *int32    `bun:"host_id"`
+	Labels            Labels    `bun:"labels,type:jsonb"`
+	Created           time.Time `bun:"created,nullzero,notnull,default:current_timestamp"`
+	Updated           time.Time `bun:"updated,nullzero,notnull,default:current_timestamp"`
+	CreatedBy         uuid.UUID `bun:"type:uuid,notnull"`
 }
 
 // ExpectedPowerShelfCredentials carries the BMC credentials for one
@@ -187,7 +187,7 @@ func (eps *ExpectedPowerShelf) FromProto(proto *cwssaws.ExpectedPowerShelf) {
 	eps.SlotID = proto.SlotId
 	eps.TrayIdx = proto.TrayIdx
 	eps.HostID = proto.HostId
-	eps.Labels = LabelsFromProtoMetadata(proto.Metadata)
+	eps.Labels.FromProto(proto.Metadata.GetLabels())
 }
 
 // ExpectedPowerShelfCreateInput input parameters for Create method

--- a/db/pkg/db/model/expectedpowershelf_test.go
+++ b/db/pkg/db/model/expectedpowershelf_test.go
@@ -101,7 +101,7 @@ func TestExpectedPowerShelf_FromProto(t *testing.T) {
 		assert.Equal(t, &slot, eps.SlotID)
 		assert.Equal(t, &trayIdx, eps.TrayIdx)
 		assert.Equal(t, &host, eps.HostID)
-		assert.Equal(t, map[string]string{"env": "prod"}, eps.Labels)
+		assert.Equal(t, Labels{"env": "prod"}, eps.Labels)
 	})
 
 	t.Run("empty BmcIpAddress yields nil pointer", func(t *testing.T) {
@@ -242,7 +242,7 @@ func TestExpectedPowerShelfSQLDAO_Create(t *testing.T) {
 					assert.Equal(t, input.BmcMacAddress, eps.BmcMacAddress)
 					assert.Equal(t, input.ShelfSerialNumber, eps.ShelfSerialNumber)
 					assert.Equal(t, input.BmcIpAddress, eps.BmcIpAddress)
-					assert.Equal(t, input.Labels, eps.Labels)
+					assert.Equal(t, Labels(input.Labels), eps.Labels)
 				}
 
 				if tc.verifyChildSpanner {
@@ -626,7 +626,7 @@ func TestExpectedPowerShelfSQLDAO_Update(t *testing.T) {
 					assert.Equal(t, tc.input.BmcIpAddress, got.BmcIpAddress)
 				}
 				if tc.input.Labels != nil {
-					assert.Equal(t, tc.input.Labels, got.Labels)
+					assert.Equal(t, Labels(tc.input.Labels), got.Labels)
 				}
 
 				if tc.verifyChildSpanner {

--- a/db/pkg/db/model/expectedrack.go
+++ b/db/pkg/db/model/expectedrack.go
@@ -60,17 +60,17 @@ var (
 type ExpectedRack struct {
 	bun.BaseModel `bun:"table:expected_rack,alias:er"`
 
-	ID            uuid.UUID         `bun:"id,pk"`
-	SiteID        uuid.UUID         `bun:"site_id,type:uuid,notnull"`
-	Site          *Site             `bun:"rel:belongs-to,join:site_id=id"`
-	RackID        string            `bun:"rack_id,notnull"`
-	RackProfileID string            `bun:"rack_profile_id,notnull"`
-	Name          string            `bun:"name,nullzero,notnull,default:''"`
-	Description   string            `bun:"description,nullzero,notnull,default:''"`
-	Labels        map[string]string `bun:"labels,type:jsonb,nullzero,notnull,default:'{}'"`
-	Created       time.Time         `bun:"created,nullzero,notnull,default:current_timestamp"`
-	Updated       time.Time         `bun:"updated,nullzero,notnull,default:current_timestamp"`
-	CreatedBy     uuid.UUID         `bun:"type:uuid,notnull"`
+	ID            uuid.UUID `bun:"id,pk"`
+	SiteID        uuid.UUID `bun:"site_id,type:uuid,notnull"`
+	Site          *Site     `bun:"rel:belongs-to,join:site_id=id"`
+	RackID        string    `bun:"rack_id,notnull"`
+	RackProfileID string    `bun:"rack_profile_id,notnull"`
+	Name          string    `bun:"name,nullzero,notnull,default:''"`
+	Description   string    `bun:"description,nullzero,notnull,default:''"`
+	Labels        Labels    `bun:"labels,type:jsonb,nullzero,notnull,default:'{}'"`
+	Created       time.Time `bun:"created,nullzero,notnull,default:current_timestamp"`
+	Updated       time.Time `bun:"updated,nullzero,notnull,default:current_timestamp"`
+	CreatedBy     uuid.UUID `bun:"type:uuid,notnull"`
 }
 
 // ExpectedRackCreateInput input parameters for Create method
@@ -153,7 +153,7 @@ func (er *ExpectedRack) FromProto(proto *cwssaws.ExpectedRack) {
 		er.Name = ""
 		er.Description = ""
 	}
-	er.Labels = LabelsFromProtoMetadata(proto.Metadata)
+	er.Labels.FromProto(proto.Metadata.GetLabels())
 }
 
 var _ bun.BeforeAppendModelHook = (*ExpectedRack)(nil)

--- a/db/pkg/db/model/expectedrack_test.go
+++ b/db/pkg/db/model/expectedrack_test.go
@@ -86,7 +86,7 @@ func TestExpectedRack_FromProto(t *testing.T) {
 		assert.Equal(t, "type-A", er.RackProfileID)
 		assert.Equal(t, "rack-name", er.Name)
 		assert.Equal(t, "primary rack", er.Description)
-		assert.Equal(t, map[string]string{"env": "prod"}, er.Labels)
+		assert.Equal(t, Labels{"env": "prod"}, er.Labels)
 	})
 
 	t.Run("nil Metadata clears Name/Description and Labels", func(t *testing.T) {
@@ -268,9 +268,9 @@ func TestExpectedRackDAO_Create(t *testing.T) {
 					assert.Equal(t, input.Description, er.Description)
 					if input.Labels == nil {
 						// default is empty map
-						assert.Equal(t, map[string]string{}, er.Labels)
+						assert.Equal(t, Labels{}, er.Labels)
 					} else {
-						assert.Equal(t, input.Labels, er.Labels)
+						assert.Equal(t, Labels(input.Labels), er.Labels)
 					}
 				}
 
@@ -737,7 +737,7 @@ func TestExpectedRackDAO_Update(t *testing.T) {
 					assert.Equal(t, *tc.input.Description, got.Description)
 				}
 				if tc.input.Labels != nil {
-					assert.Equal(t, tc.input.Labels, got.Labels)
+					assert.Equal(t, Labels(tc.input.Labels), got.Labels)
 				}
 
 				if tc.verifyChildSpanner {

--- a/db/pkg/db/model/expectedswitch.go
+++ b/db/pkg/db/model/expectedswitch.go
@@ -58,25 +58,25 @@ var (
 type ExpectedSwitch struct {
 	bun.BaseModel `bun:"table:expected_switch,alias:es"`
 
-	ID                 uuid.UUID         `bun:"id,pk"`
-	SiteID             uuid.UUID         `bun:"site_id,type:uuid,notnull"`
-	Site               *Site             `bun:"rel:belongs-to,join:site_id=id"`
-	BmcMacAddress      string            `bun:"bmc_mac_address,notnull"`
-	SwitchSerialNumber string            `bun:"switch_serial_number,notnull"`
-	BmcIpAddress       *string           `bun:"bmc_ip_address"`
-	RackID             *string           `bun:"rack_id"`
-	Name               *string           `bun:"name"`
-	Manufacturer       *string           `bun:"manufacturer"`
-	Model              *string           `bun:"model"`
-	Description        *string           `bun:"description"`
-	FirmwareVersion    *string           `bun:"firmware_version"`
-	SlotID             *int32            `bun:"slot_id"`
-	TrayIdx            *int32            `bun:"tray_idx"`
-	HostID             *int32            `bun:"host_id"`
-	Labels             map[string]string `bun:"labels,type:jsonb"`
-	Created            time.Time         `bun:"created,nullzero,notnull,default:current_timestamp"`
-	Updated            time.Time         `bun:"updated,nullzero,notnull,default:current_timestamp"`
-	CreatedBy          uuid.UUID         `bun:"type:uuid,notnull"`
+	ID                 uuid.UUID `bun:"id,pk"`
+	SiteID             uuid.UUID `bun:"site_id,type:uuid,notnull"`
+	Site               *Site     `bun:"rel:belongs-to,join:site_id=id"`
+	BmcMacAddress      string    `bun:"bmc_mac_address,notnull"`
+	SwitchSerialNumber string    `bun:"switch_serial_number,notnull"`
+	BmcIpAddress       *string   `bun:"bmc_ip_address"`
+	RackID             *string   `bun:"rack_id"`
+	Name               *string   `bun:"name"`
+	Manufacturer       *string   `bun:"manufacturer"`
+	Model              *string   `bun:"model"`
+	Description        *string   `bun:"description"`
+	FirmwareVersion    *string   `bun:"firmware_version"`
+	SlotID             *int32    `bun:"slot_id"`
+	TrayIdx            *int32    `bun:"tray_idx"`
+	HostID             *int32    `bun:"host_id"`
+	Labels             Labels    `bun:"labels,type:jsonb"`
+	Created            time.Time `bun:"created,nullzero,notnull,default:current_timestamp"`
+	Updated            time.Time `bun:"updated,nullzero,notnull,default:current_timestamp"`
+	CreatedBy          uuid.UUID `bun:"type:uuid,notnull"`
 }
 
 // ExpectedSwitchCredentials carries the BMC and NVOS credentials for one
@@ -194,7 +194,7 @@ func (es *ExpectedSwitch) FromProto(proto *cwssaws.ExpectedSwitch) {
 	es.SlotID = proto.SlotId
 	es.TrayIdx = proto.TrayIdx
 	es.HostID = proto.HostId
-	es.Labels = LabelsFromProtoMetadata(proto.Metadata)
+	es.Labels.FromProto(proto.Metadata.GetLabels())
 }
 
 // ExpectedSwitchCreateInput input parameters for Create method

--- a/db/pkg/db/model/expectedswitch_test.go
+++ b/db/pkg/db/model/expectedswitch_test.go
@@ -101,7 +101,7 @@ func TestExpectedSwitch_FromProto(t *testing.T) {
 		assert.Equal(t, &slot, es.SlotID)
 		assert.Equal(t, &trayIdx, es.TrayIdx)
 		assert.Equal(t, &host, es.HostID)
-		assert.Equal(t, map[string]string{"env": "prod"}, es.Labels)
+		assert.Equal(t, Labels{"env": "prod"}, es.Labels)
 	})
 
 	t.Run("empty BmcIpAddress yields nil pointer", func(t *testing.T) {
@@ -240,7 +240,7 @@ func TestExpectedSwitchSQLDAO_Create(t *testing.T) {
 					assert.Equal(t, input.BmcMacAddress, es.BmcMacAddress)
 					assert.Equal(t, input.SwitchSerialNumber, es.SwitchSerialNumber)
 					assert.Equal(t, input.BmcIpAddress, es.BmcIpAddress)
-					assert.Equal(t, input.Labels, es.Labels)
+					assert.Equal(t, Labels(input.Labels), es.Labels)
 				}
 
 				if tc.verifyChildSpanner {
@@ -608,7 +608,7 @@ func TestExpectedSwitchSQLDAO_Update(t *testing.T) {
 					assert.Equal(t, *tc.input.SwitchSerialNumber, got.SwitchSerialNumber)
 				}
 				if tc.input.Labels != nil {
-					assert.Equal(t, tc.input.Labels, got.Labels)
+					assert.Equal(t, Labels(tc.input.Labels), got.Labels)
 				}
 
 				if tc.verifyChildSpanner {

--- a/db/pkg/db/model/instancetype.go
+++ b/db/pkg/db/model/instancetype.go
@@ -20,6 +20,7 @@ package model
 import (
 	"context"
 	"database/sql"
+	"slices"
 	"time"
 
 	"github.com/NVIDIA/infra-controller-rest/db/pkg/db"
@@ -30,6 +31,7 @@ import (
 	"github.com/uptrace/bun"
 
 	stracer "github.com/NVIDIA/infra-controller-rest/db/pkg/tracer"
+	cwssaws "github.com/NVIDIA/infra-controller-rest/workflow-schema/schema/site-agent/workflows/v1"
 )
 
 const (
@@ -88,13 +90,124 @@ type InstanceType struct {
 	InfinityResourceTypeID   *uuid.UUID              `bun:"infinity_resource_type_id,type:uuid"`
 	SiteID                   *uuid.UUID              `bun:"site_id,type:uuid"`
 	Site                     *Site                   `bun:"rel:belongs-to,join:site_id=id"`
-	Labels                   map[string]string       `bun:"labels,type:jsonb"`
+	Labels                   Labels                  `bun:"labels,type:jsonb"`
 	Status                   string                  `bun:"status,notnull"`
 	Created                  time.Time               `bun:"created,nullzero,notnull,default:current_timestamp"`
 	Updated                  time.Time               `bun:"updated,nullzero,notnull,default:current_timestamp"`
 	Deleted                  *time.Time              `bun:"deleted,soft_delete"`
 	CreatedBy                uuid.UUID               `bun:"type:uuid,notnull"`
 	Version                  string                  `bun:"version,notnull"`
+
+	// Capabilities is the set of MachineCapability rows that describe this
+	// InstanceType's filter attributes. Populated either via a bun query
+	// with `.Relation("Capabilities")` or by the handler assigning the
+	// loaded slice directly before calling `ToProto`. Ordering matters at
+	// the wire — callers are responsible for sorting by Index before
+	// assigning. Not persisted on InstanceType itself; the relation is
+	// "instance_type has-many machine_capability".
+	Capabilities []*MachineCapability `bun:"rel:has-many,join:id=instance_type_id"`
+}
+
+// AttachCapabilities populates `it.Capabilities` from a DAO-loaded
+// `[]MachineCapability` slice, sorting by `Index` first so the wire
+// ordering matches what NICo expects. Callers (handlers) hand off the
+// raw DAO output and let the entity own the slice-of-values-to-
+// slice-of-pointers shape needed for ToProto.
+func (it *InstanceType) AttachCapabilities(mcs []MachineCapability) {
+	slices.SortFunc(mcs, func(a, b MachineCapability) int {
+		return a.Index - b.Index
+	})
+	it.Capabilities = make([]*MachineCapability, len(mcs))
+	for i := range mcs {
+		it.Capabilities[i] = &mcs[i]
+	}
+}
+
+// ToProto converts this InstanceType into its workflow proto
+// representation. Used as the canonical entity-to-proto conversion;
+// request-shape protos (create / update) are produced by `ToProto`
+// methods on the corresponding API request types in
+// api/pkg/api/model/instancetype.go.
+//
+// Capabilities come from `it.Capabilities` (populated either via a bun
+// `.Relation("Capabilities")` query or by the handler via
+// `AttachCapabilities`). Each MachineCapability does its own
+// `mc.ToProto()` mapping, which is a pure mapper that trusts the
+// request-side `Validate` having already gated the type / device-type
+// / numeric bounds. A nil/empty `Capabilities` slice yields a nil
+// `Attributes.DesiredCapabilities` so the proto round-trips cleanly.
+func (it *InstanceType) ToProto() *cwssaws.InstanceType {
+	var capabilities []*cwssaws.InstanceTypeMachineCapabilityFilterAttributes
+	for _, mc := range it.Capabilities {
+		if mc == nil {
+			continue
+		}
+		capabilities = append(capabilities, mc.ToProto())
+	}
+	md := &cwssaws.Metadata{Name: it.Name, Labels: it.Labels.ToProto()}
+	if it.Description != nil {
+		md.Description = *it.Description
+	}
+	return &cwssaws.InstanceType{
+		Id:       it.ID.String(),
+		Metadata: md,
+		Attributes: &cwssaws.InstanceTypeAttributes{
+			DesiredCapabilities: capabilities,
+		},
+	}
+}
+
+// FromProto populates this InstanceType from its workflow proto
+// representation. A nil proto is a no-op. This is the inverse of
+// `ToProto` and exists for convention symmetry — currently no code
+// path on the cloud side reconstructs a full InstanceType entity from
+// a `cwssaws.InstanceType` (the site is the destination, not the
+// source), but the method is provided so future reconciliation flows
+// have a single canonical entry point.
+//
+// Field-level contract:
+//   - `it.ID` is preserved on a missing or unparseable `proto.Id`,
+//     because callers pre-validate the UUID before calling.
+//   - `Name` is sourced from `proto.Metadata.Name`.
+//   - `Description` is cleared when the proto's Metadata omits it
+//     (empty string), so `FromProto` is a clean reset rather than a
+//     partial merge.
+//   - `Labels` are taken from `proto.Metadata.Labels`; a nil Metadata
+//     clears them.
+//
+// `Attributes` (capabilities) is intentionally NOT mapped onto the
+// receiver because capabilities live in a separate DB table and would
+// require DAO writes the model layer should not perform.
+func (it *InstanceType) FromProto(proto *cwssaws.InstanceType) {
+	if proto == nil {
+		return
+	}
+	if id, err := uuid.Parse(proto.Id); err == nil {
+		it.ID = id
+	}
+	// Reset metadata-derived fields up front so the `clean reset rather
+	// than a partial merge` contract holds when proto.Metadata is nil
+	// or omits a field.
+	it.Name = ""
+	it.Description = nil
+	it.Labels = nil
+	if proto.Metadata != nil {
+		it.Name = proto.Metadata.Name
+		if proto.Metadata.Description != "" {
+			desc := proto.Metadata.Description
+			it.Description = &desc
+		}
+		it.Labels.FromProto(proto.Metadata.GetLabels())
+	}
+}
+
+// ToDeletionRequestProto builds the workflow request that asks a Site
+// to delete this InstanceType. Lives on the entity because the delete
+// handler has no API request body — the entity's ID is the only input.
+func (it *InstanceType) ToDeletionRequestProto() *cwssaws.DeleteInstanceTypeRequest {
+	return &cwssaws.DeleteInstanceTypeRequest{
+		Id: it.ID.String(),
+	}
 }
 
 var _ bun.BeforeAppendModelHook = (*InstanceType)(nil)

--- a/db/pkg/db/model/instancetype_test.go
+++ b/db/pkg/db/model/instancetype_test.go
@@ -30,9 +30,176 @@ import (
 	"github.com/NVIDIA/infra-controller-rest/db/pkg/db/paginator"
 	stracer "github.com/NVIDIA/infra-controller-rest/db/pkg/tracer"
 	"github.com/NVIDIA/infra-controller-rest/db/pkg/util"
+	cwssaws "github.com/NVIDIA/infra-controller-rest/workflow-schema/schema/site-agent/workflows/v1"
 	"github.com/google/uuid"
 	"github.com/uptrace/bun/extra/bundebug"
 )
+
+func TestInstanceType_ToProto(t *testing.T) {
+	id := uuid.New()
+	desc := "primary"
+
+	t.Run("populates id metadata and capabilities sourced from it.Capabilities", func(t *testing.T) {
+		it := &InstanceType{
+			ID:          id,
+			Name:        "small",
+			Description: &desc,
+			Labels:      map[string]string{"env": "prod"},
+			Capabilities: []*MachineCapability{
+				{Type: MachineCapabilityTypeCPU, Name: "cpu-0"},
+			},
+		}
+		proto := it.ToProto()
+		require.NotNil(t, proto)
+		assert.Equal(t, id.String(), proto.Id)
+		require.NotNil(t, proto.Metadata)
+		assert.Equal(t, "small", proto.Metadata.Name)
+		assert.Equal(t, "primary", proto.Metadata.Description)
+		require.Len(t, proto.Metadata.Labels, 1)
+		assert.Equal(t, "env", proto.Metadata.Labels[0].Key)
+		require.NotNil(t, proto.Metadata.Labels[0].Value)
+		assert.Equal(t, "prod", *proto.Metadata.Labels[0].Value)
+		require.NotNil(t, proto.Attributes)
+		require.Len(t, proto.Attributes.DesiredCapabilities, 1)
+		assert.Equal(t, cwssaws.MachineCapabilityType_CAP_TYPE_CPU, proto.Attributes.DesiredCapabilities[0].CapabilityType)
+		require.NotNil(t, proto.Attributes.DesiredCapabilities[0].Name)
+		assert.Equal(t, "cpu-0", *proto.Attributes.DesiredCapabilities[0].Name)
+	})
+
+	t.Run("nil description and labels yield empty metadata fields, no capabilities yields nil", func(t *testing.T) {
+		it := &InstanceType{ID: id, Name: "small"}
+		proto := it.ToProto()
+		require.NotNil(t, proto)
+		assert.Equal(t, "", proto.Metadata.Description)
+		assert.Nil(t, proto.Metadata.Labels)
+		require.NotNil(t, proto.Attributes)
+		assert.Nil(t, proto.Attributes.DesiredCapabilities)
+	})
+
+	t.Run("nil entries in Capabilities are skipped", func(t *testing.T) {
+		it := &InstanceType{
+			ID:   id,
+			Name: "small",
+			Capabilities: []*MachineCapability{
+				nil,
+				{Type: MachineCapabilityTypeMemory, Name: "mem-0"},
+				nil,
+			},
+		}
+		proto := it.ToProto()
+		require.NotNil(t, proto.Attributes)
+		require.Len(t, proto.Attributes.DesiredCapabilities, 1)
+		assert.Equal(t, cwssaws.MachineCapabilityType_CAP_TYPE_MEMORY, proto.Attributes.DesiredCapabilities[0].CapabilityType)
+	})
+}
+
+func TestInstanceType_FromProto(t *testing.T) {
+	id := uuid.New()
+
+	t.Run("nil proto leaves the receiver untouched", func(t *testing.T) {
+		desc := "original"
+		it := &InstanceType{
+			ID:          id,
+			Name:        "name",
+			Description: &desc,
+			Labels:      map[string]string{"a": "1"},
+		}
+		it.FromProto(nil)
+		assert.Equal(t, id, it.ID)
+		assert.Equal(t, "name", it.Name)
+		require.NotNil(t, it.Description)
+		assert.Equal(t, "original", *it.Description)
+		assert.Equal(t, Labels{"a": "1"}, it.Labels)
+	})
+
+	t.Run("populates from proto metadata", func(t *testing.T) {
+		v := "v1"
+		proto := &cwssaws.InstanceType{
+			Id: id.String(),
+			Metadata: &cwssaws.Metadata{
+				Name:        "small",
+				Description: "primary",
+				Labels:      []*cwssaws.Label{{Key: "env", Value: &v}},
+			},
+		}
+		it := &InstanceType{}
+		it.FromProto(proto)
+		assert.Equal(t, id, it.ID)
+		assert.Equal(t, "small", it.Name)
+		require.NotNil(t, it.Description)
+		assert.Equal(t, "primary", *it.Description)
+		assert.Equal(t, Labels{"env": "v1"}, it.Labels)
+	})
+
+	t.Run("clears optional fields when proto Metadata omits them", func(t *testing.T) {
+		desc := "original"
+		it := &InstanceType{
+			ID:          id,
+			Description: &desc,
+			Labels:      map[string]string{"a": "1"},
+		}
+		proto := &cwssaws.InstanceType{
+			Id:       id.String(),
+			Metadata: &cwssaws.Metadata{Name: "small"},
+		}
+		it.FromProto(proto)
+		assert.Equal(t, "small", it.Name)
+		assert.Nil(t, it.Description)
+		assert.Nil(t, it.Labels)
+	})
+
+	t.Run("preserves existing ID when proto Id is unparseable", func(t *testing.T) {
+		it := &InstanceType{ID: id}
+		proto := &cwssaws.InstanceType{Id: "not-a-uuid"}
+		it.FromProto(proto)
+		assert.Equal(t, id, it.ID)
+	})
+
+	t.Run("clears Name, Description, Labels when proto Metadata is nil", func(t *testing.T) {
+		desc := "stale"
+		it := &InstanceType{
+			ID:          id,
+			Name:        "stale",
+			Description: &desc,
+			Labels:      map[string]string{"old": "val"},
+		}
+		proto := &cwssaws.InstanceType{Id: id.String()}
+		it.FromProto(proto)
+		assert.Equal(t, "", it.Name)
+		assert.Nil(t, it.Description)
+		assert.Nil(t, it.Labels)
+	})
+}
+
+func TestInstanceType_ToDeletionRequestProto(t *testing.T) {
+	id := uuid.New()
+	it := &InstanceType{ID: id}
+	req := it.ToDeletionRequestProto()
+	require.NotNil(t, req)
+	assert.Equal(t, id.String(), req.Id)
+}
+
+func TestLabels_ToProto(t *testing.T) {
+	t.Run("nil map yields nil slice", func(t *testing.T) {
+		var l Labels
+		assert.Nil(t, l.ToProto())
+	})
+	t.Run("empty map yields empty slice", func(t *testing.T) {
+		got := Labels{}.ToProto()
+		require.NotNil(t, got)
+		assert.Len(t, got, 0)
+	})
+	t.Run("populated map round-trips through ordering-agnostic comparison", func(t *testing.T) {
+		got := Labels{"a": "1", "b": "2"}.ToProto()
+		require.Len(t, got, 2)
+		seen := map[string]string{}
+		for _, l := range got {
+			require.NotNil(t, l.Value)
+			seen[l.Key] = *l.Value
+		}
+		assert.Equal(t, map[string]string{"a": "1", "b": "2"}, seen)
+	})
+}
 
 func testInstanceTypeInitDB(t *testing.T) *db.Session {
 	dbSession := util.GetTestDBSession(t, false)
@@ -783,7 +950,7 @@ func TestInstanceTypeSQLDAO_Update(t *testing.T) {
 		expectedDescription            *string
 		expectedInfinityResourceTypeID *uuid.UUID
 		expectedSiteID                 *uuid.UUID
-		expectedLabels                 map[string]string
+		expectedLabels                 Labels
 		expectedStatus                 *string
 		expectedVersion                *string
 		verifyChildSpanner             bool
@@ -857,7 +1024,7 @@ func TestInstanceTypeSQLDAO_Update(t *testing.T) {
 			expectedDisplayName: db.GetStrPtr("updatedDisplayName"),
 			expectedDescription: db.GetStrPtr("updatedDescription"),
 			expectedSiteID:      &site2.ID,
-			expectedLabels:      map[string]string{"test2": "test2"},
+			expectedLabels:      Labels{"test2": "test2"},
 			expectedStatus:      db.GetStrPtr(InstanceTypeStatusPending),
 		},
 		{
@@ -992,7 +1159,7 @@ func TestInstanceTypeSQLDAO_Clear(t *testing.T) {
 		expectedDisplayName *string
 		expectedDescription *string
 		expectedSiteID      *uuid.UUID
-		expectedLabels      map[string]string
+		expectedLabels      Labels
 		verifyChildSpanner  bool
 	}{
 		{
@@ -1028,7 +1195,7 @@ func TestInstanceTypeSQLDAO_Clear(t *testing.T) {
 			expectedDisplayName: nil,
 			expectedDescription: nil,
 			expectedSiteID:      nil,
-			expectedLabels:      map[string]string{"test1": "test1"},
+			expectedLabels:      Labels{"test1": "test1"},
 		},
 		{
 			desc:             "can clear labels",

--- a/db/pkg/db/model/machinecapability.go
+++ b/db/pkg/db/model/machinecapability.go
@@ -26,13 +26,16 @@ import (
 	"strings"
 	"time"
 
+	cutil "github.com/NVIDIA/infra-controller-rest/common/pkg/util"
 	"github.com/NVIDIA/infra-controller-rest/db/pkg/db"
 	"github.com/NVIDIA/infra-controller-rest/db/pkg/db/paginator"
 	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
 
 	"github.com/uptrace/bun"
 
 	stracer "github.com/NVIDIA/infra-controller-rest/db/pkg/tracer"
+	cwssaws "github.com/NVIDIA/infra-controller-rest/workflow-schema/schema/site-agent/workflows/v1"
 )
 
 // MachineCapabilityType
@@ -147,6 +150,80 @@ type MachineCapability struct {
 	ValueStr    *string `bun:"value_str"`
 	ValueInt    *int    `bun:"value_int"`
 	Description *string `bun:"description"`
+}
+
+// ToProto converts this MachineCapability to its workflow proto
+// representation used in InstanceType filter attributes.
+//
+// Per the proto-conversion convention, this is a pure mapper and does
+// not return errors. An unknown Type leaves the proto's CapabilityType
+// as the zero enum value with a warning logged; an unknown DeviceType is
+// dropped to nil. Numeric width casts are inline and rely on request-side
+// `Validate` having bounded the values to uint32 before they ever reach
+// the DB.
+//
+// The string-to-enum mappings are inlined as switches because the
+// underlying DB columns are plain strings — there is no
+// `MachineCapabilityType` Go type to hang a method on. If those columns
+// ever become typed-string enums, this is the natural place to swap to
+// `mc.Type.ToProto()`.
+func (mc *MachineCapability) ToProto() *cwssaws.InstanceTypeMachineCapabilityFilterAttributes {
+	var capType cwssaws.MachineCapabilityType
+	switch mc.Type {
+	case MachineCapabilityTypeCPU:
+		capType = cwssaws.MachineCapabilityType_CAP_TYPE_CPU
+	case MachineCapabilityTypeMemory:
+		capType = cwssaws.MachineCapabilityType_CAP_TYPE_MEMORY
+	case MachineCapabilityTypeGPU:
+		capType = cwssaws.MachineCapabilityType_CAP_TYPE_GPU
+	case MachineCapabilityTypeStorage:
+		capType = cwssaws.MachineCapabilityType_CAP_TYPE_STORAGE
+	case MachineCapabilityTypeNetwork:
+		capType = cwssaws.MachineCapabilityType_CAP_TYPE_NETWORK
+	case MachineCapabilityTypeInfiniBand:
+		capType = cwssaws.MachineCapabilityType_CAP_TYPE_INFINIBAND
+	case MachineCapabilityTypeDPU:
+		capType = cwssaws.MachineCapabilityType_CAP_TYPE_DPU
+	default:
+		log.Warn().Str("Type", mc.Type).Msg("unsupported MachineCapabilityType requested")
+	}
+
+	var inactiveDevices *cwssaws.Uint32List
+	if mc.InactiveDevices != nil {
+		inactiveDevices = &cwssaws.Uint32List{}
+		for _, d := range mc.InactiveDevices {
+			u := cutil.IntPtrToUint32Ptr(&d)
+			inactiveDevices.Items = append(inactiveDevices.Items, *u)
+		}
+	}
+
+	var deviceType *cwssaws.MachineCapabilityDeviceType
+	if mc.DeviceType != nil {
+		switch *mc.DeviceType {
+		case MachineCapabilityDeviceTypeDPU:
+			dt := cwssaws.MachineCapabilityDeviceType_MACHINE_CAPABILITY_DEVICE_TYPE_DPU
+			deviceType = &dt
+		case MachineCapabilityDeviceTypeNVLink:
+			dt := cwssaws.MachineCapabilityDeviceType_MACHINE_CAPABILITY_DEVICE_TYPE_NVLINK
+			deviceType = &dt
+		default:
+			log.Warn().Str("DeviceType", *mc.DeviceType).Msg("unsupported MachineCapabilityDeviceType requested")
+		}
+	}
+
+	return &cwssaws.InstanceTypeMachineCapabilityFilterAttributes{
+		CapabilityType:   capType,
+		Name:             &mc.Name,
+		Frequency:        mc.Frequency,
+		Capacity:         mc.Capacity,
+		Vendor:           mc.Vendor,
+		Count:            cutil.IntPtrToUint32Ptr(mc.Count),
+		DeviceType:       deviceType,
+		HardwareRevision: mc.HardwareRevision,
+		InactiveDevices:  inactiveDevices,
+		Cores:            cutil.IntPtrToUint32Ptr(mc.Cores),
+		Threads:          cutil.IntPtrToUint32Ptr(mc.Threads),
+	}
 }
 
 // GetStrInfo returns the string value of the given key in the Info map

--- a/db/pkg/db/model/machinecapability_test.go
+++ b/db/pkg/db/model/machinecapability_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/NVIDIA/infra-controller-rest/db/pkg/db/paginator"
 	stracer "github.com/NVIDIA/infra-controller-rest/db/pkg/tracer"
 	"github.com/NVIDIA/infra-controller-rest/db/pkg/util"
+	cwssaws "github.com/NVIDIA/infra-controller-rest/workflow-schema/schema/site-agent/workflows/v1"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1505,4 +1506,77 @@ func TestMachineCapability_GetIntInfo(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMachineCapability_ToProto(t *testing.T) {
+	count := 4
+	cores := 16
+	threads := 32
+	freq := "3.5GHz"
+	vendor := "ACME"
+	rev := "v1"
+	dpu := MachineCapabilityDeviceTypeDPU
+
+	t.Run("populates all fields from a CPU capability", func(t *testing.T) {
+		mc := &MachineCapability{
+			Type:             MachineCapabilityTypeCPU,
+			Name:             "cpu-0",
+			Frequency:        &freq,
+			Vendor:           &vendor,
+			HardwareRevision: &rev,
+			Count:            &count,
+			Cores:            &cores,
+			Threads:          &threads,
+		}
+		proto := mc.ToProto()
+		require.NotNil(t, proto)
+		assert.Equal(t, cwssaws.MachineCapabilityType_CAP_TYPE_CPU, proto.CapabilityType)
+		require.NotNil(t, proto.Name)
+		assert.Equal(t, "cpu-0", *proto.Name)
+		require.NotNil(t, proto.Frequency)
+		assert.Equal(t, freq, *proto.Frequency)
+		require.NotNil(t, proto.Vendor)
+		assert.Equal(t, vendor, *proto.Vendor)
+		require.NotNil(t, proto.HardwareRevision)
+		assert.Equal(t, rev, *proto.HardwareRevision)
+		require.NotNil(t, proto.Count)
+		assert.Equal(t, uint32(4), *proto.Count)
+		require.NotNil(t, proto.Cores)
+		assert.Equal(t, uint32(16), *proto.Cores)
+		require.NotNil(t, proto.Threads)
+		assert.Equal(t, uint32(32), *proto.Threads)
+		assert.Nil(t, proto.DeviceType)
+		assert.Nil(t, proto.InactiveDevices)
+	})
+
+	t.Run("maps Network + DPU device type to the proto enum", func(t *testing.T) {
+		mc := &MachineCapability{
+			Type:       MachineCapabilityTypeNetwork,
+			Name:       "net-0",
+			DeviceType: &dpu,
+		}
+		proto := mc.ToProto()
+		assert.Equal(t, cwssaws.MachineCapabilityType_CAP_TYPE_NETWORK, proto.CapabilityType)
+		require.NotNil(t, proto.DeviceType)
+		assert.Equal(t, cwssaws.MachineCapabilityDeviceType_MACHINE_CAPABILITY_DEVICE_TYPE_DPU, *proto.DeviceType)
+	})
+
+	t.Run("maps InfiniBand InactiveDevices into a Uint32List", func(t *testing.T) {
+		mc := &MachineCapability{
+			Type:            MachineCapabilityTypeInfiniBand,
+			Name:            "ib-0",
+			InactiveDevices: []int{2, 5},
+		}
+		proto := mc.ToProto()
+		require.NotNil(t, proto.InactiveDevices)
+		assert.Equal(t, []uint32{2, 5}, proto.InactiveDevices.Items)
+	})
+
+	t.Run("unknown type leaves CapabilityType as zero, unknown device type drops to nil", func(t *testing.T) {
+		unknown := "Unknown"
+		mc := &MachineCapability{Type: "Mystery", Name: "x", DeviceType: &unknown}
+		proto := mc.ToProto()
+		assert.Equal(t, cwssaws.MachineCapabilityType(0), proto.CapabilityType)
+		assert.Nil(t, proto.DeviceType)
+	})
 }

--- a/db/pkg/db/model/vpc.go
+++ b/db/pkg/db/model/vpc.go
@@ -106,7 +106,7 @@ type Vpc struct {
 	NetworkSecurityGroupID                 *string                                 `bun:"network_security_group_id"`
 	NetworkSecurityGroup                   *NetworkSecurityGroup                   `bun:"rel:belongs-to,join:network_security_group_id=id"`
 	NetworkSecurityGroupPropagationDetails *NetworkSecurityGroupPropagationDetails `bun:"network_security_group_propagation_details,type:jsonb"`
-	Labels                                 map[string]string                       `bun:"labels,type:jsonb"`
+	Labels                                 Labels                                  `bun:"labels,type:jsonb"`
 	Status                                 string                                  `bun:"status,notnull"`
 	IsMissingOnSite                        bool                                    `bun:"is_missing_on_site,notnull"`
 	Created                                time.Time                               `bun:"created,nullzero,notnull,default:current_timestamp"`
@@ -227,7 +227,7 @@ func (vpc *Vpc) FromProto(proto *cwssaws.Vpc) {
 			desc := proto.Metadata.Description
 			vpc.Description = &desc
 		}
-		vpc.Labels = LabelsFromProtoMetadata(proto.Metadata)
+		vpc.Labels.FromProto(proto.Metadata.GetLabels())
 	} else {
 		vpc.Description = nil
 		vpc.Labels = nil

--- a/db/pkg/db/model/vpc_test.go
+++ b/db/pkg/db/model/vpc_test.go
@@ -1649,7 +1649,7 @@ func TestVpc_FromProto(t *testing.T) {
 		assert.Equal(t, nvllpID, *v.NVLinkLogicalPartitionID)
 		require.NotNil(t, v.Description)
 		assert.Equal(t, "primary", *v.Description)
-		assert.Equal(t, map[string]string{"env": "prod"}, v.Labels)
+		assert.Equal(t, Labels{"env": "prod"}, v.Labels)
 	})
 
 	t.Run("missing optional fields are explicitly cleared", func(t *testing.T) {

--- a/workflow/pkg/activity/expectedmachine/expectedmachine_test.go
+++ b/workflow/pkg/activity/expectedmachine/expectedmachine_test.go
@@ -439,7 +439,8 @@ func TestManageExpectedMachine_UpdateExpectedMachinesInDB(t *testing.T) {
 						fmt.Sprintf("ExpectedMachine %v should have been updated", em.ID))
 
 					// Verify labels are updated correctly
-					expectedLabels := cdbm.LabelsFromProtoMetadata(ctrlEM.Metadata)
+					var expectedLabels cdbm.Labels
+					expectedLabels.FromProto(ctrlEM.Metadata.GetLabels())
 					// Both nil and empty maps should be treated as equivalent (no labels)
 					if len(expectedLabels) == 0 && len(updated.Labels) == 0 {
 						// Both are effectively empty, which is correct
@@ -462,7 +463,8 @@ func TestManageExpectedMachine_UpdateExpectedMachinesInDB(t *testing.T) {
 				assert.NoError(t, perr)
 				created := machinesByID[emID]
 				if created != nil {
-					expectedLabels := cdbm.LabelsFromProtoMetadata(cem.Metadata)
+					var expectedLabels cdbm.Labels
+					expectedLabels.FromProto(cem.Metadata.GetLabels())
 					// Both nil and empty maps should be treated as equivalent (no labels)
 					if len(expectedLabels) == 0 && len(created.Labels) == 0 {
 						// Both are effectively empty, which is correct

--- a/workflow/pkg/activity/expectedpowershelf/expectedpowershelf_test.go
+++ b/workflow/pkg/activity/expectedpowershelf/expectedpowershelf_test.go
@@ -464,7 +464,8 @@ func TestManageExpectedPowerShelf_UpdateExpectedPowerShelvesInDB(t *testing.T) {
 					}
 
 					// Verify labels are updated correctly
-					expectedLabels := cdbm.LabelsFromProtoMetadata(ctrlEPS.Metadata)
+					var expectedLabels cdbm.Labels
+					expectedLabels.FromProto(ctrlEPS.Metadata.GetLabels())
 					// Both nil and empty maps should be treated as equivalent (no labels)
 					if len(expectedLabels) == 0 && len(updated.Labels) == 0 {
 						// Both are effectively empty, which is correct
@@ -487,7 +488,8 @@ func TestManageExpectedPowerShelf_UpdateExpectedPowerShelvesInDB(t *testing.T) {
 				assert.NoError(t, perr)
 				created := powerShelvesByID[epsID]
 				if created != nil {
-					expectedLabels := cdbm.LabelsFromProtoMetadata(ceps.Metadata)
+					var expectedLabels cdbm.Labels
+					expectedLabels.FromProto(ceps.Metadata.GetLabels())
 					// Both nil and empty maps should be treated as equivalent (no labels)
 					if len(expectedLabels) == 0 && len(created.Labels) == 0 {
 						// Both are effectively empty, which is correct

--- a/workflow/pkg/activity/expectedrack/expectedrack_test.go
+++ b/workflow/pkg/activity/expectedrack/expectedrack_test.go
@@ -466,7 +466,8 @@ func TestManageExpectedRack_UpdateExpectedRacksInDB(t *testing.T) {
 					assert.Equal(t, reportedDescription, updated.Description,
 						fmt.Sprintf("ExpectedRack %v Description should match", er.RackID))
 
-					expectedLabels := cdbm.LabelsFromProtoMetadata(ctrlER.Metadata)
+					var expectedLabels cdbm.Labels
+					expectedLabels.FromProto(ctrlER.Metadata.GetLabels())
 					if len(expectedLabels) == 0 && len(updated.Labels) == 0 {
 						// Both effectively empty, which is correct
 					} else {
@@ -501,7 +502,8 @@ func TestManageExpectedRack_UpdateExpectedRacksInDB(t *testing.T) {
 					assert.Equal(t, reportedDescription, created.Description,
 						fmt.Sprintf("ExpectedRack %v Description should match on creation", cer.RackId.Id))
 
-					expectedLabels := cdbm.LabelsFromProtoMetadata(cer.Metadata)
+					var expectedLabels cdbm.Labels
+					expectedLabels.FromProto(cer.Metadata.GetLabels())
 					if len(expectedLabels) == 0 && len(created.Labels) == 0 {
 						// Both effectively empty, which is correct
 					} else {

--- a/workflow/pkg/activity/expectedswitch/expectedswitch_test.go
+++ b/workflow/pkg/activity/expectedswitch/expectedswitch_test.go
@@ -431,7 +431,8 @@ func TestManageExpectedSwitch_UpdateExpectedSwitchesInDB(t *testing.T) {
 						fmt.Sprintf("ExpectedSwitch %v should have been updated", es.ID))
 
 					// Verify labels are updated correctly
-					expectedLabels := cdbm.LabelsFromProtoMetadata(ctrlES.Metadata)
+					var expectedLabels cdbm.Labels
+					expectedLabels.FromProto(ctrlES.Metadata.GetLabels())
 					// Both nil and empty maps should be treated as equivalent (no labels)
 					if len(expectedLabels) == 0 && len(updated.Labels) == 0 {
 						// Both are effectively empty, which is correct
@@ -454,7 +455,8 @@ func TestManageExpectedSwitch_UpdateExpectedSwitchesInDB(t *testing.T) {
 				assert.NoError(t, perr)
 				created := switchesByID[esID]
 				if created != nil {
-					expectedLabels := cdbm.LabelsFromProtoMetadata(ces.Metadata)
+					var expectedLabels cdbm.Labels
+					expectedLabels.FromProto(ces.Metadata.GetLabels())
 					// Both nil and empty maps should be treated as equivalent (no labels)
 					if len(expectedLabels) == 0 && len(created.Labels) == 0 {
 						// Both are effectively empty, which is correct


### PR DESCRIPTION
## Description

Brings the `InstanceType` handler in line with our proto modeling. Instead of building workflow requests inline next to the RPC calls, the handler now goes through `ToProto`-style receiver methods on the appropriate types: the *create* and *update* flows live on the API request types (because each has a client body driving the shape), and the *delete* flow lives on the entity (because it has no API body).

**Capabilities** now ride along on the entity itself via a `Capabilities` relation, so a single `apiRequest.ToProto(it)` call is all the handler needs; per-capability wire rules live in `Validate`, keeping `ToProto` a pure mapper, which is the goal we're looking to achieve here.

We now have:
- API request side: `(*APIInstanceTypeCreateRequest).ToProto(it)` and `(*APIInstanceTypeUpdateRequest).ToProto(it)`
- Entity side: `(*InstanceType).ToProto()` / `FromProto(proto)`
- Capabilities are sourced from the new `it.Capabilities`, and each `(*MachineCapability).ToProto()` does its own mapping.

As mentioned above, per-capability rules (device type / InactiveDevices / numeric bounds) now live in `APIInstanceTypeCreateRequest.Validate` and `APIInstanceTypeUpdateRequest.Validate` (including a new `validateMachineCapUint32Bounds` that was put together), so by the time the request reaches `ToProto`, everything is safe to map.

I did have to do some reworking of things to fit the pattern, now it's all in line with the distinct `Validate` + `ToProto` flow that @thossain-nv is hoping to get out of this!

Tests added!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>


## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [x] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [x] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [x] **Site Agent** - Site Agent updated
- [ ] **Flow** - Flow service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
