### PR TITLE
fix: Delete InfiniBand Interfaces based on config sync flag instead of Instance status

### DIFF
--- a/api/pkg/api/handler/instance.go
+++ b/api/pkg/api/handler/instance.go
@@ -55,7 +55,8 @@ import (
 )
 
 const (
-	NVLinkInterfaceStatusSyncGraceWindow = 90 * time.Second
+	NVLinkInterfaceStatusSyncGraceWindow     = 90 * time.Second
+	InfiniBandInterfaceStatusSyncGraceWindow = 30 * time.Second
 )
 
 // ~~~~~ Create Handler ~~~~~ //
@@ -2718,6 +2719,7 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 	var dbskgs []cdbm.SSHKeyGroup
 	var ssds []cdbm.StatusDetail
 	reqCtx := ctx
+	reIssueInfiniBandInterfaces := false
 	reIssueNVLinkInterfaces := false
 
 	// timeoutResp lets the closure signal a post-rollback handler — the
@@ -2990,46 +2992,97 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 		}
 
 		if apiRequest.InfiniBandInterfaces != nil {
-			for _, apiibifc := range apiRequest.InfiniBandInterfaces {
-				// NOTE: This is redundant due to earlier validation, but we handle it anyway
-				ibpID, err := uuid.Parse(apiibifc.InfiniBandPartitionID)
-				if err != nil {
-					logger.Error().Err(err).Msg("failed to parse InfinibandPartitionID")
-					return cutil.NewAPIError(http.StatusBadRequest, fmt.Sprintf("Failed to parse InfiniBand Partition ID specified in request: %s", apiibifc.InfiniBandPartitionID), nil)
-				}
 
-				dbibifc, err := ibiDAO.Create(ctx, tx, cdbm.InfiniBandInterfaceCreateInput{
-					InstanceID:            instanceID,
-					SiteID:                site.ID,
-					InfiniBandPartitionID: ibpID,
-					Device:                apiibifc.Device,
-					Vendor:                apiibifc.Vendor,
-					DeviceInstance:        apiibifc.DeviceInstance,
-					IsPhysical:            apiibifc.IsPhysical,
-					VirtualFunctionID:     apiibifc.VirtualFunctionID,
-					Status:                cdbm.InfiniBandInterfaceStatusPending,
-					CreatedBy:             dbUser.ID,
-				})
+			// Bucket existing InfiniBand rows by (partition ID, device name, device instance) so we can align with the incoming request.
+			existingIbIfcMap := make(map[string][]cdbm.InfiniBandInterface)
 
-				if err != nil {
-					logger.Error().Err(err).Msg("failed to create Infiniband Interface record in DB")
-					return cutil.NewAPIError(http.StatusInternalServerError, "Failed to create Infiniband Interface for Instance, DB error", nil)
-				}
-
-				newIbIfcs = append(newIbIfcs, *dbibifc)
+			// There can be multiple historical rows per key; Ordering existingIbIfcs by Created ascending makes the slice per key chronological.
+			for i := range existingIbIfcs {
+				key := fmt.Sprintf("%s:%s:%d", existingIbIfcs[i].InfiniBandPartitionID.String(), existingIbIfcs[i].Device, existingIbIfcs[i].DeviceInstance)
+				existingIbIfcMap[key] = append(existingIbIfcMap[key], existingIbIfcs[i])
 			}
 
-			// Update status of existing InfiniBand Interfaces to Deleting
-			for i := range existingIbIfcs {
-				existingIbIfcs[i].Status = cdbm.InfiniBandInterfaceStatusDeleting
-				_, err = ibiDAO.Update(ctx, tx, cdbm.InfiniBandInterfaceUpdateInput{
-					InfiniBandInterfaceID: existingIbIfcs[i].ID,
-					Status:                cdb.GetStrPtr(cdbm.InfiniBandInterfaceStatusDeleting),
-				})
-				if err != nil {
-					logger.Error().Err(err).Msg("failed to update Infiniband Interface record in DB")
-					return cutil.NewAPIError(http.StatusInternalServerError, "Failed to update Infiniband Interface for Instance, DB error", nil)
+			existingReadyIbIfcsCount := 0
+			existingPendingIbIfcsCount := 0
+			existingDeletingIbIfcsCount := 0
+
+			for _, apiIbIfc := range apiRequest.InfiniBandInterfaces {
+				key := fmt.Sprintf("%s:%s:%d", apiIbIfc.InfiniBandPartitionID, apiIbIfc.Device, apiIbIfc.DeviceInstance)
+				existingIbIfcsForKey := existingIbIfcMap[key]
+
+				// Check the status of the most recent InfiniBand interface for this (partition, device, device instance) key.
+				if len(existingIbIfcsForKey) > 0 {
+					mostRecentIbIfc := existingIbIfcsForKey[len(existingIbIfcsForKey)-1]
+					if mostRecentIbIfc.Status == cdbm.InfiniBandInterfaceStatusReady {
+						// This interface is already ready, we don't need to re-issue the InfiniBand interface
+						existingReadyIbIfcsCount++
+					} else {
+						if mostRecentIbIfc.Updated.After(time.Now().Add(-InfiniBandInterfaceStatusSyncGraceWindow)) {
+							if mostRecentIbIfc.Status == cdbm.InfiniBandInterfaceStatusPending {
+								existingPendingIbIfcsCount++
+							} else if mostRecentIbIfc.Status == cdbm.InfiniBandInterfaceStatusDeleting {
+								existingDeletingIbIfcsCount++
+							}
+						} else {
+							reIssueInfiniBandInterfaces = true
+						}
+					}
+				} else {
+					// No existing InfiniBand interface found for this InfiniBand Partition ID, Device and Device Instance
+					reIssueInfiniBandInterfaces = true
 				}
+			}
+
+			// Each requested (partition ID, device, deviceInstance) slot should have matched exactly once in the Ready / in-grace Pending / in-grace Deleting buckets; otherwise we need another sync pass.
+			syncedIbIfcSlots := existingReadyIbIfcsCount + existingPendingIbIfcsCount + existingDeletingIbIfcsCount
+			if !reIssueInfiniBandInterfaces && syncedIbIfcSlots != len(apiRequest.InfiniBandInterfaces) {
+				reIssueInfiniBandInterfaces = true
+			}
+
+			if reIssueInfiniBandInterfaces {
+				for _, apiibifc := range apiRequest.InfiniBandInterfaces {
+					// NOTE: This is redundant due to earlier validation, but we handle it anyway
+					ibpID, err := uuid.Parse(apiibifc.InfiniBandPartitionID)
+					if err != nil {
+						logger.Error().Err(err).Msg("failed to parse InfinibandPartitionID")
+						return cutil.NewAPIError(http.StatusBadRequest, fmt.Sprintf("Failed to parse InfiniBand Partition ID specified in request: %s", apiibifc.InfiniBandPartitionID), nil)
+					}
+
+					dbibifc, err := ibiDAO.Create(ctx, tx, cdbm.InfiniBandInterfaceCreateInput{
+						InstanceID:            instanceID,
+						SiteID:                site.ID,
+						InfiniBandPartitionID: ibpID,
+						Device:                apiibifc.Device,
+						Vendor:                apiibifc.Vendor,
+						DeviceInstance:        apiibifc.DeviceInstance,
+						IsPhysical:            apiibifc.IsPhysical,
+						VirtualFunctionID:     apiibifc.VirtualFunctionID,
+						Status:                cdbm.InfiniBandInterfaceStatusPending,
+						CreatedBy:             dbUser.ID,
+					})
+
+					if err != nil {
+						logger.Error().Err(err).Msg("failed to create Infiniband Interface record in DB")
+						return cutil.NewAPIError(http.StatusInternalServerError, "Failed to create Infiniband Interface for Instance, DB error", nil)
+					}
+
+					newIbIfcs = append(newIbIfcs, *dbibifc)
+				}
+
+				// Update status of existing InfiniBand Interfaces to Deleting
+				for i := range existingIbIfcs {
+					existingIbIfcs[i].Status = cdbm.InfiniBandInterfaceStatusDeleting
+					_, err = ibiDAO.Update(ctx, tx, cdbm.InfiniBandInterfaceUpdateInput{
+						InfiniBandInterfaceID: existingIbIfcs[i].ID,
+						Status:                cdb.GetStrPtr(cdbm.InfiniBandInterfaceStatusDeleting),
+					})
+					if err != nil {
+						logger.Error().Err(err).Msg("failed to update Infiniband Interface record in DB")
+						return cutil.NewAPIError(http.StatusInternalServerError, "Failed to update Infiniband Interface for Instance, DB error", nil)
+					}
+				}
+			} else {
+				newIbIfcs = existingIbIfcs
 			}
 		} else {
 			newIbIfcs = existingIbIfcs
@@ -3452,7 +3505,7 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 	}
 
 	// If existing InfiniBand Interfaces were updated, add them to the response
-	if len(existingIbIfcs) > 0 {
+	if len(existingIbIfcs) > 0 && !reIssueInfiniBandInterfaces {
 		// Add the existing InfiniBand Interfaces to the response
 		newIbIfcs = append(newIbIfcs, existingIbIfcs...)
 	}

--- a/api/pkg/api/handler/instance.go
+++ b/api/pkg/api/handler/instance.go
@@ -2716,6 +2716,8 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 	var existingIfcs []cdbm.Interface
 	var existingIbIfcs []cdbm.InfiniBandInterface
 	var existingNvlIfcs []cdbm.NVLinkInterface
+	var newOrExistingIbIfcs []cdbm.InfiniBandInterface
+	var newOrExistingNvlIfcs []cdbm.NVLinkInterface
 	var dbskgs []cdbm.SSHKeyGroup
 	var ssds []cdbm.StatusDetail
 	reqCtx := ctx
@@ -3033,10 +3035,21 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 				}
 			}
 
-			// Each requested (partition ID, device, deviceInstance) slot should have matched exactly once in the Ready / in-grace Pending / in-grace Deleting buckets; otherwise we need another sync pass.
-			syncedIbIfcSlots := existingReadyIbIfcsCount + existingPendingIbIfcsCount + existingDeletingIbIfcsCount
-			if !reIssueInfiniBandInterfaces && syncedIbIfcSlots != len(apiRequest.InfiniBandInterfaces) {
-				reIssueInfiniBandInterfaces = true
+			// If we're here and we're not re-issuing InfiniBand interfaces, we need to check if the number of existing InfiniBand interfaces in transition is different from the number of InfiniBand interfaces in the request
+			// Assumptions:
+			// - There can be no more than 4 InfiniBand Interfaces in Ready state
+			// - There can be no more than 4 InfiniBand Interfaces in Pending state
+			// - There can more than 4 InfiniBand Interfaces in Deleting state, in multiples of 4
+			// - There cannot be Ready and Pending InfiniBand Interfaces at the same time
+			// - There cannot be Ready and Deleting InfiniBand Interfaces at the same time
+			if !reIssueInfiniBandInterfaces {
+				if existingReadyIbIfcsCount > 0 && existingReadyIbIfcsCount != len(apiRequest.InfiniBandInterfaces) {
+					reIssueInfiniBandInterfaces = true
+				} else if existingPendingIbIfcsCount > 0 && existingPendingIbIfcsCount != len(apiRequest.InfiniBandInterfaces) {
+					reIssueInfiniBandInterfaces = true
+				} else if existingDeletingIbIfcsCount > 0 && existingDeletingIbIfcsCount != len(apiRequest.InfiniBandInterfaces) {
+					reIssueInfiniBandInterfaces = true
+				}
 			}
 
 			if reIssueInfiniBandInterfaces {
@@ -3081,11 +3094,7 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 						return cutil.NewAPIError(http.StatusInternalServerError, "Failed to update Infiniband Interface for Instance, DB error", nil)
 					}
 				}
-			} else {
-				newIbIfcs = existingIbIfcs
 			}
-		} else {
-			newIbIfcs = existingIbIfcs
 		}
 
 		// Fetch existing DPU Extension Service Deployments for the Instance
@@ -3227,8 +3236,21 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 				}
 			}
 
-			if !reIssueNVLinkInterfaces && (existingReadyNvlIfcsCount != len(apiRequest.NVLinkInterfaces) || (existingPendingNvlIfcsCount != len(apiRequest.NVLinkInterfaces)) || (existingDeletingNvlIfcsCount != 0)) {
-				reIssueNVLinkInterfaces = true
+			// If we're here and we're not re-issuing NVLink interfaces, we need to check if the number of existing NVLink interfaces in transition is different from the number of NVLink interfaces in the request
+			// Assumptions:
+			// - There can be no more than 4 NVLink Interfaces in Ready state
+			// - There can be no more than 4 NVLink Interfaces in Pending state
+			// - There can more than 4 NVLink Interfaces in Deleting state, in multiples of 4
+			// - There cannot be Ready and Pending NVLink Interfaces at the same time
+			// - There cannot be Ready and Deleting NVLink Interfaces at the same time
+			if !reIssueNVLinkInterfaces {
+				if existingReadyNvlIfcsCount > 0 && existingReadyNvlIfcsCount != len(apiRequest.NVLinkInterfaces) {
+					reIssueNVLinkInterfaces = true
+				} else if existingPendingNvlIfcsCount > 0 && existingPendingNvlIfcsCount != len(apiRequest.NVLinkInterfaces) {
+					reIssueNVLinkInterfaces = true
+				} else if existingDeletingNvlIfcsCount > 0 && existingDeletingNvlIfcsCount != len(apiRequest.NVLinkInterfaces) {
+					reIssueNVLinkInterfaces = true
+				}
 			}
 
 			if reIssueNVLinkInterfaces {
@@ -3280,11 +3302,7 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 						return cutil.NewAPIError(http.StatusInternalServerError, "Failed to update NVLink Interfaces for Instance, DB error", nil)
 					}
 				}
-			} else {
-				newNvlIfcs = existingNvlIfcs
 			}
-		} else {
-			newNvlIfcs = existingNvlIfcs
 		}
 
 		// Get Status Details
@@ -3357,9 +3375,11 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 		}
 
 		// Populate InfiniBand Interface details for Site Controller request
+		// This loop accommodates both cases where InfiniBand Interfaces for updated or no update was requested
+		// IF there are any new InfiniBand Interfaces, that means all existing InfiniBand Interfaces will be in Deleting state
 		ibInterfaceConfigs := []*cwssaws.InstanceIBInterfaceConfig{}
-
-		for _, newIbIfc := range newIbIfcs {
+		newOrExistingIbIfcs = append(newIbIfcs, existingIbIfcs...)
+		for _, newIbIfc := range newOrExistingIbIfcs {
 			if newIbIfc.Status == cdbm.InfiniBandInterfaceStatusDeleting {
 				// NOTE: Don't send any InfiniBand Interfaces that are being deleted
 				continue
@@ -3403,8 +3423,11 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 		}
 
 		// Populate NVLink Interface details for Site Controller request
+		// IF there are any new NVLink Interfaces, that means all existing NVLink Interfaces will be in Deleting state
+		// This loop accommodates both cases where NVLink Interfaces for updated or no update was requested
 		nvlInterfaceConfigs := []*cwssaws.InstanceNVLinkGpuConfig{}
-		for _, newNvlIfc := range newNvlIfcs {
+		newOrExistingNvlIfcs = append(newNvlIfcs, existingNvlIfcs...)
+		for _, newNvlIfc := range newOrExistingNvlIfcs {
 			if newNvlIfc.Status == cdbm.NVLinkInterfaceStatusDeleting {
 				// NOTE: Don't send any NVLink interfaces that are being deleted
 				continue
@@ -3504,20 +3527,8 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 		newdbIfcs = append(newdbIfcs, existingIfcs...)
 	}
 
-	// If existing InfiniBand Interfaces were updated, add them to the response
-	if len(existingIbIfcs) > 0 && !reIssueInfiniBandInterfaces {
-		// Add the existing InfiniBand Interfaces to the response
-		newIbIfcs = append(newIbIfcs, existingIbIfcs...)
-	}
-
-	// If existing NVLink Interfaces were updated, add them to the response
-	if len(existingNvlIfcs) > 0 && !reIssueNVLinkInterfaces {
-		// Add the existing NVLink Interfaces to the response
-		newNvlIfcs = append(newNvlIfcs, existingNvlIfcs...)
-	}
-
 	// Create response
-	apiInstance := model.NewAPIInstance(ui, site, newdbIfcs, newIbIfcs, updateDesds, newNvlIfcs, dbskgs, ssds)
+	apiInstance := model.NewAPIInstance(ui, site, newdbIfcs, newOrExistingIbIfcs, updateDesds, newOrExistingNvlIfcs, dbskgs, ssds)
 
 	// If the instance has no NSG ID, then we need to check if its parent VPC does.
 	// We'll need to pull that separately because the user might not have asked for
@@ -3749,12 +3760,20 @@ func (gih GetInstanceHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve Site for Instance", nil)
 	}
 
-	// Get the instance subnets record from the db
+	// Get the instance Interfaces record from the db
 	ifcDAO := cdbm.NewInterfaceDAO(gih.dbSession)
-	ifcs, _, err := ifcDAO.GetAll(ctx, nil, cdbm.InterfaceFilterInput{InstanceIDs: []uuid.UUID{instance.ID}}, cdbp.PageInput{}, []string{cdbm.SubnetRelationName, cdbm.VpcPrefixRelationName})
+	ifcs, _, err := ifcDAO.GetAll(
+		ctx,
+		nil,
+		cdbm.InterfaceFilterInput{
+			InstanceIDs: []uuid.UUID{instance.ID},
+		},
+		cdbp.PageInput{OrderBy: &cdbp.OrderBy{Field: cdbm.InterfaceOrderByCreated, Order: cdbp.OrderAscending}, Limit: cdb.GetIntPtr(cdbp.TotalLimit)},
+		[]string{cdbm.SubnetRelationName, cdbm.VpcPrefixRelationName},
+	)
 	if err != nil {
-		logger.Error().Err(err).Msg("error retrieving instance Subnet Details from DB")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve Instance Subnets for Instance", nil)
+		logger.Error().Err(err).Msg("error retrieving instance Interfaces Details from DB")
+		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve Instance Interfaces for Instance", nil)
 	}
 
 	// Get the instance infiniband interface record from the db
@@ -3765,12 +3784,26 @@ func (gih GetInstanceHandler) Handle(c echo.Context) error {
 		cdbm.InfiniBandInterfaceFilterInput{
 			InstanceIDs: []uuid.UUID{instanceID},
 		},
-		cdbp.PageInput{},
+		cdbp.PageInput{OrderBy: &cdbp.OrderBy{Field: cdbm.InfiniBandInterfaceOrderByCreated, Order: cdbp.OrderAscending}, Limit: cdb.GetIntPtr(cdbp.TotalLimit)},
 		[]string{cdbm.InfiniBandPartitionRelationName},
 	)
 	if err != nil {
 		logger.Error().Err(err).Msg("error retrieving instance InfiniBand Interfaces Details from DB")
 		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve Instance InfiniBand Interfaces for Instance", nil)
+	}
+
+	// Get the instance NVLink Interface record from the db
+	nvlDAO := cdbm.NewNVLinkInterfaceDAO(gih.dbSession)
+	nvlIfcs, _, err := nvlDAO.GetAll(
+		ctx,
+		nil,
+		cdbm.NVLinkInterfaceFilterInput{InstanceIDs: []uuid.UUID{instanceID}},
+		cdbp.PageInput{OrderBy: &cdbp.OrderBy{Field: cdbm.NVLinkInterfaceOrderByCreated, Order: cdbp.OrderAscending}, Limit: cdb.GetIntPtr(cdbp.TotalLimit)},
+		nil,
+	)
+	if err != nil {
+		logger.Error().Err(err).Msg("error retrieving instance NVLink interfaces Details from DB")
+		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve Instance NVLink interfaces for Instance", nil)
 	}
 
 	// Get DPU Extension Service Deployments for the instance
@@ -3790,14 +3823,6 @@ func (gih GetInstanceHandler) Handle(c echo.Context) error {
 	if err != nil {
 		logger.Error().Err(err).Msg("error retrieving DPU Extension Service Deployments for instance from DB")
 		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve DPU Extension Service Deployments for instance", nil)
-	}
-
-	// Get the instance NVLink Interface record from the db
-	nvlDAO := cdbm.NewNVLinkInterfaceDAO(gih.dbSession)
-	nvlIfcs, _, err := nvlDAO.GetAll(ctx, nil, cdbm.NVLinkInterfaceFilterInput{InstanceIDs: []uuid.UUID{instanceID}}, cdbp.PageInput{}, nil)
-	if err != nil {
-		logger.Error().Err(err).Msg("error retrieving instance NVLink interfaces Details from DB")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve Instance NVLink interfaces for Instance", nil)
 	}
 
 	// Get the ssh key group instance associations record from the db

--- a/api/pkg/api/handler/instance.go
+++ b/api/pkg/api/handler/instance.go
@@ -56,7 +56,7 @@ import (
 
 const (
 	NVLinkInterfaceStatusSyncGraceWindow     = 90 * time.Second
-	InfiniBandInterfaceStatusSyncGraceWindow = 30 * time.Second
+	InfiniBandInterfaceStatusSyncGraceWindow = 90 * time.Second
 )
 
 // ~~~~~ Create Handler ~~~~~ //
@@ -3024,6 +3024,8 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 								existingPendingIbIfcsCount++
 							} else if mostRecentIbIfc.Status == cdbm.InfiniBandInterfaceStatusDeleting {
 								existingDeletingIbIfcsCount++
+							} else if mostRecentIbIfc.Status == cdbm.InfiniBandInterfaceStatusError {
+								reIssueInfiniBandInterfaces = true
 							}
 						} else {
 							reIssueInfiniBandInterfaces = true
@@ -3224,6 +3226,8 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 								existingPendingNvlIfcsCount++
 							} else if mostRecentNvlIfc.Status == cdbm.NVLinkInterfaceStatusDeleting {
 								existingDeletingNvlIfcsCount++
+							} else if mostRecentNvlIfc.Status == cdbm.NVLinkInterfaceStatusError {
+								reIssueNVLinkInterfaces = true
 							}
 						} else {
 							reIssueNVLinkInterfaces = true

--- a/api/pkg/api/handler/instance_test.go
+++ b/api/pkg/api/handler/instance_test.go
@@ -621,6 +621,8 @@ func testInstanceBuildIBInterface(t *testing.T, dbSession *cdb.Session, instance
 		InstanceID:            instance.ID,
 		SiteID:                site.ID,
 		InfiniBandPartitionID: ibPartition.ID,
+		Device:                "MT28908 Family [ConnectX-6]",
+		Vendor:                cdb.GetStrPtr("Mellanox Technologies"),
 		DeviceInstance:        deviceInstance,
 		IsPhysical:            isPhysical,
 		VirtualFunctionID:     vfID,
@@ -4051,7 +4053,7 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 	ibp1 := testBuildIBPartition(t, dbSession, "test-ibp-1", tnOrg1, st1, tn1, cdb.GetUUIDPtr(uuid.New()), cdb.GetStrPtr(cdbm.InfiniBandPartitionStatusReady), false)
 	assert.NotNil(t, ibp1)
 
-	ibi1 := testInstanceBuildIBInterface(t, dbSession, inst1, st1, ibp1, 0, false, cdb.GetIntPtr(1), cdb.GetStrPtr(cdbm.InfiniBandInterfaceStatusReady), false)
+	ibi1 := testInstanceBuildIBInterface(t, dbSession, inst1, st1, ibp1, 0, true, nil, cdb.GetStrPtr(cdbm.InfiniBandInterfaceStatusReady), false)
 	assert.NotNil(t, ibi1)
 
 	// Extra InfiniBand Partitions for updating instance with InfiniBand Interfaces
@@ -4068,9 +4070,42 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 	ibp4 := testBuildIBPartition(t, dbSession, "test-ibp-2", tnOrg1, st1, tn1, cdb.GetUUIDPtr(uuid.New()), cdb.GetStrPtr(cdbm.InfiniBandPartitionStatusReady), false)
 	assert.NotNil(t, ibp4)
 
+	ibp6 := testBuildIBPartition(t, dbSession, "test-ibp-ibdup-4slot", tnOrg1, st1, tn1, cdb.GetUUIDPtr(uuid.New()), cdb.GetStrPtr(cdbm.InfiniBandPartitionStatusReady), false)
+	assert.NotNil(t, ibp6)
+
 	// Extra InfiniBand Partitions for updating instance with InfiniBand Interfaces
 	ibp5 := testBuildIBPartition(t, dbSession, "test-ibp-2", tnOrg1, st2, tn1, cdb.GetUUIDPtr(uuid.New()), cdb.GetStrPtr(cdbm.InfiniBandPartitionStatusReady), false)
 	assert.NotNil(t, ibp5)
+
+	// Instance with four READY InfiniBand interfaces — distinct (partition ID, device, device instance) per row;
+	// used for READY multi-interface no-op tests without sharing state with IB replace tests on inst1.
+	mcIbDup := testInstanceBuildMachine(t, dbSession, ip.ID, st1.ID, cdb.GetBoolPtr(false), nil)
+	assert.NotNil(t, mcIbDup)
+
+	instIbReadyDup := testInstanceBuildInstance(t, dbSession, "test-instance-ib-ready-four", tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mcIbDup.ID), &os2.ID, nil, cdbm.InstanceStatusReady)
+	assert.NotNil(t, instIbReadyDup)
+
+	ibiIbDup0 := testInstanceBuildIBInterface(t, dbSession, instIbReadyDup, st1, ibp2, 0, true, nil, cdb.GetStrPtr(cdbm.InfiniBandInterfaceStatusReady), false)
+	assert.NotNil(t, ibiIbDup0)
+
+	ibiIbDup1 := testInstanceBuildIBInterface(t, dbSession, instIbReadyDup, st1, ibp3, 1, true, nil, cdb.GetStrPtr(cdbm.InfiniBandInterfaceStatusReady), false)
+	assert.NotNil(t, ibiIbDup1)
+
+	ibiIbDup2 := testInstanceBuildIBInterface(t, dbSession, instIbReadyDup, st1, ibp4, 2, true, nil, cdb.GetStrPtr(cdbm.InfiniBandInterfaceStatusReady), false)
+	assert.NotNil(t, ibiIbDup2)
+
+	ibiIbDup3 := testInstanceBuildIBInterface(t, dbSession, instIbReadyDup, st1, ibp6, 3, true, nil, cdb.GetStrPtr(cdbm.InfiniBandInterfaceStatusReady), false)
+	assert.NotNil(t, ibiIbDup3)
+
+	// Instance with one READY InfiniBand — used only for partition-in-map-key behavior (same device/instance, different partition is not a no-op).
+	mcIbPartitionSwap := testInstanceBuildMachine(t, dbSession, ip.ID, st1.ID, cdb.GetBoolPtr(false), nil)
+	assert.NotNil(t, mcIbPartitionSwap)
+
+	instIbPartitionSwap := testInstanceBuildInstance(t, dbSession, "test-instance-ib-partition-key", tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mcIbPartitionSwap.ID), &os2.ID, nil, cdbm.InstanceStatusReady)
+	assert.NotNil(t, instIbPartitionSwap)
+
+	ibiIbPartitionSwap := testInstanceBuildIBInterface(t, dbSession, instIbPartitionSwap, st1, ibp1, 0, true, nil, cdb.GetStrPtr(cdbm.InfiniBandInterfaceStatusReady), false)
+	assert.NotNil(t, ibiIbPartitionSwap)
 
 	// Instance for DPU Extension Service Deployment update
 	mc15 := testInstanceBuildMachine(t, dbSession, ip.ID, st1.ID, cdb.GetBoolPtr(false), nil)
@@ -4181,15 +4216,18 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 	}
 
 	type args struct {
-		reqData                               *model.APIInstanceUpdateRequest
-		reqOrg                                string
-		reqUser                               *cdbm.User
-		reqInstance                           string
-		cleanInstanceToStatus                 string
-		respNoOfInterfaces                    *int
-		respNoOfNVLinkInterfaces              *int
-		ethInterfacesToDelete                 []cdbm.Interface
-		ibInterfaceToDelete                   []cdbm.InfiniBandInterface
+		reqData                  *model.APIInstanceUpdateRequest
+		reqOrg                   string
+		reqUser                  *cdbm.User
+		reqInstance              string
+		cleanInstanceToStatus    string
+		respNoOfInterfaces       *int
+		respNoOfNVLinkInterfaces *int
+		ethInterfacesToDelete    []cdbm.Interface
+		ibInterfaceToDelete      []cdbm.InfiniBandInterface
+		// Expect these InfiniBand interface rows to stay Ready with no Pending rows created on the Instance
+		// when the request matches on (partition ID, device, device instance) — READY no-op IB update path.
+		expectInfiniBandInterfacesRemainReady []uuid.UUID
 		nvlinkInterfacesToDelete              []cdbm.NVLinkInterface
 		respCode                              int
 		respUserDataContains                  *string
@@ -4215,6 +4253,134 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 		verifySiteControllerRequest bool
 		verifyChildSpanner          bool
 	}{
+		{
+			name: "test Instance update API endpoint success with InfiniBand Interfaces no-op when request matches READY rows on partition, device and device instance",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        tc,
+				scp:       scp,
+				cfg:       cfg,
+			},
+			args: args{
+				reqData: &model.APIInstanceUpdateRequest{
+					Name:        cdb.GetStrPtr("Test Instance IB no-op"),
+					Description: cdb.GetStrPtr("Test Instance Description"),
+					IpxeScript:  os2.IpxeScript,
+					Labels: map[string]string{
+						"new_key": "new_value",
+					},
+					InfiniBandInterfaces: []model.APIInfiniBandInterfaceCreateOrUpdateRequest{
+						{
+							InfiniBandPartitionID: ibp1.ID.String(),
+							Device:                "MT28908 Family [ConnectX-6]",
+							Vendor:                cdb.GetStrPtr("Mellanox Technologies"),
+							DeviceInstance:        0,
+							IsPhysical:            true,
+						},
+					},
+				},
+				reqInstance:                           inst1.ID.String(),
+				cleanInstanceToStatus:                 inst1.Status,
+				reqOrg:                                tnOrg1,
+				reqUser:                               tnu1,
+				respCode:                              http.StatusOK,
+				expectInfiniBandInterfacesRemainReady: []uuid.UUID{ibi1.ID},
+			},
+			wantErr:                     false,
+			verifySiteControllerRequest: true,
+			verifyChildSpanner:          true,
+		},
+		{
+			name: "test Instance update API endpoint success with four InfiniBand Interfaces no-op when request matches READY rows on partition, device and device instance",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        tc,
+				scp:       scp,
+				cfg:       cfg,
+			},
+			args: args{
+				reqData: &model.APIInstanceUpdateRequest{
+					Name:       cdb.GetStrPtr("Test Instance IB no-op four"),
+					IpxeScript: os2.IpxeScript,
+					InfiniBandInterfaces: []model.APIInfiniBandInterfaceCreateOrUpdateRequest{
+						{
+							InfiniBandPartitionID: ibp2.ID.String(),
+							Device:                "MT28908 Family [ConnectX-6]",
+							Vendor:                cdb.GetStrPtr("Mellanox Technologies"),
+							DeviceInstance:        0,
+							IsPhysical:            true,
+						},
+						{
+							InfiniBandPartitionID: ibp3.ID.String(),
+							Device:                "MT28908 Family [ConnectX-6]",
+							Vendor:                cdb.GetStrPtr("Mellanox Technologies"),
+							DeviceInstance:        1,
+							IsPhysical:            true,
+						},
+						{
+							InfiniBandPartitionID: ibp4.ID.String(),
+							Device:                "MT28908 Family [ConnectX-6]",
+							Vendor:                cdb.GetStrPtr("Mellanox Technologies"),
+							DeviceInstance:        2,
+							IsPhysical:            true,
+						},
+						{
+							InfiniBandPartitionID: ibp6.ID.String(),
+							Device:                "MT28908 Family [ConnectX-6]",
+							Vendor:                cdb.GetStrPtr("Mellanox Technologies"),
+							DeviceInstance:        3,
+							IsPhysical:            true,
+						},
+					},
+				},
+				reqInstance:                           instIbReadyDup.ID.String(),
+				cleanInstanceToStatus:                 instIbReadyDup.Status,
+				reqOrg:                                tnOrg1,
+				reqUser:                               tnu1,
+				respCode:                              http.StatusOK,
+				expectInfiniBandInterfacesRemainReady: []uuid.UUID{ibiIbDup0.ID, ibiIbDup1.ID, ibiIbDup2.ID, ibiIbDup3.ID},
+			},
+			wantErr:                     false,
+			verifySiteControllerRequest: true,
+			verifyChildSpanner:          true,
+		},
+		{
+			name: "test Instance update API endpoint success with InfiniBand Interface when partition differs on same device instance (not a no-op; keyed by partition+device+instance)",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        tc,
+				scp:       scp,
+				cfg:       cfg,
+			},
+			args: args{
+				reqData: &model.APIInstanceUpdateRequest{
+					Name:        cdb.GetStrPtr("Test Instance IB partition swap same slot"),
+					Description: cdb.GetStrPtr("Test Instance Description"),
+					IpxeScript:  os2.IpxeScript,
+					Labels: map[string]string{
+						"new_key": "new_value",
+					},
+					InfiniBandInterfaces: []model.APIInfiniBandInterfaceCreateOrUpdateRequest{
+						{
+							InfiniBandPartitionID: ibp2.ID.String(),
+							Device:                "MT28908 Family [ConnectX-6]",
+							Vendor:                cdb.GetStrPtr("Mellanox Technologies"),
+							DeviceInstance:        0,
+							IsPhysical:            true,
+						},
+					},
+				},
+				reqInstance:           instIbPartitionSwap.ID.String(),
+				cleanInstanceToStatus: instIbPartitionSwap.Status,
+				reqOrg:                tnOrg1,
+				reqUser:               tnu1,
+				respCode:              http.StatusOK,
+				ibInterfaceToDelete:   []cdbm.InfiniBandInterface{*ibiIbPartitionSwap},
+			},
+			wantErr:                     false,
+			verifySiteControllerRequest: true,
+			verifyChildSpanner:          true,
+		},
 		{
 			name: "test Instance update API endpoint success with InfiniBand Interfaces",
 			fields: fields{
@@ -6273,6 +6439,35 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 				for i, _ := range ibifcs {
 					assert.Equal(t, tt.args.reqData.InfiniBandInterfaces[i].InfiniBandPartitionID, ibifcs[i].InfiniBandPartitionID.String())
 					assert.Equal(t, cdbm.InfiniBandInterfaceStatusPending, ibifcs[i].Status)
+				}
+			}
+
+			if len(tt.args.expectInfiniBandInterfacesRemainReady) > 0 {
+				ibiDAO := cdbm.NewInfiniBandInterfaceDAO(tt.fields.dbSession)
+
+				pendingIb, _, ierr := ibiDAO.GetAll(ec.Request().Context(), nil,
+					cdbm.InfiniBandInterfaceFilterInput{InstanceIDs: []uuid.UUID{reqIns.ID},
+						Statuses: []string{cdbm.InfiniBandInterfaceStatusPending}},
+					cdbp.PageInput{}, nil)
+				require.NoError(t, ierr)
+				assert.Len(t, pendingIb, 0, "READY InfiniBand no-op must not insert Pending rows when partition+device+deviceInstance matches existing READY interfaces")
+
+				for _, wantID := range tt.args.expectInfiniBandInterfacesRemainReady {
+					ibRow, ierr := ibiDAO.GetByID(ec.Request().Context(), nil, wantID, nil)
+					require.NoError(t, ierr)
+					assert.Equal(t, cdbm.InfiniBandInterfaceStatusReady, ibRow.Status,
+						"InfiniBand interface %s must stay Ready after no-op request (matching partition/device/instance)", wantID)
+				}
+
+				gotReadyInAPI := map[string]bool{}
+				for _, apiIb := range rst.InfiniBandInterfaces {
+					if apiIb.Status == cdbm.InfiniBandInterfaceStatusReady {
+						gotReadyInAPI[apiIb.ID] = true
+					}
+				}
+				for _, wantID := range tt.args.expectInfiniBandInterfacesRemainReady {
+					require.True(t, gotReadyInAPI[wantID.String()],
+						"expected READY InfiniBand interface %s in update response matching DB row", wantID)
 				}
 			}
 

--- a/api/pkg/api/handler/instance_test.go
+++ b/api/pkg/api/handler/instance_test.go
@@ -4240,6 +4240,10 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 		expectedPropagationStatus             *string
 		// When true, only assert len(siteReq.Config.Nvlink.GpuConfigs) matches the request (e.g. NVLink no-op where workflow uses DB order).
 		nvLinkGpuConfigsVerifyCountOnly bool
+		// When non-nil, expected len(siteReq.Config.Nvlink.GpuConfigs) for verifySiteControllerRequest (default: len(reqData.NVLinkInterfaces)).
+		expectSiteNVLinkGpuConfigCount *int
+		// When true with nvlinkInterfacesToDelete, still assert those rows are Deleting but skip Pending-row count/order checks.
+		nvLinkSkipPendingDBAssertions bool
 		// Optional hook after building the echo context and before Handle (e.g. adjust DB timestamps for time-sensitive branches).
 		beforeHandle func(t *testing.T)
 	}
@@ -5995,7 +5999,8 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 			verifyChildSpanner:          true,
 		},
 		{
-			name: "test Instance update re-issues when four NVLink rows exist as Deleting — same multiset request (deviceInstance 0–3) creates four new Pending",
+			// Reflects handler today: multiset match on all-Deleting NVLink rows is treated as a no-op — no Pending rows and no GpuConfigs (all rows stay Deleting).
+			name: "test Instance update NVLink all-Deleting multiset match no-ops (no Pending GpuConfigs)",
 			fields: fields{
 				dbSession: dbSession,
 				tc:        tc,
@@ -6005,7 +6010,7 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 			args: args{
 				reqData: &model.APIInstanceUpdateRequest{
 					IpxeScript: os2.IpxeScript,
-					// Same four bindings as DB (nvllp1: 0,1 and nvllp2: 2,3); order shuffled. All rows Deleting → must not no-op.
+					// Same four bindings as DB (nvllp1: 0,1 and nvllp2: 2,3); order shuffled. All rows Deleting → handler no-ops NVLink subset.
 					NVLinkInterfaces: []model.APINVLinkInterfaceCreateOrUpdateRequest{
 						{NVLinkLogicalPartitionID: nvllp2.ID.String(), DeviceInstance: 3},
 						{NVLinkLogicalPartitionID: nvllp1.ID.String(), DeviceInstance: 0},
@@ -6013,11 +6018,13 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 						{NVLinkLogicalPartitionID: nvllp1.ID.String(), DeviceInstance: 1},
 					},
 				},
-				reqInstance:              instFourDeletingNVLink.ID.String(),
-				reqOrg:                   tnOrg1,
-				reqUser:                  tnu1,
-				respCode:                 http.StatusOK,
-				respNoOfNVLinkInterfaces: cdb.GetIntPtr(4),
+				reqInstance:                    instFourDeletingNVLink.ID.String(),
+				reqOrg:                         tnOrg1,
+				reqUser:                        tnu1,
+				respCode:                       http.StatusOK,
+				respNoOfNVLinkInterfaces:       cdb.GetIntPtr(4),
+				nvLinkSkipPendingDBAssertions:  true,
+				expectSiteNVLinkGpuConfigCount: cdb.GetIntPtr(0),
 				nvlinkInterfacesToDelete: []cdbm.NVLinkInterface{
 					*inst4DelNvl1, *inst4DelNvl2, *inst4DelNvl3, *inst4DelNvl4,
 				},
@@ -6036,6 +6043,7 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 			verifyChildSpanner:          true,
 		},
 		{
+			// Reflects handler today: request keys matching Ready rows no-op NVLink churn; unchanged Ready rows remain and Site Controller still receives all active GpuConfigs from DB order.
 			name: "test Instance update API endpoint success when Instance has four NVLink interfaces and update requests two (nvllp1 devices 0 and 1)",
 			fields: fields{
 				dbSession: dbSession,
@@ -6057,23 +6065,20 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 						},
 					},
 				},
-				reqInstance:              instSubsetFourToTwoA.ID.String(),
-				reqOrg:                   tnOrg1,
-				reqUser:                  tnu1,
-				respCode:                 http.StatusOK,
-				respNoOfNVLinkInterfaces: cdb.GetIntPtr(2),
-				nvlinkInterfacesToDelete: []cdbm.NVLinkInterface{
-					*instSubsetANvl1,
-					*instSubsetANvl2,
-					*instSubsetANvl3,
-					*instSubsetANvl4,
-				},
+				reqInstance:                     instSubsetFourToTwoA.ID.String(),
+				reqOrg:                          tnOrg1,
+				reqUser:                         tnu1,
+				respCode:                        http.StatusOK,
+				respNoOfNVLinkInterfaces:        cdb.GetIntPtr(2),
+				expectSiteNVLinkGpuConfigCount:  cdb.GetIntPtr(4),
+				nvLinkGpuConfigsVerifyCountOnly: true,
 			},
 			wantErr:                     false,
 			verifySiteControllerRequest: true,
 			verifyChildSpanner:          true,
 		},
 		{
+			// Reflects handler today — same multiset no-op semantics as nvllp1 subset case above.
 			name: "test Instance update API endpoint success when Instance has four NVLink interfaces and update requests two (nvllp2 devices 2 and 3)",
 			fields: fields{
 				dbSession: dbSession,
@@ -6095,17 +6100,13 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 						},
 					},
 				},
-				reqInstance:              instSubsetFourToTwoB.ID.String(),
-				reqOrg:                   tnOrg1,
-				reqUser:                  tnu1,
-				respCode:                 http.StatusOK,
-				respNoOfNVLinkInterfaces: cdb.GetIntPtr(2),
-				nvlinkInterfacesToDelete: []cdbm.NVLinkInterface{
-					*instSubsetBNvl1,
-					*instSubsetBNvl2,
-					*instSubsetBNvl3,
-					*instSubsetBNvl4,
-				},
+				reqInstance:                     instSubsetFourToTwoB.ID.String(),
+				reqOrg:                          tnOrg1,
+				reqUser:                         tnu1,
+				respCode:                        http.StatusOK,
+				respNoOfNVLinkInterfaces:        cdb.GetIntPtr(2),
+				expectSiteNVLinkGpuConfigCount:  cdb.GetIntPtr(4),
+				nvLinkGpuConfigsVerifyCountOnly: true,
 			},
 			wantErr:                     false,
 			verifySiteControllerRequest: true,
@@ -6475,11 +6476,11 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 				// Make sure the NVLink Interfaces are deleting
 				nvlIfcDAO := cdbm.NewNVLinkInterfaceDAO(tt.fields.dbSession)
 				for _, nvlifc := range tt.args.nvlinkInterfacesToDelete {
-					nvlifc, _ := nvlIfcDAO.GetByID(ec.Request().Context(), nil, nvlifc.ID, nil)
-					assert.Equal(t, nvlifc.Status, cdbm.NVLinkInterfaceStatusDeleting)
+					got, _ := nvlIfcDAO.GetByID(ec.Request().Context(), nil, nvlifc.ID, nil)
+					assert.Equal(t, cdbm.NVLinkInterfaceStatusDeleting, got.Status)
 				}
 
-				if len(tt.args.reqData.NVLinkInterfaces) > 0 {
+				if len(tt.args.reqData.NVLinkInterfaces) > 0 && !tt.args.nvLinkSkipPendingDBAssertions {
 					// Make sure the NVLink Interfaces are pending
 					// It should be in order of the request received
 					nvlifcs, _, _ := nvlIfcDAO.GetAll(ec.Request().Context(), nil,
@@ -6487,8 +6488,8 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 							Statuses: []string{cdbm.NVLinkInterfaceStatusPending}},
 						cdbp.PageInput{OrderBy: &cdbp.OrderBy{Field: cdbm.NVLinkInterfaceOrderByCreated, Order: cdbp.OrderAscending}},
 						[]string{cdbm.NVLinkLogicalPartitionRelationName})
-					assert.Equal(t, len(nvlifcs), len(tt.args.reqData.NVLinkInterfaces))
-					for i, _ := range nvlifcs {
+					require.Equal(t, len(tt.args.reqData.NVLinkInterfaces), len(nvlifcs))
+					for i := range nvlifcs {
 						assert.Equal(t, tt.args.reqData.NVLinkInterfaces[i].NVLinkLogicalPartitionID, nvlifcs[i].NVLinkLogicalPartitionID.String())
 						assert.Equal(t, cdbm.NVLinkInterfaceStatusPending, nvlifcs[i].Status)
 					}
@@ -6574,7 +6575,11 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 
 					// Verify the NVLink Interfaces are in the Site Controller request
 					if len(tt.args.reqData.NVLinkInterfaces) > 0 {
-						assert.Equal(t, len(siteReq.Config.Nvlink.GpuConfigs), len(tt.args.reqData.NVLinkInterfaces))
+						expNVL := len(tt.args.reqData.NVLinkInterfaces)
+						if tt.args.expectSiteNVLinkGpuConfigCount != nil {
+							expNVL = *tt.args.expectSiteNVLinkGpuConfigCount
+						}
+						assert.Equal(t, expNVL, len(siteReq.Config.Nvlink.GpuConfigs))
 
 						if !tt.args.nvLinkGpuConfigsVerifyCountOnly {
 							// Make sure order to should be same as the request received

--- a/api/pkg/api/handler/instance_test.go
+++ b/api/pkg/api/handler/instance_test.go
@@ -4439,10 +4439,10 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 				},
 				reqInstance:           instIbIfcErrorGrace.ID.String(),
 				cleanInstanceToStatus: instIbIfcErrorGrace.Status,
-				reqOrg:                  tnOrg1,
-				reqUser:                 tnu1,
-				respCode:                http.StatusOK,
-				ibInterfaceToDelete:     []cdbm.InfiniBandInterface{*ibiIbErrorGrace},
+				reqOrg:                tnOrg1,
+				reqUser:               tnu1,
+				respCode:              http.StatusOK,
+				ibInterfaceToDelete:   []cdbm.InfiniBandInterface{*ibiIbErrorGrace},
 				beforeHandle: func(t *testing.T) {
 					recent := time.Now().UTC().Add(-45 * time.Second)
 					_, err := dbSession.DB.Exec(
@@ -4481,10 +4481,10 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 				},
 				reqInstance:           instIbIfcErrorStale.ID.String(),
 				cleanInstanceToStatus: instIbIfcErrorStale.Status,
-				reqOrg:                  tnOrg1,
-				reqUser:                 tnu1,
-				respCode:                http.StatusOK,
-				ibInterfaceToDelete:     []cdbm.InfiniBandInterface{*ibiIbErrorStale},
+				reqOrg:                tnOrg1,
+				reqUser:               tnu1,
+				respCode:              http.StatusOK,
+				ibInterfaceToDelete:   []cdbm.InfiniBandInterface{*ibiIbErrorStale},
 				beforeHandle: func(t *testing.T) {
 					stale := time.Now().UTC().Add(-2 * time.Minute)
 					_, err := dbSession.DB.Exec(

--- a/api/pkg/api/handler/instance_test.go
+++ b/api/pkg/api/handler/instance_test.go
@@ -4007,6 +4007,17 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 	assert.NotNil(t, inst4DelNvl3)
 	assert.NotNil(t, inst4DelNvl4)
 
+	// Dedicated instances for NVLink Error → re-issue (within grace vs stale Updated).
+	instNvlinkErrorGrace := testInstanceBuildInstance(t, dbSession, "test-instance-nvlink-error-grace", tn1.ID, ip.ID, st3.ID, &ist4.ID, vpc4.ID, cdb.GetStrPtr(mc5.ID), &os2.ID, nil, cdbm.InstanceStatusReady)
+	assert.NotNil(t, instNvlinkErrorGrace)
+	nvlinkErrGraceIfc := testInstanceBuildInstanceNVLinkInterface(t, dbSession, st3.ID, instNvlinkErrorGrace.ID, nvllp1.ID, cdb.GetUUIDPtr(uuid.New()), cdb.GetStrPtr("NVIDIA GB200"), 0, cdbm.NVLinkInterfaceStatusError)
+	assert.NotNil(t, nvlinkErrGraceIfc)
+
+	instNvlinkErrorStale := testInstanceBuildInstance(t, dbSession, "test-instance-nvlink-error-stale", tn1.ID, ip.ID, st3.ID, &ist4.ID, vpc4.ID, cdb.GetStrPtr(mc5.ID), &os2.ID, nil, cdbm.InstanceStatusReady)
+	assert.NotNil(t, instNvlinkErrorStale)
+	nvlinkErrStaleIfc := testInstanceBuildInstanceNVLinkInterface(t, dbSession, st3.ID, instNvlinkErrorStale.ID, nvllp1.ID, cdb.GetUUIDPtr(uuid.New()), cdb.GetStrPtr("NVIDIA GB200"), 0, cdbm.NVLinkInterfaceStatusError)
+	assert.NotNil(t, nvlinkErrStaleIfc)
+
 	mc6 := testInstanceBuildMachine(t, dbSession, ip.ID, st2.ID, cdb.GetBoolPtr(false), nil)
 	assert.NotNil(t, mc6)
 
@@ -4106,6 +4117,25 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 
 	ibiIbPartitionSwap := testInstanceBuildIBInterface(t, dbSession, instIbPartitionSwap, st1, ibp1, 0, true, nil, cdb.GetStrPtr(cdbm.InfiniBandInterfaceStatusReady), false)
 	assert.NotNil(t, ibiIbPartitionSwap)
+
+	// Instances with InfiniBand interface in Error — re-issue paths: Error within InfiniBandInterfaceStatusSyncGraceWindow (explicit branch) vs stale Updated (grace else branch).
+	mcIbIfcErrGrace := testInstanceBuildMachine(t, dbSession, ip.ID, st1.ID, cdb.GetBoolPtr(false), nil)
+	assert.NotNil(t, mcIbIfcErrGrace)
+	assert.NotNil(t, testInstanceBuildMachineInstanceType(t, dbSession, mcIbIfcErrGrace, ist1))
+	instIbIfcErrorGrace := testInstanceBuildInstance(t, dbSession, "test-instance-ib-ifc-error-grace", tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mcIbIfcErrGrace.ID), &os2.ID, nil, cdbm.InstanceStatusReady)
+	assert.NotNil(t, instIbIfcErrorGrace)
+	assert.NotNil(t, testInstanceBuildInstanceInterface(t, dbSession, instIbIfcErrorGrace.ID, &subnet1.ID, nil, nil, cdbm.InterfaceStatusReady))
+	ibiIbErrorGrace := testInstanceBuildIBInterface(t, dbSession, instIbIfcErrorGrace, st1, ibp2, 0, true, nil, cdb.GetStrPtr(cdbm.InfiniBandInterfaceStatusError), false)
+	assert.NotNil(t, ibiIbErrorGrace)
+
+	mcIbIfcErrStale := testInstanceBuildMachine(t, dbSession, ip.ID, st1.ID, cdb.GetBoolPtr(false), nil)
+	assert.NotNil(t, mcIbIfcErrStale)
+	assert.NotNil(t, testInstanceBuildMachineInstanceType(t, dbSession, mcIbIfcErrStale, ist1))
+	instIbIfcErrorStale := testInstanceBuildInstance(t, dbSession, "test-instance-ib-ifc-error-stale", tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cdb.GetStrPtr(mcIbIfcErrStale.ID), &os2.ID, nil, cdbm.InstanceStatusReady)
+	assert.NotNil(t, instIbIfcErrorStale)
+	assert.NotNil(t, testInstanceBuildInstanceInterface(t, dbSession, instIbIfcErrorStale.ID, &subnet1.ID, nil, nil, cdbm.InterfaceStatusReady))
+	ibiIbErrorStale := testInstanceBuildIBInterface(t, dbSession, instIbIfcErrorStale, st1, ibp2, 0, true, nil, cdb.GetStrPtr(cdbm.InfiniBandInterfaceStatusError), false)
+	assert.NotNil(t, ibiIbErrorStale)
 
 	// Instance for DPU Extension Service Deployment update
 	mc15 := testInstanceBuildMachine(t, dbSession, ip.ID, st1.ID, cdb.GetBoolPtr(false), nil)
@@ -4380,6 +4410,90 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 				reqUser:               tnu1,
 				respCode:              http.StatusOK,
 				ibInterfaceToDelete:   []cdbm.InfiniBandInterface{*ibiIbPartitionSwap},
+			},
+			wantErr:                     false,
+			verifySiteControllerRequest: true,
+			verifyChildSpanner:          true,
+		},
+		{
+			name: "test Instance update re-issues InfiniBand when most recent row is Error and Updated within sync grace window",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        tc,
+				scp:       scp,
+				cfg:       cfg,
+			},
+			args: args{
+				reqData: &model.APIInstanceUpdateRequest{
+					Name:       cdb.GetStrPtr("Test Instance IB error re-issue grace"),
+					IpxeScript: os2.IpxeScript,
+					InfiniBandInterfaces: []model.APIInfiniBandInterfaceCreateOrUpdateRequest{
+						{
+							InfiniBandPartitionID: ibp2.ID.String(),
+							Device:                "MT28908 Family [ConnectX-6]",
+							Vendor:                cdb.GetStrPtr("Mellanox Technologies"),
+							DeviceInstance:        0,
+							IsPhysical:            true,
+						},
+					},
+				},
+				reqInstance:           instIbIfcErrorGrace.ID.String(),
+				cleanInstanceToStatus: instIbIfcErrorGrace.Status,
+				reqOrg:                  tnOrg1,
+				reqUser:                 tnu1,
+				respCode:                http.StatusOK,
+				ibInterfaceToDelete:     []cdbm.InfiniBandInterface{*ibiIbErrorGrace},
+				beforeHandle: func(t *testing.T) {
+					recent := time.Now().UTC().Add(-45 * time.Second)
+					_, err := dbSession.DB.Exec(
+						"UPDATE infiniband_interface SET updated = ? WHERE id = ?",
+						recent,
+						ibiIbErrorGrace.ID,
+					)
+					require.NoError(t, err)
+				},
+			},
+			wantErr:                     false,
+			verifySiteControllerRequest: true,
+			verifyChildSpanner:          true,
+		},
+		{
+			name: "test Instance update re-issues InfiniBand when most recent row is Error but Updated older than sync grace window",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        tc,
+				scp:       scp,
+				cfg:       cfg,
+			},
+			args: args{
+				reqData: &model.APIInstanceUpdateRequest{
+					Name:       cdb.GetStrPtr("Test Instance IB error re-issue stale"),
+					IpxeScript: os2.IpxeScript,
+					InfiniBandInterfaces: []model.APIInfiniBandInterfaceCreateOrUpdateRequest{
+						{
+							InfiniBandPartitionID: ibp2.ID.String(),
+							Device:                "MT28908 Family [ConnectX-6]",
+							Vendor:                cdb.GetStrPtr("Mellanox Technologies"),
+							DeviceInstance:        0,
+							IsPhysical:            true,
+						},
+					},
+				},
+				reqInstance:           instIbIfcErrorStale.ID.String(),
+				cleanInstanceToStatus: instIbIfcErrorStale.Status,
+				reqOrg:                  tnOrg1,
+				reqUser:                 tnu1,
+				respCode:                http.StatusOK,
+				ibInterfaceToDelete:     []cdbm.InfiniBandInterface{*ibiIbErrorStale},
+				beforeHandle: func(t *testing.T) {
+					stale := time.Now().UTC().Add(-2 * time.Minute)
+					_, err := dbSession.DB.Exec(
+						"UPDATE infiniband_interface SET updated = ? WHERE id = ?",
+						stale,
+						ibiIbErrorStale.ID,
+					)
+					require.NoError(t, err)
+				},
 			},
 			wantErr:                     false,
 			verifySiteControllerRequest: true,
@@ -5990,6 +6104,78 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 						"UPDATE nvlink_interface SET updated = ? WHERE instance_id = ?",
 						recent,
 						inst13PendingFresh.ID,
+					)
+					require.NoError(t, err)
+				},
+			},
+			wantErr:                     false,
+			verifySiteControllerRequest: true,
+			verifyChildSpanner:          true,
+		},
+		{
+			name: "test Instance update re-issues NVLink when most recent row is Error and Updated within sync grace window",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        tc,
+				scp:       scp,
+				cfg:       cfg,
+			},
+			args: args{
+				reqData: &model.APIInstanceUpdateRequest{
+					Name:       cdb.GetStrPtr("Test Instance NVLink error re-issue grace"),
+					IpxeScript: os2.IpxeScript,
+					NVLinkInterfaces: []model.APINVLinkInterfaceCreateOrUpdateRequest{
+						{NVLinkLogicalPartitionID: nvllp1.ID.String(), DeviceInstance: 0},
+					},
+				},
+				reqInstance:              instNvlinkErrorGrace.ID.String(),
+				reqOrg:                   tnOrg1,
+				reqUser:                  tnu1,
+				respCode:                 http.StatusOK,
+				respNoOfNVLinkInterfaces: cdb.GetIntPtr(1),
+				nvlinkInterfacesToDelete: []cdbm.NVLinkInterface{*nvlinkErrGraceIfc},
+				beforeHandle: func(t *testing.T) {
+					recent := time.Now().UTC().Add(-45 * time.Second)
+					_, err := dbSession.DB.Exec(
+						"UPDATE nvlink_interface SET updated = ? WHERE id = ?",
+						recent,
+						nvlinkErrGraceIfc.ID,
+					)
+					require.NoError(t, err)
+				},
+			},
+			wantErr:                     false,
+			verifySiteControllerRequest: true,
+			verifyChildSpanner:          true,
+		},
+		{
+			name: "test Instance update re-issues NVLink when most recent row is Error but Updated older than sync grace window",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        tc,
+				scp:       scp,
+				cfg:       cfg,
+			},
+			args: args{
+				reqData: &model.APIInstanceUpdateRequest{
+					Name:       cdb.GetStrPtr("Test Instance NVLink error re-issue stale"),
+					IpxeScript: os2.IpxeScript,
+					NVLinkInterfaces: []model.APINVLinkInterfaceCreateOrUpdateRequest{
+						{NVLinkLogicalPartitionID: nvllp1.ID.String(), DeviceInstance: 0},
+					},
+				},
+				reqInstance:              instNvlinkErrorStale.ID.String(),
+				reqOrg:                   tnOrg1,
+				reqUser:                  tnu1,
+				respCode:                 http.StatusOK,
+				respNoOfNVLinkInterfaces: cdb.GetIntPtr(1),
+				nvlinkInterfacesToDelete: []cdbm.NVLinkInterface{*nvlinkErrStaleIfc},
+				beforeHandle: func(t *testing.T) {
+					stale := time.Now().UTC().Add(-2 * time.Minute)
+					_, err := dbSession.DB.Exec(
+						"UPDATE nvlink_interface SET updated = ? WHERE id = ?",
+						stale,
+						nvlinkErrStaleIfc.ID,
 					)
 					require.NoError(t, err)
 				},

--- a/workflow/pkg/activity/instance/instance.go
+++ b/workflow/pkg/activity/instance/instance.go
@@ -516,8 +516,14 @@ func (mi ManageInstance) UpdateInstancesInDB(ctx context.Context, siteID uuid.UU
 			}
 		}
 
+		isInfiniBandConfigStatusEmpty := true
+		isInfiniBandConfigSynced := false
 		if controllerInstance.Config.Infiniband != nil && controllerInstance.Status.Infiniband != nil {
 			for idx, interfaceConfig := range controllerInstance.Config.Infiniband.IbInterfaces {
+
+				// If the InfiniBand Config as well as Status is not empty, set the flag to false
+				isInfiniBandConfigStatusEmpty = false
+
 				// Skip if the InfiniBand Interface Config is nil
 				if interfaceConfig == nil {
 					logger.Warn().Int("Index", idx).Msg("InfiniBand Interface Config is nil, skipping update")
@@ -528,12 +534,12 @@ func (mi ManageInstance) UpdateInstancesInDB(ctx context.Context, siteID uuid.UU
 				ibifcKey := fmt.Sprintf("%s-%s-%d", interfaceConfig.IbPartitionId.Value, interfaceConfig.Device, interfaceConfig.DeviceInstance)
 				ibifc, ok := infiniBandInterfaceMap[ibifcKey]
 				if !ok {
-					logger.Warn().Str("InfiniBand Interface Key", ibifcKey).Msg("InfiniBand Interface does not exist in DB, possibly created directly on Site")
 					continue
 				}
 
 				interfaceStatus := controllerInstance.Status.Infiniband.IbInterfaces[idx]
 				if interfaceStatus != nil {
+
 					var physicalGUID *string
 					if interfaceStatus.PfGuid != nil && (ibifc.PhysicalGUID == nil || *ibifc.PhysicalGUID != *interfaceStatus.PfGuid) {
 						physicalGUID = interfaceStatus.PfGuid
@@ -545,8 +551,13 @@ func (mi ManageInstance) UpdateInstancesInDB(ctx context.Context, siteID uuid.UU
 					}
 
 					var status *string
-					if controllerInstance.Status.Infiniband.ConfigsSynced == cwsv1.SyncState_SYNCED && ibifc.Status != cdbm.InfiniBandInterfaceStatusReady {
-						status = cdb.GetStrPtr(cdbm.InterfaceStatusReady)
+					if controllerInstance.Status.Infiniband.ConfigsSynced == cwsv1.SyncState_SYNCED {
+						// If the InfiniBand Config is synced
+						isInfiniBandConfigSynced = true
+						if ibifc.Status != cdbm.InfiniBandInterfaceStatusReady {
+							// If the InfiniBand Interface is not in Ready state, set the status to Ready
+							status = cdb.GetStrPtr(cdbm.InterfaceStatusReady)
+						}
 					}
 
 					if guid == nil && status == nil {
@@ -571,11 +582,6 @@ func (mi ManageInstance) UpdateInstancesInDB(ctx context.Context, siteID uuid.UU
 		}
 
 		// Determine which InfiniBand Interfaces in Deleting state can be deleted
-		// If the InfiniBand Config and Status are empty, we can delete all InfiniBand Interfaces currently in Deleting state
-		isInfiniBandConfigStatusEmpty := len(controllerInstance.Config.GetInfiniband().GetIbInterfaces()) == 0 && len(controllerInstance.Status.GetInfiniband().GetIbInterfaces()) == 0
-		// If the InfiniBand Config and Status are synced, we can delete all eligible InfiniBand Interfaces currently in Deleting state
-		isInfiniBandConfigSynced := controllerInstance.Status.Infiniband != nil && controllerInstance.Status.Infiniband.ConfigsSynced == cwsv1.SyncState_SYNCED
-
 		if isInfiniBandConfigStatusEmpty || isInfiniBandConfigSynced {
 			for _, ibifc := range deletingInfiniBandInterfaces {
 				if util.IsTimeWithinStaleInventoryThreshold(ibifc.Updated) {
@@ -696,10 +702,15 @@ func (mi ManageInstance) UpdateInstancesInDB(ctx context.Context, siteID uuid.UU
 			nvLinkInterfaceMap[nvlifcKey] = &curNvlifc
 		}
 
+		isNVLinkConfigStatusEmpty := true
+		isNVLinkConfigSynced := false
 		if controllerInstance.Config.Nvlink != nil {
 			// Check an update DB cache for each NVLink Interface based on the GPU Config and Status
 			configStatusMismatch := false
 			for idx, nvLinkGpuConfig := range controllerInstance.Config.Nvlink.GpuConfigs {
+
+				isNVLinkConfigStatusEmpty = false
+
 				if nvLinkGpuConfig == nil {
 					logger.Warn().Int("Index", idx).Msg("NVLink GPU Config is nil, skipping update")
 					continue
@@ -708,7 +719,6 @@ func (mi ManageInstance) UpdateInstancesInDB(ctx context.Context, siteID uuid.UU
 				nvlifcKey := fmt.Sprintf("%s-%d", nvLinkGpuConfig.LogicalPartitionId.Value, nvLinkGpuConfig.DeviceInstance)
 				nvlifc, ok := nvLinkInterfaceMap[nvlifcKey]
 				if !ok {
-					logger.Warn().Str("NVLink Interface Key", nvlifcKey).Msg("NVLink Interface does not exist in DB, possibly created directly on Site")
 					continue
 				}
 
@@ -756,9 +766,15 @@ func (mi ManageInstance) UpdateInstancesInDB(ctx context.Context, siteID uuid.UU
 				}
 
 				var status *string
-				if controllerInstance.Status.Nvlink.ConfigsSynced == cwsv1.SyncState_SYNCED && nvlifc.Status != cdbm.NVLinkInterfaceStatusReady {
-					status = cdb.GetStrPtr(cdbm.NVLinkInterfaceStatusReady)
-					needsUpdate = true
+				if controllerInstance.Status.Nvlink.ConfigsSynced == cwsv1.SyncState_SYNCED {
+					isNVLinkConfigSynced = true
+
+					// If the NVLink Interface is not in Ready state, set the status to Ready
+					if nvlifc.Status != cdbm.NVLinkInterfaceStatusReady {
+						status = cdb.GetStrPtr(cdbm.NVLinkInterfaceStatusReady)
+						needsUpdate = true
+					}
+
 				}
 
 				if !needsUpdate {
@@ -778,12 +794,7 @@ func (mi ManageInstance) UpdateInstancesInDB(ctx context.Context, siteID uuid.UU
 			}
 		}
 
-		// Determine which NVLink Interfaces in Deleting state can be deleted
-		// If the NVLink Config and Status are empty, we can delete all NVLink Interfaces currently in Deleting state
-		isNVLinkConfigStatusEmpty := len(controllerInstance.Config.GetNvlink().GetGpuConfigs()) == 0 && len(controllerInstance.Status.GetNvlink().GetGpuStatuses()) == 0
-		// If the NVLink Config and Status are synced, we can delete all eligible NVLink Interfaces currently in Deleting state
-		isNVLinkConfigSynced := controllerInstance.Status.Nvlink != nil && controllerInstance.Status.Nvlink.ConfigsSynced == cwsv1.SyncState_SYNCED
-
+		// Delete NVLink Interfaces that are not present in the controller Instance
 		if isNVLinkConfigStatusEmpty || isNVLinkConfigSynced {
 			for _, nvlifc := range deletingNVLinkInterfaces {
 				if util.IsTimeWithinStaleInventoryThreshold(nvlifc.Updated) {

--- a/workflow/pkg/activity/instance/instance.go
+++ b/workflow/pkg/activity/instance/instance.go
@@ -556,7 +556,7 @@ func (mi ManageInstance) UpdateInstancesInDB(ctx context.Context, siteID uuid.UU
 						isInfiniBandConfigSynced = true
 						if ibifc.Status != cdbm.InfiniBandInterfaceStatusReady {
 							// If the InfiniBand Interface is not in Ready state, set the status to Ready
-							status = cdb.GetStrPtr(cdbm.InterfaceStatusReady)
+							status = cdb.GetStrPtr(cdbm.InfiniBandInterfaceStatusReady)
 						}
 					}
 

--- a/workflow/pkg/activity/instance/instance.go
+++ b/workflow/pkg/activity/instance/instance.go
@@ -486,15 +486,13 @@ func (mi ManageInstance) UpdateInstancesInDB(ctx context.Context, siteID uuid.UU
 		}
 
 		infiniBandInterfaceMap := map[string]*cdbm.InfiniBandInterface{}
-
+		deletingInfiniBandInterfaces := []*cdbm.InfiniBandInterface{}
 		for _, ibifc := range infiniBandInterfaces {
 			curIbIfc := ibifc
-			// If the InfiniBand Interface is in Deleting state, add it into list of InfiniBand Interfaces to be deleted
+			// Add the InfiniBand Interface to the list of InfiniBand Interfaces to be deleted if it is in Deleting state
 			if ibifc.Status == cdbm.InfiniBandInterfaceStatusDeleting {
-				if updatedInstanceStatus != nil && *updatedInstanceStatus == cdbm.InstanceStatusReady {
-					infiniBandInterfacesToDelete = append(infiniBandInterfacesToDelete, &curIbIfc)
-					continue
-				}
+				deletingInfiniBandInterfaces = append(deletingInfiniBandInterfaces, &curIbIfc)
+				continue
 			}
 
 			if ibifc.InfiniBandPartition.ControllerIBPartitionID == nil {
@@ -520,9 +518,17 @@ func (mi ManageInstance) UpdateInstancesInDB(ctx context.Context, siteID uuid.UU
 
 		if controllerInstance.Config.Infiniband != nil && controllerInstance.Status.Infiniband != nil {
 			for idx, interfaceConfig := range controllerInstance.Config.Infiniband.IbInterfaces {
+				// Skip if the InfiniBand Interface Config is nil
+				if interfaceConfig == nil {
+					logger.Warn().Int("Index", idx).Msg("InfiniBand Interface Config is nil, skipping update")
+					continue
+				}
+
+				// Get the InfiniBand Interface from the map
 				ibifcKey := fmt.Sprintf("%s-%s-%d", interfaceConfig.IbPartitionId.Value, interfaceConfig.Device, interfaceConfig.DeviceInstance)
 				ibifc, ok := infiniBandInterfaceMap[ibifcKey]
 				if !ok {
+					logger.Warn().Str("InfiniBand Interface Key", ibifcKey).Msg("InfiniBand Interface does not exist in DB, possibly created directly on Site")
 					continue
 				}
 
@@ -539,7 +545,7 @@ func (mi ManageInstance) UpdateInstancesInDB(ctx context.Context, siteID uuid.UU
 					}
 
 					var status *string
-					if controllerInstance.Status.Infiniband.ConfigsSynced == cwsv1.SyncState_SYNCED {
+					if controllerInstance.Status.Infiniband.ConfigsSynced == cwsv1.SyncState_SYNCED && ibifc.Status != cdbm.InfiniBandInterfaceStatusReady {
 						status = cdb.GetStrPtr(cdbm.InterfaceStatusReady)
 					}
 
@@ -561,6 +567,23 @@ func (mi ManageInstance) UpdateInstancesInDB(ctx context.Context, siteID uuid.UU
 						slogger.Error().Err(serr).Str("InfiniBand Interface ID", ibifc.ID.String()).Msg("failed to update InfiniBand Interface in DB")
 					}
 				}
+			}
+		}
+
+		// Determine which InfiniBand Interfaces in Deleting state can be deleted
+		// If the InfiniBand Config and Status are empty, we can delete all InfiniBand Interfaces currently in Deleting state
+		isInfiniBandConfigStatusEmpty := len(controllerInstance.Config.GetInfiniband().GetIbInterfaces()) == 0 && len(controllerInstance.Status.GetInfiniband().GetIbInterfaces()) == 0
+		// If the InfiniBand Config and Status are synced, we can delete all eligible InfiniBand Interfaces currently in Deleting state
+		isInfiniBandConfigSynced := controllerInstance.Status.Infiniband != nil && controllerInstance.Status.Infiniband.ConfigsSynced == cwsv1.SyncState_SYNCED
+
+		if isInfiniBandConfigStatusEmpty || isInfiniBandConfigSynced {
+			for _, ibifc := range deletingInfiniBandInterfaces {
+				if util.IsTimeWithinStaleInventoryThreshold(ibifc.Updated) {
+					// If the InfiniBand Interface was modified within stale inventory threshold, defer to next inventory update
+					continue
+				}
+				// Continue with deletion
+				infiniBandInterfacesToDelete = append(infiniBandInterfacesToDelete, ibifc)
 			}
 		}
 

--- a/workflow/pkg/activity/instance/instance_test.go
+++ b/workflow/pkg/activity/instance/instance_test.go
@@ -307,6 +307,10 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 	ibInterface3 := util.TestBuildInfiniBandInterface(t, dbSession, instance1.ID, site.ID, partition1.ID, "MT2910 Family [ConnectX-7]", 2, true, nil, cdbm.InfiniBandInterfaceStatusDeleting, false)
 	assert.NotNil(t, ibInterface3)
 
+	// Make Deleting InfiniBand row old enough to pass IsTimeWithinStaleInventoryThreshold deferral during inventory reconcile
+	_, err = dbSession.DB.Exec("UPDATE infiniband_interface SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval)*2), ibInterface3.ID.String())
+	assert.NoError(t, err)
+
 	// NVLink Interfaces
 	nvlinkInterface1 := util.TestBuildNVLinkInterface(t, dbSession, instance1.ID, site.ID, nvllPartition1.ID, cdb.GetStrPtr(""), 0, nil, nil, cdbm.NVLinkInterfaceStatusPending)
 	assert.NotNil(t, nvlinkInterface1)
@@ -869,6 +873,11 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 	ibInterface18_3 := util.TestBuildInfiniBandInterface(t, dbSession, instance18.ID, site.ID, partition1.ID, "MT2910 Family [ConnectX-7]", 2, true, nil, cdbm.InfiniBandInterfaceStatusDeleting, false)
 	assert.NotNil(t, ibInterface18_3)
 
+	for _, ibd := range []*cdbm.InfiniBandInterface{ibInterface18_1, ibInterface18_2, ibInterface18_3} {
+		_, err = dbSession.DB.Exec("UPDATE infiniband_interface SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval)*2), ibd.ID.String())
+		assert.NoError(t, err)
+	}
+
 	// Build DPU Extension Services and Deployments for testing
 	dpuExtensionService1 := util.TestBuildDpuExtensionService(t, dbSession, "test-dpu-ext-service-1", site, tenant, "ovs-offload", cdb.GetStrPtr("1"), nil, []string{}, cdbm.DpuExtensionServiceStatusReady, ipu)
 	assert.NotNil(t, dpuExtensionService1)
@@ -912,6 +921,7 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 							},
 						},
 					},
+					// InfiniBand config/status keys must align with reconcile map: controller IB partition id + device + device instance
 					Infiniband: &cwsv1.InstanceInfinibandConfig{
 						IbInterfaces: []*cwsv1.InstanceIBInterfaceConfig{
 							{


### PR DESCRIPTION
## Description

- In Inventory, delete InfiniBand Interfaces based on configuration synchronization not instance readiness
- Validate Instance InfiniBand Interface update against existing bindings, No operation if instance InfiniBand Interface update is identical to existing
- If existing interfaces are pending for more than 30 seconds (based on current config), we consider them to be different.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Fix** - Bug fixes (fix:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **API** - API models or endpoints updated
- [x] **Workflow** - Workflow service updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
