### PR TITLE
chore: Allow privileged Tenants to retrieve Machines without specifying Site ID

### DIFF
--- a/api/pkg/api/handler/instancebatch.go
+++ b/api/pkg/api/handler/instancebatch.go
@@ -1770,7 +1770,6 @@ func allocateMachinesForBatch(
 
 	// Get all available Machines for the Instance Type
 	filterInput := cdbm.MachineFilterInput{
-		SiteID:          instancetype.SiteID,
 		InstanceTypeIDs: []uuid.UUID{instancetype.ID},
 		IsAssigned:      cdb.GetBoolPtr(false),
 		Statuses:        []string{cdbm.MachineStatusReady},

--- a/api/pkg/api/handler/machine.go
+++ b/api/pkg/api/handler/machine.go
@@ -250,31 +250,26 @@ func (gamh GetAllMachineHandler) Handle(c echo.Context) error {
 	// Validate other query params
 	if infrastructureProvider != nil {
 		filterInput.InfrastructureProviderIDs = []uuid.UUID{infrastructureProvider.ID}
-	} else if tenant != nil {
-		// Check if Tenant is privileged
-		if !tenant.Config.TargetedInstanceCreation {
-			logger.Warn().Msg("Tenant doesn't have targeted Instance creation capability, access denied")
-			return cutil.NewAPIErrorResponse(c, http.StatusForbidden, "Tenant must have targeted Instance creation capability in order to retrieve Machines", nil)
-		}
-
-		// Get IDs for all Providers the privileged Tenant has an account with
-		taDAO := cdbm.NewTenantAccountDAO(gamh.dbSession)
-		tas, _, serr := taDAO.GetAll(ctx, nil, cdbm.TenantAccountFilterInput{
-			TenantIDs: []uuid.UUID{tenant.ID},
-		}, cdbp.PageInput{}, []string{})
-		if serr != nil {
-			logger.Error().Err(serr).Msg("error retrieving Tenant Accounts for privileged Tenant")
-			return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Error retrieving Tenant Accounts for privileged Tenant", nil)
-		}
-
-		providerIDs := make([]uuid.UUID, 0, len(tas))
-		for _, ta := range tas {
-			providerIDs = append(providerIDs, ta.InfrastructureProviderID)
-		}
-		filterInput.InfrastructureProviderIDs = providerIDs
 	}
 
-	mDAO := cdbm.NewMachineDAO(gamh.dbSession)
+	if tenant != nil {
+		// Check if Tenant is privileged
+		if tenant.Config.TargetedInstanceCreation {
+			// Get IDs for all Providers the privileged Tenant has an account with
+			taDAO := cdbm.NewTenantAccountDAO(gamh.dbSession)
+			tas, _, serr := taDAO.GetAll(ctx, nil, cdbm.TenantAccountFilterInput{
+				TenantIDs: []uuid.UUID{tenant.ID},
+			}, cdbp.PageInput{}, []string{})
+			if serr != nil {
+				logger.Error().Err(serr).Msg("error retrieving Tenant Accounts for privileged Tenant")
+				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Error retrieving Tenant Accounts for privileged Tenant", nil)
+			}
+
+			for _, ta := range tas {
+				filterInput.InfrastructureProviderIDs = append(filterInput.InfrastructureProviderIDs, ta.InfrastructureProviderID)
+			}
+		}
+	}
 
 	// Validate site id if provided
 	qSiteID := c.QueryParam("siteId")
@@ -499,6 +494,9 @@ func (gamh GetAllMachineHandler) Handle(c echo.Context) error {
 		Limit:   pageRequest.Limit,
 		OrderBy: pageRequest.OrderBy,
 	}
+
+	mDAO := cdbm.NewMachineDAO(gamh.dbSession)
+
 	ms, total, err := mDAO.GetAll(ctx, nil, filterInput, pageInput, qIncludeRelations)
 	if err != nil {
 		logger.Error().Err(err).Msg("error getting Machines from DB")

--- a/api/pkg/api/handler/machine.go
+++ b/api/pkg/api/handler/machine.go
@@ -259,7 +259,7 @@ func (gamh GetAllMachineHandler) Handle(c echo.Context) error {
 			taDAO := cdbm.NewTenantAccountDAO(gamh.dbSession)
 			tas, _, serr := taDAO.GetAll(ctx, nil, cdbm.TenantAccountFilterInput{
 				TenantIDs: []uuid.UUID{tenant.ID},
-			}, cdbp.PageInput{}, []string{})
+			}, cdbp.PageInput{Limit: cdb.GetIntPtr(cdbp.TotalLimit)}, []string{})
 			if serr != nil {
 				logger.Error().Err(serr).Msg("error retrieving Tenant Accounts for privileged Tenant")
 				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Error retrieving Tenant Accounts for privileged Tenant", nil)

--- a/api/pkg/api/handler/machine.go
+++ b/api/pkg/api/handler/machine.go
@@ -249,7 +249,29 @@ func (gamh GetAllMachineHandler) Handle(c echo.Context) error {
 
 	// Validate other query params
 	if infrastructureProvider != nil {
-		filterInput.InfrastructureProviderID = &infrastructureProvider.ID
+		filterInput.InfrastructureProviderIDs = []uuid.UUID{infrastructureProvider.ID}
+	} else if tenant != nil {
+		// Check if Tenant is privileged
+		if !tenant.Config.TargetedInstanceCreation {
+			logger.Warn().Msg("Tenant doesn't have targeted Instance creation capability, access denied")
+			return cutil.NewAPIErrorResponse(c, http.StatusForbidden, "Tenant must have targeted Instance creation capability in order to retrieve Machines", nil)
+		}
+
+		// Get IDs for all Providers the privileged Tenant has an account with
+		taDAO := cdbm.NewTenantAccountDAO(gamh.dbSession)
+		tas, _, serr := taDAO.GetAll(ctx, nil, cdbm.TenantAccountFilterInput{
+			TenantIDs: []uuid.UUID{tenant.ID},
+		}, cdbp.PageInput{}, []string{})
+		if serr != nil {
+			logger.Error().Err(serr).Msg("error retrieving Tenant Accounts for privileged Tenant")
+			return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Error retrieving Tenant Accounts for privileged Tenant", nil)
+		}
+
+		providerIDs := make([]uuid.UUID, 0, len(tas))
+		for _, ta := range tas {
+			providerIDs = append(providerIDs, ta.InfrastructureProviderID)
+		}
+		filterInput.InfrastructureProviderIDs = providerIDs
 	}
 
 	mDAO := cdbm.NewMachineDAO(gamh.dbSession)
@@ -266,39 +288,25 @@ func (gamh GetAllMachineHandler) Handle(c echo.Context) error {
 			return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Error retrieving Site specified in query", nil)
 		}
 
+		isAssociated := false
 		if infrastructureProvider != nil {
 			// Check if Site belongs to org's Infrastructure Provider
-			if site.InfrastructureProviderID != infrastructureProvider.ID {
-				logger.Error().Msg("Site's Infrastructure Provider doesn't match org's Infrastructure Provider")
-				return cutil.NewAPIErrorResponse(c, http.StatusForbidden, "Site specified in query doesn't belong to org's Infrastructure provider", nil)
-			}
-		} else if tenant != nil {
-			// Check if Tenant is privileged
-			if !tenant.Config.TargetedInstanceCreation {
-				logger.Warn().Msg("Tenant doesn't have targeted Instance creation capability, access denied")
-				return cutil.NewAPIErrorResponse(c, http.StatusForbidden, "Tenant must have targeted Instance creation capability in order to retrieve Machines", nil)
-			}
-
-			// Check if privileged Tenant has an account with Infrastructure Provider
-			taDAO := cdbm.NewTenantAccountDAO(gamh.dbSession)
-			_, taCount, serr := taDAO.GetAll(ctx, nil, cdbm.TenantAccountFilterInput{
-				InfrastructureProviderID: &site.InfrastructureProviderID,
-				TenantIDs:                []uuid.UUID{tenant.ID},
-			}, cdbp.PageInput{}, []string{})
-			if serr != nil {
-				logger.Error().Err(serr).Msg("error retrieving Tenant Account for Site")
-				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Error retrieving Tenant Account for Site", nil)
-			}
-
-			if taCount == 0 {
-				logger.Error().Msg("privileged Tenant doesn't have an account with Infrastructure Provider")
-				return cutil.NewAPIErrorResponse(c, http.StatusForbidden, "Privileged Tenant must have an account with Provider of Site specified in query", nil)
+			if site.InfrastructureProviderID == infrastructureProvider.ID {
+				isAssociated = true
 			}
 		}
 
-		filterInput.SiteID = &site.ID
-	} else if tenant != nil {
-		return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "Site ID must be specified in query when retrieving Machines as a privileged Tenant", nil)
+		if !isAssociated && tenant != nil {
+			// We've already populated the filter with Providers the Tenant has an account with
+			isAssociated = slices.Contains(filterInput.InfrastructureProviderIDs, site.InfrastructureProviderID)
+		}
+
+		if isAssociated {
+			filterInput.SiteIDs = []uuid.UUID{site.ID}
+		} else {
+			logger.Error().Msg("Site is not associated with org")
+			return cutil.NewAPIErrorResponse(c, http.StatusForbidden, "Current org is not associated with the Site specified in query", nil)
+		}
 	}
 
 	// Validate InstanceType ID if provided
@@ -306,7 +314,7 @@ func (gamh GetAllMachineHandler) Handle(c echo.Context) error {
 	if len(qInstanceTypeID) > 0 {
 		gamh.tracerSpan.SetAttribute(handlerSpan, attribute.StringSlice("instanceTypeId", qInstanceTypeID), logger)
 		for _, instanceTypeID := range qInstanceTypeID {
-			instancetype, serr := common.GetInstanceTypeFromIDString(ctx, nil, instanceTypeID, gamh.dbSession)
+			instanceType, serr := common.GetInstanceTypeFromIDString(ctx, nil, instanceTypeID, gamh.dbSession)
 
 			if serr != nil {
 				instanceTypeIdError := validation.Errors{
@@ -315,11 +323,11 @@ func (gamh GetAllMachineHandler) Handle(c echo.Context) error {
 				if serr == cdb.ErrDoesNotExist {
 					return cutil.NewAPIErrorResponse(c, http.StatusNotFound, "Could not find Instance Type specified in query", instanceTypeIdError)
 				}
-				logger.Error().Err(serr).Str("Instance Type ID", instanceTypeID).Msg("error retreiving Instance Type specified in query")
+				logger.Error().Err(serr).Str("Instance Type ID", instanceTypeID).Msg("error retrieving Instance Type specified in query")
 				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Error retrieving Instance Type specified in query", instanceTypeIdError)
 			}
 
-			filterInput.InstanceTypeIDs = append(filterInput.InstanceTypeIDs, instancetype.ID)
+			filterInput.InstanceTypeIDs = append(filterInput.InstanceTypeIDs, instanceType.ID)
 		}
 	}
 
@@ -364,7 +372,7 @@ func (gamh GetAllMachineHandler) Handle(c echo.Context) error {
 		for _, tenantIDStr := range qTenantIDStrs {
 			tenantID, err := uuid.Parse(tenantIDStr)
 			if err != nil {
-				return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "Invalid tenant ID specified in query", nil)
+				return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "Invalid Tenant ID specified in query", nil)
 			}
 			tenantIDs = append(tenantIDs, tenantID)
 		}
@@ -413,7 +421,7 @@ func (gamh GetAllMachineHandler) Handle(c echo.Context) error {
 			return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "Invalid value specified for `hasInstance` in query", nil)
 		}
 
-		if filterInput.SiteID == nil {
+		if len(filterInput.SiteIDs) == 0 {
 			return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "`hasInstance` cannot be specified when `siteId` is not specified in query", nil)
 		}
 

--- a/api/pkg/api/handler/machine.go
+++ b/api/pkg/api/handler/machine.go
@@ -245,11 +245,13 @@ func (gamh GetAllMachineHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, errMsg, nil)
 	}
 
-	filterInput := cdbm.MachineFilterInput{}
+	filterInput := cdbm.MachineFilterInput{
+		InfrastructureProviderIDs: []uuid.UUID{},
+	}
 
 	// Validate other query params
 	if infrastructureProvider != nil {
-		filterInput.InfrastructureProviderIDs = []uuid.UUID{infrastructureProvider.ID}
+		filterInput.InfrastructureProviderIDs = append(filterInput.InfrastructureProviderIDs, infrastructureProvider.ID)
 	}
 
 	if tenant != nil {

--- a/api/pkg/api/handler/machine_test.go
+++ b/api/pkg/api/handler/machine_test.go
@@ -808,7 +808,6 @@ func TestMachineHandler_GetAll(t *testing.T) {
 	}
 
 	// Build Targeted Instance
-
 	tnOrg4 := "test-tn-org-4"
 	tnu4 := testMachineBuildUser(t, dbSession, uuid.NewString(), []string{tnOrg4}, tnRoles)
 
@@ -917,6 +916,12 @@ func TestMachineHandler_GetAll(t *testing.T) {
 	)
 	assert.Nil(t, err)
 	assert.NotNil(t, ins34)
+
+	tnOrg7 := "test-tn-org-7"
+	tnu7 := testMachineBuildUser(t, dbSession, uuid.NewString(), []string{tnOrg7}, tnRoles)
+	tenant7 := testMachineBuildTenant(t, dbSession, tnOrg7, "test-tenant7")
+	_ = testMachineUpdateTenantCapability(t, dbSession, tenant7)
+	_ = common.TestBuildTenantAccount(t, dbSession, ip, &tenant7.ID, tnOrg7, cdbm.TenantAccountStatusReady, tnu7)
 
 	cfg := common.GetTestConfig()
 	tempClient := &tmocks.Client{}
@@ -1052,7 +1057,7 @@ func TestMachineHandler_GetAll(t *testing.T) {
 			verifyChildSpanner: true,
 		},
 		{
-			name:               "success case when tenant has TenantAdmin role and has TargetedInstanceCreation capability",
+			name:               "success case when Tenant has TargetedInstanceCreation capability and filters by Site ID",
 			reqOrgName:         tnOrg2,
 			user:               tnu2,
 			querySiteID:        cdb.GetStrPtr(siteT2.ID.String()),
@@ -1062,6 +1067,15 @@ func TestMachineHandler_GetAll(t *testing.T) {
 			expectedTotal:      cdb.GetIntPtr(0),
 			expectInstance:     false,
 			verifyChildSpanner: true,
+		},
+		{
+			name:           "success case when Tenant has TargetedInstanceCreation capability",
+			reqOrgName:     tnOrg7,
+			user:           tnu7,
+			expectedErr:    false,
+			expectedStatus: http.StatusOK,
+			expectedCnt:    totalCount / 2,
+			expectedTotal:  cdb.GetIntPtr(totalCount / 2),
 		},
 		{
 			name:                "success case when Instance Type ID specified in query",
@@ -1338,7 +1352,7 @@ func TestMachineHandler_GetAll(t *testing.T) {
 			expectedCnt:    0,
 		},
 		{
-			name:           "failure case when Tenant ID specified in query does not belong to the current infrastructure provider",
+			name:           "failure case when Tenant ID specified in query does have an account with current org's Provider",
 			reqOrgName:     ipOrg4,
 			user:           ipu,
 			queryTenantID:  []string{tenant2.ID.String()},

--- a/api/pkg/api/handler/machine_test.go
+++ b/api/pkg/api/handler/machine_test.go
@@ -923,6 +923,11 @@ func TestMachineHandler_GetAll(t *testing.T) {
 	_ = testMachineUpdateTenantCapability(t, dbSession, tenant7)
 	_ = common.TestBuildTenantAccount(t, dbSession, ip, &tenant7.ID, tnOrg7, cdbm.TenantAccountStatusReady, tnu7)
 
+	tnOrg8 := "test-tn-org-8"
+	tnu8 := testMachineBuildUser(t, dbSession, uuid.NewString(), []string{tnOrg8}, tnRoles)
+	tenant8 := testMachineBuildTenant(t, dbSession, tnOrg8, "test-tenant8")
+	_ = testMachineUpdateTenantCapability(t, dbSession, tenant8)
+
 	cfg := common.GetTestConfig()
 	tempClient := &tmocks.Client{}
 
@@ -1076,6 +1081,15 @@ func TestMachineHandler_GetAll(t *testing.T) {
 			expectedStatus: http.StatusOK,
 			expectedCnt:    totalCount / 2,
 			expectedTotal:  cdb.GetIntPtr(totalCount / 2),
+		},
+		{
+			name:           "empty result when Tenant has TargetedInstanceCreation capability but no Tenant Account",
+			reqOrgName:     tnOrg8,
+			user:           tnu8,
+			expectedErr:    false,
+			expectedStatus: http.StatusOK,
+			expectedCnt:    0,
+			expectedTotal:  cdb.GetIntPtr(0),
 		},
 		{
 			name:                "success case when Instance Type ID specified in query",

--- a/api/pkg/api/handler/machinecapability.go
+++ b/api/pkg/api/handler/machinecapability.go
@@ -153,10 +153,13 @@ func (gamch GetAllMachineCapabilityHandler) Handle(c echo.Context) error {
 	// Get Machines
 	filterInput := cdbm.MachineFilterInput{
 		InfrastructureProviderIDs: []uuid.UUID{orgInfrastructureProvider.ID},
-		SiteIDs:                   []uuid.UUID{site.ID},
 		HasInstanceType:           hasInstanceType,
 		ExcludeMetadata:           true, // Exclude metadata since we're only retrieving Machines for the IDs
 	}
+	if site != nil {
+		filterInput.SiteIDs = []uuid.UUID{site.ID}
+	}
+
 	ms, _, err := mDAO.GetAll(ctx, nil, filterInput, cdbp.PageInput{Limit: cdb.GetIntPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("error getting Machines from DB")

--- a/api/pkg/api/handler/machinecapability.go
+++ b/api/pkg/api/handler/machinecapability.go
@@ -120,9 +120,10 @@ func (gamch GetAllMachineCapabilityHandler) Handle(c echo.Context) error {
 	qSiteID := c.QueryParam("siteId")
 
 	// Validate site id if provided
-	var siteIDPtr *uuid.UUID
+	var site *cdbm.Site
 	if qSiteID != "" {
-		site, serr := common.GetSiteFromIDString(ctx, nil, qSiteID, gamch.dbSession)
+		var serr error
+		site, serr = common.GetSiteFromIDString(ctx, nil, qSiteID, gamch.dbSession)
 		if serr != nil {
 			if serr == cdb.ErrDoesNotExist {
 				return cutil.NewAPIErrorResponse(c, http.StatusNotFound, "Could not find Site specified in query", nil)
@@ -135,8 +136,6 @@ func (gamch GetAllMachineCapabilityHandler) Handle(c echo.Context) error {
 			logger.Error().Msg("Site's Infrastructure Provider doesn't match org's Infrastructure Provider")
 			return cutil.NewAPIErrorResponse(c, http.StatusForbidden, "Site specified in query doesn't belong to org's Infrastructure provider", nil)
 		}
-
-		siteIDPtr = &site.ID
 	}
 
 	// Check if `hasInstanceType` query params
@@ -153,9 +152,10 @@ func (gamch GetAllMachineCapabilityHandler) Handle(c echo.Context) error {
 
 	// Get Machines
 	filterInput := cdbm.MachineFilterInput{
-		InfrastructureProviderID: &orgInfrastructureProvider.ID,
-		SiteID:                   siteIDPtr,
-		HasInstanceType:          hasInstanceType,
+		InfrastructureProviderIDs: []uuid.UUID{orgInfrastructureProvider.ID},
+		SiteIDs:                   []uuid.UUID{site.ID},
+		HasInstanceType:           hasInstanceType,
+		ExcludeMetadata:           true, // Exclude metadata since we're only retrieving Machines for the IDs
 	}
 	ms, _, err := mDAO.GetAll(ctx, nil, filterInput, cdbp.PageInput{Limit: cdb.GetIntPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {

--- a/api/pkg/api/handler/stats.go
+++ b/api/pkg/api/handler/stats.go
@@ -89,12 +89,10 @@ func (gmgsh GetMachineGPUStatsHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusForbidden, "User does not have access to the specified site", nil)
 	}
 
-	siteID := &site.ID
-
 	// Fetch all machines for the site (exclude metadata for performance)
 	machineDAO := cdbm.NewMachineDAO(gmgsh.dbSession)
 	machines, _, err := machineDAO.GetAll(ctx, nil, cdbm.MachineFilterInput{
-		SiteID:          siteID,
+		SiteIDs:         []uuid.UUID{site.ID},
 		ExcludeMetadata: true,
 	}, cdbp.PageInput{Limit: cdb.GetIntPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {
@@ -229,7 +227,7 @@ func (gtitsh GetTenantInstanceTypeStatsHandler) Handle(c echo.Context) error {
 	// 5. Fetch all machines with instance types for the site (exclude metadata)
 	machineDAO := cdbm.NewMachineDAO(gtitsh.dbSession)
 	machines, _, err := machineDAO.GetAll(ctx, nil, cdbm.MachineFilterInput{
-		SiteID:          siteID,
+		SiteIDs:         []uuid.UUID{site.ID},
 		InstanceTypeIDs: instanceTypeIDs,
 		ExcludeMetadata: true,
 	}, cdbp.PageInput{Limit: cdb.GetIntPtr(cdbp.TotalLimit)}, nil)
@@ -411,12 +409,10 @@ func (gmitsh GetMachineInstanceTypeSummaryHandler) Handle(c echo.Context) error 
 		return cutil.NewAPIErrorResponse(c, http.StatusForbidden, "User does not have access to the specified site", nil)
 	}
 
-	siteID := &site.ID
-
 	// Fetch all machines for the site (exclude metadata for performance)
 	machineDAO := cdbm.NewMachineDAO(gmitsh.dbSession)
 	machines, _, err := machineDAO.GetAll(ctx, nil, cdbm.MachineFilterInput{
-		SiteID:          siteID,
+		SiteIDs:         []uuid.UUID{site.ID},
 		ExcludeMetadata: true,
 	}, cdbp.PageInput{Limit: cdb.GetIntPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {
@@ -497,8 +493,7 @@ func (gmitsh GetMachineInstanceTypeStatsHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusForbidden, "User does not have access to the specified site", nil)
 	}
 
-	siteID := &site.ID
-	siteIDs := []uuid.UUID{*siteID}
+	siteIDs := []uuid.UUID{site.ID}
 
 	// 1. Fetch all instance types for the site
 	itDAO := cdbm.NewInstanceTypeDAO(gmitsh.dbSession)
@@ -518,7 +513,7 @@ func (gmitsh GetMachineInstanceTypeStatsHandler) Handle(c echo.Context) error {
 	// 2. Fetch all machines for the site (exclude metadata)
 	machineDAO := cdbm.NewMachineDAO(gmitsh.dbSession)
 	machines, _, err := machineDAO.GetAll(ctx, nil, cdbm.MachineFilterInput{
-		SiteID:          siteID,
+		SiteIDs:         siteIDs,
 		ExcludeMetadata: true,
 	}, cdbp.PageInput{Limit: cdb.GetIntPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {

--- a/api/pkg/api/handler/util/common/common.go
+++ b/api/pkg/api/handler/util/common/common.go
@@ -307,8 +307,8 @@ func AcquireInstanceTypeQuotaLock(ctx context.Context, tx *cdb.Tx, tenantID uuid
 }
 
 // GetUnallocatedMachineForInstanceType provides unallocatd machine based on instancetype
-func GetUnallocatedMachineForInstanceType(ctx context.Context, tx *cdb.Tx, dbSession *cdb.Session, instancetype *cdbm.InstanceType) (*cdbm.Machine, error) {
-	if instancetype == nil {
+func GetUnallocatedMachineForInstanceType(ctx context.Context, tx *cdb.Tx, dbSession *cdb.Session, instanceType *cdbm.InstanceType) (*cdbm.Machine, error) {
+	if instanceType == nil {
 		return nil, ErrInvalidFunctionParams
 	}
 
@@ -322,8 +322,7 @@ func GetUnallocatedMachineForInstanceType(ctx context.Context, tx *cdb.Tx, dbSes
 	// Get all available Machines for the Instance Type
 	// Since this query is occurring outside of a lock, we will have to double check availability of Machines
 	filterInput := cdbm.MachineFilterInput{
-		SiteID:          instancetype.SiteID,
-		InstanceTypeIDs: []uuid.UUID{instancetype.ID},
+		InstanceTypeIDs: []uuid.UUID{instanceType.ID},
 		IsAssigned:      cdb.GetBoolPtr(false),
 		Statuses:        []string{cdbm.MachineStatusReady},
 	}
@@ -401,8 +400,16 @@ func GetCountOfMachinesForInstanceType(ctx context.Context, tx *cdb.Tx, dbSessio
 // machines broken down by site and machine status.
 func GetSiteMachineCountStats(ctx context.Context, tx *cdb.Tx, dbSession *cdb.Session, logger zerolog.Logger, infrastructureProviderID *uuid.UUID, siteID *uuid.UUID) (map[uuid.UUID]*cam.APISiteMachineStats, error) {
 	mDAO := cdbm.NewMachineDAO(dbSession)
-	machines, _, err := mDAO.GetAll(ctx, tx, cdbm.MachineFilterInput{InfrastructureProviderID: infrastructureProviderID, SiteID: siteID}, cdbp.PageInput{Limit: cdb.GetIntPtr(cdbp.TotalLimit)}, nil)
 
+	filterInput := cdbm.MachineFilterInput{}
+	if infrastructureProviderID != nil {
+		filterInput.InfrastructureProviderIDs = []uuid.UUID{*infrastructureProviderID}
+	}
+	if siteID != nil {
+		filterInput.SiteIDs = []uuid.UUID{*siteID}
+	}
+
+	machines, _, err := mDAO.GetAll(ctx, tx, filterInput, cdbp.PageInput{Limit: cdb.GetIntPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/db/pkg/db/model/machine.go
+++ b/db/pkg/db/model/machine.go
@@ -246,21 +246,21 @@ type MachineClearInput struct {
 
 // MachineFilterInput filtering options for GetAll method
 type MachineFilterInput struct {
-	InfrastructureProviderID *uuid.UUID
-	SiteID                   *uuid.UUID
-	HasInstanceType          *bool
-	InstanceTypeIDs          []uuid.UUID
-	ControllerMachineID      *string
-	HwSkuDeviceTypes         []string
-	IsAssigned               *bool
-	Hostname                 *string
-	CapabilityType           *string
-	CapabilityNames          []string
-	Statuses                 []string
-	SearchQuery              *string
-	MachineIDs               []string
-	IsMissingOnSite          *bool
-	ExcludeMetadata          bool // When true, excludes the metadata JSONB column from SELECT to improve performance on bulk queries
+	InfrastructureProviderIDs []uuid.UUID
+	SiteIDs                   []uuid.UUID
+	HasInstanceType           *bool
+	InstanceTypeIDs           []uuid.UUID
+	ControllerMachineID       *string
+	HwSkuDeviceTypes          []string
+	IsAssigned                *bool
+	Hostname                  *string
+	CapabilityType            *string
+	CapabilityNames           []string
+	Statuses                  []string
+	SearchQuery               *string
+	MachineIDs                []string
+	IsMissingOnSite           *bool
+	ExcludeMetadata           bool // When true, excludes the metadata JSONB column from SELECT to improve performance on bulk queries
 }
 
 type MachineHealth struct {
@@ -504,19 +504,19 @@ func (msd MachineSQLDAO) GetCountByStatus(ctx context.Context, tx *db.Tx, infras
 }
 
 func (msd MachineSQLDAO) setQueryWithFilter(filter MachineFilterInput, query *bun.SelectQuery, machineDAOSpan *stracer.CurrentContextSpan) (*bun.SelectQuery, error) {
-	if filter.InfrastructureProviderID != nil {
-		query = query.Where("m.infrastructure_provider_id = ?", *filter.InfrastructureProviderID)
+	if filter.InfrastructureProviderIDs != nil {
+		query = query.Where("m.infrastructure_provider_id IN (?)", bun.In(filter.InfrastructureProviderIDs))
 
 		if machineDAOSpan != nil {
-			msd.tracerSpan.SetAttribute(machineDAOSpan, "infrastructure_provider_id", filter.InfrastructureProviderID.String())
+			msd.tracerSpan.SetAttribute(machineDAOSpan, "infrastructure_provider_ids", filter.InfrastructureProviderIDs)
 		}
 	}
 
-	if filter.SiteID != nil {
-		query = query.Where("m.site_id = ?", *filter.SiteID)
+	if filter.SiteIDs != nil {
+		query = query.Where("m.site_id IN (?)", bun.In(filter.SiteIDs))
 
 		if machineDAOSpan != nil {
-			msd.tracerSpan.SetAttribute(machineDAOSpan, "site_id", filter.SiteID.String())
+			msd.tracerSpan.SetAttribute(machineDAOSpan, "site_ids", filter.SiteIDs)
 		}
 	}
 

--- a/db/pkg/db/model/machine_test.go
+++ b/db/pkg/db/model/machine_test.go
@@ -864,7 +864,7 @@ func TestMachineSQLDAO_GetAll(t *testing.T) {
 		{
 			desc: "GetAll with ip filters returns objects",
 			filter: MachineFilterInput{
-				InfrastructureProviderID: &ms1[0].InfrastructureProviderID,
+				InfrastructureProviderIDs: []uuid.UUID{ms1[0].InfrastructureProviderID},
 			},
 			expectedCount: totalCount / 2,
 			expectedError: false,
@@ -872,7 +872,7 @@ func TestMachineSQLDAO_GetAll(t *testing.T) {
 		{
 			desc: "GetAll with site filters returns objects",
 			filter: MachineFilterInput{
-				SiteID: &ms2[0].SiteID,
+				SiteIDs: []uuid.UUID{ms2[0].SiteID},
 			},
 			expectedCount: totalCount / 2,
 			expectedError: false,
@@ -880,7 +880,7 @@ func TestMachineSQLDAO_GetAll(t *testing.T) {
 		{
 			desc: "GetAll with is assigned filters returns objects",
 			filter: MachineFilterInput{
-				SiteID:     &ms1[0].SiteID,
+				SiteIDs:    []uuid.UUID{ms1[0].SiteID},
 				IsAssigned: db.GetBoolPtr(true),
 			},
 			expectedCount: 1,
@@ -889,7 +889,7 @@ func TestMachineSQLDAO_GetAll(t *testing.T) {
 		{
 			desc: "GetAll with unknown ip filters returns no objects",
 			filter: MachineFilterInput{
-				InfrastructureProviderID: &dummyID,
+				InfrastructureProviderIDs: []uuid.UUID{dummyID},
 			},
 			expectedCount: 0,
 			expectedError: false,
@@ -897,7 +897,7 @@ func TestMachineSQLDAO_GetAll(t *testing.T) {
 		{
 			desc: "GetAll with hostname filters returns objects",
 			filter: MachineFilterInput{
-				SiteID:   &ms1[0].SiteID,
+				SiteIDs:  []uuid.UUID{ms1[0].SiteID},
 				Hostname: db.GetStrPtr("testhostname-1"),
 			},
 			expectedCount: 1,
@@ -958,7 +958,7 @@ func TestMachineSQLDAO_GetAll(t *testing.T) {
 		{
 			desc: "GetAll with offset returns objects",
 			filter: MachineFilterInput{
-				SiteID: &ms2[0].SiteID,
+				SiteIDs: []uuid.UUID{ms2[0].SiteID},
 			},
 			pageInput: paginator.PageInput{
 				Offset: db.GetIntPtr(5),
@@ -970,7 +970,7 @@ func TestMachineSQLDAO_GetAll(t *testing.T) {
 		{
 			desc: "GetAll with order by returns objects",
 			filter: MachineFilterInput{
-				SiteID: &ms2[0].SiteID,
+				SiteIDs: []uuid.UUID{ms2[0].SiteID},
 			},
 			pageInput: paginator.PageInput{
 				OrderBy: &paginator.OrderBy{
@@ -1788,21 +1788,21 @@ func TestMachineSQLDAO_GetCount(t *testing.T) {
 		{
 			desc: "filter with InfrastructureProviderID",
 			filter: MachineFilterInput{
-				InfrastructureProviderID: &ms1[0].InfrastructureProviderID,
+				InfrastructureProviderIDs: []uuid.UUID{ms1[0].InfrastructureProviderID},
 			},
 			expectedCount: totalCount / 2,
 		},
 		{
 			desc: "filter with SiteID",
 			filter: MachineFilterInput{
-				SiteID: &ms2[0].SiteID,
+				SiteIDs: []uuid.UUID{ms2[0].SiteID},
 			},
 			expectedCount: totalCount / 2,
 		},
 		{
 			desc: "filter with SiteID and IsAssigned",
 			filter: MachineFilterInput{
-				SiteID:     &ms1[0].SiteID,
+				SiteIDs:    []uuid.UUID{ms1[0].SiteID},
 				IsAssigned: db.GetBoolPtr(true),
 			},
 			expectedCount: 1,
@@ -1810,14 +1810,14 @@ func TestMachineSQLDAO_GetCount(t *testing.T) {
 		{
 			desc: "filter with unknown InfrastructureProviderID",
 			filter: MachineFilterInput{
-				InfrastructureProviderID: &dummyID,
+				InfrastructureProviderIDs: []uuid.UUID{dummyID},
 			},
 			expectedCount: 0,
 		},
 		{
 			desc: "filter with SiteID and Hostname",
 			filter: MachineFilterInput{
-				SiteID:   &ms1[0].SiteID,
+				SiteIDs:  []uuid.UUID{ms1[0].SiteID},
 				Hostname: db.GetStrPtr("testhostname-1"),
 			},
 			expectedCount: 1,

--- a/workflow/pkg/activity/machine/machine.go
+++ b/workflow/pkg/activity/machine/machine.go
@@ -190,7 +190,8 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 
 	// Get all machines for Site to allow faster lookups
 	mDAO := cdbm.NewMachineDAO(mm.dbSession)
-	filterInput := cdbm.MachineFilterInput{SiteID: &siteID}
+
+	filterInput := cdbm.MachineFilterInput{SiteIDs: []uuid.UUID{site.ID}}
 
 	existingMachines, _, err := mDAO.GetAll(ctx, nil, filterInput, cdbp.PageInput{Limit: cdb.GetIntPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {

--- a/workflow/pkg/activity/machine/machine_test.go
+++ b/workflow/pkg/activity/machine/machine_test.go
@@ -1179,7 +1179,7 @@ func TestManageMachine_UpdateMachinesInDB(t *testing.T) {
 
 			if tt.args.newControllerMachineID != nil {
 				// Check if a new Machine got created in DB based on machineInfo2
-				sms, _, serr := mDAO.GetAll(tt.args.ctx, nil, cdbm.MachineFilterInput{SiteID: &tt.args.siteID}, cdbp.PageInput{}, nil)
+				sms, _, serr := mDAO.GetAll(tt.args.ctx, nil, cdbm.MachineFilterInput{SiteIDs: []uuid.UUID{tt.args.siteID}}, cdbp.PageInput{}, nil)
 				assert.Nil(t, serr)
 
 				var m4 *cdbm.Machine
@@ -1327,7 +1327,7 @@ func TestManageMachine_UpdateMachinesInDB(t *testing.T) {
 				if tt.args.machineInventory.InventoryPage.CurrentPage == 1 {
 					// Check that the first 10 Machines now have status `Ready`
 					filterInput := cdbm.MachineFilterInput{
-						SiteID:     &tt.args.siteID,
+						SiteIDs:    []uuid.UUID{tt.args.siteID},
 						MachineIDs: pagedInvIds[0:10],
 					}
 					tms, _, serr := mDAO.GetAll(tt.args.ctx, nil, filterInput, cdbp.PageInput{}, nil)
@@ -1338,7 +1338,7 @@ func TestManageMachine_UpdateMachinesInDB(t *testing.T) {
 
 					// Check that no Machine status is Error due to being missing
 					filterInput = cdbm.MachineFilterInput{
-						SiteID:   &tt.args.siteID,
+						SiteIDs:  []uuid.UUID{tt.args.siteID},
 						Statuses: []string{cdbm.MachineStatusError},
 					}
 					_, missingCount, serr := mDAO.GetAll(tt.args.ctx, nil, filterInput, cdbp.PageInput{}, nil)
@@ -1349,7 +1349,7 @@ func TestManageMachine_UpdateMachinesInDB(t *testing.T) {
 				if tt.args.machineInventory.InventoryPage.CurrentPage == tt.args.machineInventory.InventoryPage.TotalPages {
 					// Check that the last 4 Machines now have status `Ready`
 					filterInput := cdbm.MachineFilterInput{
-						SiteID:     &tt.args.siteID,
+						SiteIDs:    []uuid.UUID{tt.args.siteID},
 						MachineIDs: pagedInvIds[30:34],
 					}
 					tms, _, serr := mDAO.GetAll(tt.args.ctx, nil, filterInput, cdbp.PageInput{}, nil)
@@ -1360,7 +1360,7 @@ func TestManageMachine_UpdateMachinesInDB(t *testing.T) {
 
 					// Check that no Machine status is Error due to being missing
 					filterInput = cdbm.MachineFilterInput{
-						SiteID:   &tt.args.siteID,
+						SiteIDs:  []uuid.UUID{tt.args.siteID},
 						Statuses: []string{cdbm.MachineStatusError},
 					}
 					_, missingCount, serr := mDAO.GetAll(tt.args.ctx, nil, filterInput, cdbp.PageInput{}, nil)

--- a/workflow/pkg/activity/site/site.go
+++ b/workflow/pkg/activity/site/site.go
@@ -212,7 +212,7 @@ func (mst ManageSite) DeleteSiteComponentsFromDB(ctx context.Context, siteID uui
 
 	// Delete Machines
 	// Check if Machines exist
-	mcs, _, err := mDAO.GetAll(ctx, nil, cdbm.MachineFilterInput{SiteID: &siteID}, cdbp.PageInput{Limit: cdb.GetIntPtr(cdbp.TotalLimit)}, nil)
+	mcs, _, err := mDAO.GetAll(ctx, nil, cdbm.MachineFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: cdb.GetIntPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("error retrieving Machine for Site from DB")
 		return err


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
Currently privileged Tenants must specify Site ID in order to retrieve Machines available to them. There is not particular need for this restriction, this PR removes that requirement.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Chore** - Modification or removal of existing functionality (chore:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **API** - API models or endpoints updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->
None

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
None
