### PR TITLE
fix: Add create verb for forge.nvidia.io/sites in site-manager RBAC

### DIFF
--- a/deploy/INSTALLATION.md
+++ b/deploy/INSTALLATION.md
@@ -481,13 +481,13 @@ kubectl wait --for=condition=complete job/nico-rest-db-migration -n nico-rest --
 
 | File | Contents |
 |---|---|
-| `base/site-manager/site-crd.yaml` | CRD `sites.nico.nvidia.io` — the `Site` custom resource |
+| `base/site-manager/site-crd.yaml` | CRD `sites.forge.nvidia.io` — the `Site` custom resource |
 | `base/site-manager/deployment.yaml` | Deployment `nico-rest-site-manager` |
 | `base/site-manager/certificate.yaml` | cert-manager `Certificate` `site-manager-tls` — TLS cert for the HTTPS server |
 | `base/site-manager/rbac.yaml` | ServiceAccount + Role/RoleBinding + ClusterRole/ClusterRoleBinding |
 | `base/site-manager/service.yaml` | ClusterIP Service on port 8100 — DNS: `nico-rest-site-manager.nico-rest` |
 
-### Site CRD (`sites.nico.nvidia.io`)
+### Site CRD (`sites.forge.nvidia.io`)
 
 ```yaml
 spec:

--- a/helm/README.md
+++ b/helm/README.md
@@ -32,7 +32,7 @@ The following must be running before installing charts:
 - **cert-manager.io** with ClusterIssuer `nico-rest-ca-issuer`
 - **Keycloak** (optional) — only if using Keycloak for authentication
 
-> The Site CRD (`sites.nico.nvidia.io`) is bundled in `nico-rest-site-manager/crds/` and installed automatically by Helm.
+> The Site CRD (`sites.forge.nvidia.io`) is bundled in `nico-rest-site-manager/crds/` and installed automatically by Helm.
 
 ## Authentication
 

--- a/helm/charts/nico-rest/Chart.lock
+++ b/helm/charts/nico-rest/Chart.lock
@@ -13,9 +13,9 @@ dependencies:
   version: 0.1.0
 - name: nico-rest-site-manager
   repository: ""
-  version: 0.1.0
+  version: 0.1.1
 - name: nico-rest-db
   repository: ""
   version: 0.1.0
-digest: sha256:7cec75245925550764a6da00ce3cb01a9d065b7edffc76c07736d4c05aca860e
-generated: "2026-05-13T10:07:24.468333-07:00"
+digest: sha256:241b9c676f1c73361c20c25df6901b76de1e5e349cc305a6670c14a2652a6759
+generated: "2026-05-19T16:45:16.67864-07:00"

--- a/helm/charts/nico-rest/Chart.yaml
+++ b/helm/charts/nico-rest/Chart.yaml
@@ -17,7 +17,7 @@ apiVersion: v2
 name: nico-rest
 description: Umbrella chart for the NICo REST API platform
 type: application
-version: 0.1.10
+version: 0.1.11
 appVersion: "1.5.0"
 keywords:
   - nico
@@ -39,7 +39,7 @@ dependencies:
     version: "0.1.0"
     condition: nico-rest-workflow.enabled
   - name: nico-rest-site-manager
-    version: "0.1.0"
+    version: "0.1.1"
     condition: nico-rest-site-manager.enabled
   - name: nico-rest-db
     version: "0.1.0"

--- a/helm/charts/nico-rest/charts/nico-rest-site-manager/Chart.yaml
+++ b/helm/charts/nico-rest/charts/nico-rest-site-manager/Chart.yaml
@@ -17,7 +17,7 @@ apiVersion: v2
 name: nico-rest-site-manager
 description: Helm chart for the NICo REST site lifecycle manager
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "latest"
 keywords:
   - nico

--- a/helm/charts/nico-rest/charts/nico-rest-site-manager/templates/rbac.yaml
+++ b/helm/charts/nico-rest/charts/nico-rest-site-manager/templates/rbac.yaml
@@ -39,7 +39,7 @@ rules:
   # TODO: remove forge.nvidia.io rules once all site agents have migrated to nico.nvidia.io.
   - apiGroups: ["forge.nvidia.io"]
     resources: ["sites"]
-    verbs: ["get", "list", "watch", "update", "patch", "delete"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["forge.nvidia.io"]
     resources: ["sites/status"]
     verbs: ["get", "update", "patch"]
@@ -81,7 +81,7 @@ rules:
   # TODO: remove forge.nvidia.io rules once all site agents have migrated to nico.nvidia.io.
   - apiGroups: ["forge.nvidia.io"]
     resources: ["sites"]
-    verbs: ["get", "list", "watch", "update", "patch", "delete"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["forge.nvidia.io"]
     resources: ["sites/status"]
     verbs: ["get", "update", "patch"]

--- a/helm/charts/nico-rest/charts/nico-rest-site-manager/templates/rbac.yaml
+++ b/helm/charts/nico-rest/charts/nico-rest-site-manager/templates/rbac.yaml
@@ -30,13 +30,6 @@ metadata:
   labels:
     {{- include "nico-rest-site-manager.labels" . | nindent 4 }}
 rules:
-  - apiGroups: ["nico.nvidia.io"]
-    resources: ["sites"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: ["nico.nvidia.io"]
-    resources: ["sites/status"]
-    verbs: ["get", "update", "patch"]
-  # TODO: remove forge.nvidia.io rules once all site agents have migrated to nico.nvidia.io.
   - apiGroups: ["forge.nvidia.io"]
     resources: ["sites"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
@@ -72,13 +65,6 @@ metadata:
   labels:
     {{- include "nico-rest-site-manager.labels" . | nindent 4 }}
 rules:
-  - apiGroups: ["nico.nvidia.io"]
-    resources: ["sites"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: ["nico.nvidia.io"]
-    resources: ["sites/status"]
-    verbs: ["get", "update", "patch"]
-  # TODO: remove forge.nvidia.io rules once all site agents have migrated to nico.nvidia.io.
   - apiGroups: ["forge.nvidia.io"]
     resources: ["sites"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]


### PR DESCRIPTION
## Description

Role/ClusterRole granted to the `nico-rest-site-manager` ServiceAccount in `helm/charts/nico-rest/charts/nico-rest-site-manager/templates/rbac.yaml` are missing the `create` verb on `forge.nvidia.io/sites` resources.

Without `create`, `POST /v2/org/{org}/nico/site` fails at runtime when the site-manager attempts to create the underlying Site CR. The API surfaces this as HTTP 500:

```json
{"source":"nico","message":"Unable to create Site Manager entry for Site","data":null}
```

`forge.nvidia.io` CRDs are going to be deprecated in favor of `nico.nvidia.io` CRDs in future. However the repo incorrectly refers to `nico.nvidia.io` CRDs which do not exist. This PR cleans up the references which should not be present until a migration PR is added.

### Reproduction

After `make kind-reset-helm` from a clean checkout (which calls `helm-deploy-site-agent`):

```
deployment "nico-rest-api" successfully rolled out
Waiting for site-manager...
pod/nico-rest-site-manager-... condition met
Allowing API and Temporal to stabilize...
Acquiring token...
Creating site...
Site creation attempt 1 failed (HTTP 500), retrying...
Response: {"source":"nico","message":"Unable to create Site Manager entry for Site","data":null}
Site creation attempt 2 failed (HTTP 500), retrying...
ERROR: Failed to create site (HTTP 500)
make[1]: *** [Makefile:572: helm-deploy-site-agent] Error 1
```

Manually granting `create` on `forge.nvidia.io/sites` to the `nico-rest-site-manager` ServiceAccount resolves the failure.

### Root cause

The Role and ClusterRole for `forge.nvidia.io/sites` had:
```yaml
verbs: ["get", "list", "watch", "update", "patch", "delete"]
```
## Type of Change
- [x] **Fix** - Bug fixes (fix:)

## Services Affected
- [x] **Site Manager** - Site Manager updated

## Related Issues (Optional)

The same fix was previously bundled inside #507 ("Feat/rename ncx to nico"), but #507 was closed without merging on 2026-05-13, so the bug is still live on `main`. Opening this as a focused, single-purpose PR per [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) (*"Keep pull requests focused on a single change"*) so it can land independently of any future rename effort.

## Breaking Changes

- [ ] This PR contains breaking changes

Adding a verb to a Role/ClusterRole is permission-additive and cannot break existing deployments.

## Testing
- [x] Manual testing performed

Verified by re-running `make helm-deploy-site-agent` against a kind cluster with the patched RBAC: the previously failing `Creating site...` step succeeds.

> [!NOTE]  
> Drafted with Claude assistance. The problem was discovered by me (jeremypruitt) and manually verified by me, reproducing the HTTP 500 against a kind cluster and confirming the patched RBAC unblocks Site creation.