### PR TITLE
chore: Apply the new FromProto/ToProto modeling to MachineCapability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -333,6 +333,19 @@ on the underlying primitive until they need it.
   Entity callers reach it via `entity.Labels.FromProto(proto.Metadata.GetLabels())`
   — the proto getter is nil-safe and returns `nil` for missing
   metadata, which the method translates into a `nil` receiver.
+- `db/pkg/db/model.MachineCapabilityType` and `MachineCapabilityDeviceType`
+  (`type X string` with `(X).ToProto() cwssaws.X` and
+  `(*X).FromProto(cwssaws.X)`) are the reference for **typed-string
+  domain enums** that round-trip with proto enum values. The DB column
+  stays a plain string under the named type, but the conversion to /
+  from the proto enum lives as methods on the type — not as a free
+  helper. `(*MachineCapability).ToProto` collapses to
+  `mc.Type.ToProto()` / `mc.DeviceType.ToProto()`, and `FromProto`
+  collapses to `mc.Type.FromProto(...)`. Unknown values silently leave
+  the receiver as the empty string (a warning is logged) so the
+  entity-level `Validate` can be the gate that rejects them; an
+  optional `*X` field with the proto's zero-value enum on the wire
+  drops to `nil` rather than encoding an "unknown" pointer.
 - `APIMachineCapabilities` (`type APIMachineCapabilities
   []APIMachineCapability` with `(APIMachineCapabilities).Validate()`)
   is the reference for slice-shaped values that own list-level rules.

--- a/api/pkg/api/handler/instance.go
+++ b/api/pkg/api/handler/instance.go
@@ -1039,7 +1039,7 @@ func (cih CreateInstanceHandler) Handle(c echo.Context) error {
 			var ibCaps []cdbm.MachineCapability
 
 			if instanceTypeID != nil {
-				ibCaps, ibCapCount, err = mcDAO.GetAll(ctx, nil, nil, []uuid.UUID{*instanceTypeID}, cdb.GetStrPtr(cdbm.MachineCapabilityTypeInfiniBand), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+				ibCaps, ibCapCount, err = mcDAO.GetAll(ctx, nil, nil, []uuid.UUID{*instanceTypeID}, cdb.GetTypedStrPtr(cdbm.MachineCapabilityTypeInfiniBand), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 				if err != nil {
 					logger.Error().Err(err).Msg("error retrieving Machine Capabilities from DB for Instance Type")
 					return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve InfiniBand Capabilities for Instance Type, DB error", nil)
@@ -1048,7 +1048,7 @@ func (cih CreateInstanceHandler) Handle(c echo.Context) error {
 
 			// If Instance Type does not have InfiniBand Capability, get capabilities from Machine
 			if ibCapCount == 0 {
-				ibCaps, ibCapCount, err = mcDAO.GetAll(ctx, nil, []string{machine.ID}, nil, cdb.GetStrPtr(cdbm.MachineCapabilityTypeInfiniBand), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+				ibCaps, ibCapCount, err = mcDAO.GetAll(ctx, nil, []string{machine.ID}, nil, cdb.GetTypedStrPtr(cdbm.MachineCapabilityTypeInfiniBand), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 				if err != nil {
 					logger.Error().Err(err).Msg("error retrieving Machine Capabilities from DB for Machine")
 					return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve InfiniBand Capabilities for Machine, DB error", nil)
@@ -1125,7 +1125,7 @@ func (cih CreateInstanceHandler) Handle(c echo.Context) error {
 			var dpuNetworkCaps []cdbm.MachineCapability
 
 			if instanceTypeID != nil {
-				dpuNetworkCaps, dpuNetworkCapCount, err = mcDAO.GetAll(ctx, nil, nil, []uuid.UUID{*instanceTypeID}, cdb.GetStrPtr(cdbm.MachineCapabilityTypeNetwork), nil, nil, nil, nil, nil, cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeDPU), nil, nil, nil, nil, nil)
+				dpuNetworkCaps, dpuNetworkCapCount, err = mcDAO.GetAll(ctx, nil, nil, []uuid.UUID{*instanceTypeID}, cdb.GetTypedStrPtr(cdbm.MachineCapabilityTypeNetwork), nil, nil, nil, nil, nil, cdb.GetTypedStrPtr(cdbm.MachineCapabilityDeviceTypeDPU), nil, nil, nil, nil, nil)
 				if err != nil {
 					logger.Error().Err(err).Msg("error retrieving Machine Capabilities from DB for Instance Type")
 					return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve DPU aware Network Capabilities for Instance Type, DB error", nil)
@@ -1133,7 +1133,7 @@ func (cih CreateInstanceHandler) Handle(c echo.Context) error {
 			}
 
 			if dpuNetworkCapCount == 0 {
-				dpuNetworkCaps, dpuNetworkCapCount, err = mcDAO.GetAll(ctx, nil, []string{machine.ID}, nil, cdb.GetStrPtr(cdbm.MachineCapabilityTypeNetwork), nil, nil, nil, nil, nil, cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeDPU), nil, nil, nil, nil, nil)
+				dpuNetworkCaps, dpuNetworkCapCount, err = mcDAO.GetAll(ctx, nil, []string{machine.ID}, nil, cdb.GetTypedStrPtr(cdbm.MachineCapabilityTypeNetwork), nil, nil, nil, nil, nil, cdb.GetTypedStrPtr(cdbm.MachineCapabilityDeviceTypeDPU), nil, nil, nil, nil, nil)
 				if err != nil {
 					logger.Error().Err(err).Msg("error retrieving Machine Capabilities from DB for Machine")
 					return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve DPU aware Network Capabilities for Machine, DB error", nil)
@@ -1184,7 +1184,7 @@ func (cih CreateInstanceHandler) Handle(c echo.Context) error {
 
 		// Fetch GPU Capabilities from Instance Type or Machine
 		if instanceTypeID != nil {
-			nvlCaps, nvlCapCount, err = mcDAO.GetAll(ctx, nil, nil, []uuid.UUID{*instanceTypeID}, cdb.GetStrPtr(cdbm.MachineCapabilityTypeGPU), nil, nil, nil, nil, nil, cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink), nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
+			nvlCaps, nvlCapCount, err = mcDAO.GetAll(ctx, nil, nil, []uuid.UUID{*instanceTypeID}, cdb.GetTypedStrPtr(cdbm.MachineCapabilityTypeGPU), nil, nil, nil, nil, nil, cdb.GetTypedStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink), nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
 			if err != nil {
 				logger.Error().Err(err).Msg("error retrieving GPU Machine Capabilities from DB for Instance Type")
 				return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve GPU Capabilities for Instance Type, DB error", nil)
@@ -1192,7 +1192,7 @@ func (cih CreateInstanceHandler) Handle(c echo.Context) error {
 		}
 
 		if nvlCapCount == 0 {
-			nvlCaps, nvlCapCount, err = mcDAO.GetAll(ctx, nil, []string{machine.ID}, nil, cdb.GetStrPtr(cdbm.MachineCapabilityTypeGPU), nil, nil, nil, nil, nil, cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink), nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
+			nvlCaps, nvlCapCount, err = mcDAO.GetAll(ctx, nil, []string{machine.ID}, nil, cdb.GetTypedStrPtr(cdbm.MachineCapabilityTypeGPU), nil, nil, nil, nil, nil, cdb.GetTypedStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink), nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
 			if err != nil {
 				logger.Error().Err(err).Msg("error retrieving GPU Machine Capabilities from DB for Machine")
 				return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve GPU Capabilities for Machine, DB error", nil)
@@ -2471,7 +2471,7 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 		var dpuNetworkCaps []cdbm.MachineCapability
 		var dpuNetworkCapCount int
 		if instance.InstanceTypeID != nil {
-			dpuNetworkCaps, dpuNetworkCapCount, err = mcDAO.GetAll(ctx, nil, nil, []uuid.UUID{*instance.InstanceTypeID}, cdb.GetStrPtr(cdbm.MachineCapabilityTypeNetwork), nil, nil, nil, nil, nil, cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeDPU), nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
+			dpuNetworkCaps, dpuNetworkCapCount, err = mcDAO.GetAll(ctx, nil, nil, []uuid.UUID{*instance.InstanceTypeID}, cdb.GetTypedStrPtr(cdbm.MachineCapabilityTypeNetwork), nil, nil, nil, nil, nil, cdb.GetTypedStrPtr(cdbm.MachineCapabilityDeviceTypeDPU), nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
 			if err != nil {
 				logger.Error().Err(err).Msg("error retrieving Machine Capabilities from DB for Instance Type")
 				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve DPU aware Network Capabilities for Instance Type", nil)
@@ -2479,7 +2479,7 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 		}
 
 		if dpuNetworkCapCount == 0 {
-			dpuNetworkCaps, dpuNetworkCapCount, err = mcDAO.GetAll(ctx, nil, []string{machine.ID}, nil, cdb.GetStrPtr(cdbm.MachineCapabilityTypeNetwork), nil, nil, nil, nil, nil, cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeDPU), nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
+			dpuNetworkCaps, dpuNetworkCapCount, err = mcDAO.GetAll(ctx, nil, []string{machine.ID}, nil, cdb.GetTypedStrPtr(cdbm.MachineCapabilityTypeNetwork), nil, nil, nil, nil, nil, cdb.GetTypedStrPtr(cdbm.MachineCapabilityDeviceTypeDPU), nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
 			if err != nil {
 				logger.Error().Err(err).Msg("error retrieving DPU aware Network Capabilities from DB for Machine")
 				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve DPU aware Network Capabilities for Machine", nil)
@@ -2554,7 +2554,7 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 		var ibCaps []cdbm.MachineCapability
 
 		if instance.InstanceTypeID != nil {
-			ibCaps, ibCapCount, err = mcDAO.GetAll(ctx, nil, nil, []uuid.UUID{*instance.InstanceTypeID}, cdb.GetStrPtr(cdbm.MachineCapabilityTypeInfiniBand), nil, nil, nil, nil, nil, nil, nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
+			ibCaps, ibCapCount, err = mcDAO.GetAll(ctx, nil, nil, []uuid.UUID{*instance.InstanceTypeID}, cdb.GetTypedStrPtr(cdbm.MachineCapabilityTypeInfiniBand), nil, nil, nil, nil, nil, nil, nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
 			if err != nil {
 				logger.Error().Err(err).Msg("error retrieving InfiniBand Capabilities from DB for Instance Type")
 				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve InfiniBand Capabilities for Instance Type", nil)
@@ -2562,7 +2562,7 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 		}
 
 		if ibCapCount == 0 {
-			ibCaps, ibCapCount, err = mcDAO.GetAll(ctx, nil, []string{machine.ID}, nil, cdb.GetStrPtr(cdbm.MachineCapabilityTypeInfiniBand), nil, nil, nil, nil, nil, nil, nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
+			ibCaps, ibCapCount, err = mcDAO.GetAll(ctx, nil, []string{machine.ID}, nil, cdb.GetTypedStrPtr(cdbm.MachineCapabilityTypeInfiniBand), nil, nil, nil, nil, nil, nil, nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
 			if err != nil {
 				logger.Error().Err(err).Msg("error retrieving InfiniBand Capabilities from DB for Machine")
 				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve InfiniBand Capabilities for Machine", nil)
@@ -2714,7 +2714,7 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 
 		if instance.InstanceTypeID != nil {
 			// Try to get GPU capabilities from Instance Type first
-			nvlCaps, nvlCapCount, err = mcDAO.GetAll(ctx, nil, nil, []uuid.UUID{*instance.InstanceTypeID}, cdb.GetStrPtr(cdbm.MachineCapabilityTypeGPU), nil, nil, nil, nil, nil, cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink), nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
+			nvlCaps, nvlCapCount, err = mcDAO.GetAll(ctx, nil, nil, []uuid.UUID{*instance.InstanceTypeID}, cdb.GetTypedStrPtr(cdbm.MachineCapabilityTypeGPU), nil, nil, nil, nil, nil, cdb.GetTypedStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink), nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
 			if err != nil {
 				logger.Error().Err(err).Msg("error retrieving GPU Machine Capabilities from DB for Instance Type")
 				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve GPU Capabilities for Instance Type", nil)
@@ -2723,7 +2723,7 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 
 		// If Instance was not created using Instance Type, or Instance Type does not have NVLink  Capability, get capabilities from Machine
 		if nvlCapCount == 0 {
-			nvlCaps, nvlCapCount, err = mcDAO.GetAll(ctx, nil, []string{machine.ID}, nil, cdb.GetStrPtr(cdbm.MachineCapabilityTypeGPU), nil, nil, nil, nil, nil, cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink), nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
+			nvlCaps, nvlCapCount, err = mcDAO.GetAll(ctx, nil, []string{machine.ID}, nil, cdb.GetTypedStrPtr(cdbm.MachineCapabilityTypeGPU), nil, nil, nil, nil, nil, cdb.GetTypedStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink), nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
 			if err != nil {
 				logger.Error().Err(err).Msg("error retrieving GPU Machine Capabilities from DB for Instance's Machine")
 				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve GPU Capabilities for Instance's Machine", nil)

--- a/api/pkg/api/handler/instance_test.go
+++ b/api/pkg/api/handler/instance_test.go
@@ -373,7 +373,7 @@ func testInstanceBuildMachineWithID(t *testing.T, dbSession *cdb.Session, ip uui
 	return m
 }
 
-func testInstanceBuildMachineCapability(t *testing.T, dbSession *cdb.Session, mID *string, capabilityType string, name string, capacity *string, count *int) *cdbm.MachineCapability {
+func testInstanceBuildMachineCapability(t *testing.T, dbSession *cdb.Session, mID *string, capabilityType cdbm.MachineCapabilityType, name string, capacity *string, count *int) *cdbm.MachineCapability {
 	mc := &cdbm.MachineCapability{
 		ID:             uuid.New(),
 		MachineID:      mID,
@@ -693,13 +693,13 @@ func TestCreateInstanceHandler_Handle(t *testing.T) {
 	assert.NotNil(t, ist1)
 
 	// Add InfiniBand capability to Instance Type
-	common.TestBuildMachineCapability(t, dbSession, nil, &ist1.ID, cdbm.MachineCapabilityTypeInfiniBand, "MT28908 Family [ConnectX-6]", nil, nil, cdb.GetStrPtr("Mellanox Technologies"), cdb.GetIntPtr(3), cdb.GetStrPtr(""), nil)
+	common.TestBuildMachineCapability(t, dbSession, nil, &ist1.ID, cdbm.MachineCapabilityTypeInfiniBand, "MT28908 Family [ConnectX-6]", nil, nil, cdb.GetStrPtr("Mellanox Technologies"), cdb.GetIntPtr(3), cdb.Ptr(cdbm.MachineCapabilityDeviceType("")), nil)
 
 	// Add Network DPU capability to Instance Type
-	common.TestBuildMachineCapability(t, dbSession, nil, &ist1.ID, cdbm.MachineCapabilityTypeNetwork, "MT42822 BlueField-2 integrated ConnectX-6 Dx network controller", nil, nil, cdb.GetStrPtr("Mellanox Technologies"), cdb.GetIntPtr(2), cdb.GetStrPtr("DPU"), nil)
+	common.TestBuildMachineCapability(t, dbSession, nil, &ist1.ID, cdbm.MachineCapabilityTypeNetwork, "MT42822 BlueField-2 integrated ConnectX-6 Dx network controller", nil, nil, cdb.GetStrPtr("Mellanox Technologies"), cdb.GetIntPtr(2), cdb.Ptr(cdbm.MachineCapabilityDeviceTypeDPU), nil)
 
 	// Add NVLink GPU capability to Instance Type
-	mcNvlType := common.TestBuildMachineCapability(t, dbSession, nil, &ist1.ID, cdbm.MachineCapabilityTypeGPU, "NVIDIA GB200", nil, nil, cdb.GetStrPtr("NVIDIA"), cdb.GetIntPtr(4), cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink), nil)
+	mcNvlType := common.TestBuildMachineCapability(t, dbSession, nil, &ist1.ID, cdbm.MachineCapabilityTypeGPU, "NVIDIA GB200", nil, nil, cdb.GetStrPtr("NVIDIA"), cdb.GetIntPtr(4), cdb.Ptr(cdbm.MachineCapabilityDeviceTypeNVLink), nil)
 	assert.NotNil(t, mcNvlType)
 
 	istnoib := testInstanceBuildInstanceType(t, dbSession, ip, "test-instance-type-noib", st1, cdbm.InstanceStatusReady)
@@ -725,7 +725,7 @@ func TestCreateInstanceHandler_Handle(t *testing.T) {
 	assert.NotNil(t, mcbyid)
 
 	// Add capability to machine
-	common.TestBuildMachineCapability(t, dbSession, &mcbyid.ID, nil, cdbm.MachineCapabilityTypeGPU, "NVIDIA GB200", nil, nil, cdb.GetStrPtr("NVIDIA"), cdb.GetIntPtr(4), cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink), nil)
+	common.TestBuildMachineCapability(t, dbSession, &mcbyid.ID, nil, cdbm.MachineCapabilityTypeGPU, "NVIDIA GB200", nil, nil, cdb.GetStrPtr("NVIDIA"), cdb.GetIntPtr(4), cdb.Ptr(cdbm.MachineCapabilityDeviceTypeNVLink), nil)
 
 	mcinstbyid := testInstanceBuildMachineInstanceType(t, dbSession, mcbyid, istbyid)
 	assert.NotNil(t, mcinstbyid)
@@ -3939,12 +3939,12 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 	setVpcProp(vpcSecondaryPartial, []string{instUpdatePartial.ID.String()}, []string{instUpdatePartial.ID.String()}, cwssaws.NetworkSecurityGroupPropagationStatus_NSG_PROP_STATUS_NONE)
 
 	// Add Network DPU capability to Instance Type
-	common.TestBuildMachineCapability(t, dbSession, nil, &ist4.ID, cdbm.MachineCapabilityTypeNetwork, "MT42822 BlueField-2 integrated ConnectX-6 Dx network controller", nil, nil, cdb.GetStrPtr("Mellanox Technologies"), cdb.GetIntPtr(2), cdb.GetStrPtr("DPU"), nil)
+	common.TestBuildMachineCapability(t, dbSession, nil, &ist4.ID, cdbm.MachineCapabilityTypeNetwork, "MT42822 BlueField-2 integrated ConnectX-6 Dx network controller", nil, nil, cdb.GetStrPtr("Mellanox Technologies"), cdb.GetIntPtr(2), cdb.Ptr(cdbm.MachineCapabilityDeviceTypeDPU), nil)
 
 	inst13 := testInstanceBuildInstance(t, dbSession, "test-instance-nvlink-update", tn1.ID, ip.ID, st3.ID, &ist4.ID, vpc4.ID, cdb.GetStrPtr(mc5.ID), &os2.ID, nil, cdbm.InstanceStatusReady)
 
 	// Add NVLink GPU capability to Machine
-	common.TestBuildMachineCapability(t, dbSession, &mc5.ID, nil, cdbm.MachineCapabilityTypeGPU, "NVIDIA GB200", nil, nil, cdb.GetStrPtr("NVIDIA"), cdb.GetIntPtr(4), cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink), nil)
+	common.TestBuildMachineCapability(t, dbSession, &mc5.ID, nil, cdbm.MachineCapabilityTypeGPU, "NVIDIA GB200", nil, nil, cdb.GetStrPtr("NVIDIA"), cdb.GetIntPtr(4), cdb.Ptr(cdbm.MachineCapabilityDeviceTypeNVLink), nil)
 
 	nvllp1 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-1", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg1, st3, tn1, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusReady), false)
 	assert.NotNil(t, nvllp1)
@@ -4088,7 +4088,7 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 	// Extra InfiniBand Partitions for updating instance with InfiniBand Interfaces
 
 	// Add InfiniBand capability to Instance Type
-	common.TestBuildMachineCapability(t, dbSession, nil, &ist1.ID, cdbm.MachineCapabilityTypeInfiniBand, "MT28908 Family [ConnectX-6]", nil, nil, cdb.GetStrPtr("Mellanox Technologies"), cdb.GetIntPtr(5), cdb.GetStrPtr(""), nil)
+	common.TestBuildMachineCapability(t, dbSession, nil, &ist1.ID, cdbm.MachineCapabilityTypeInfiniBand, "MT28908 Family [ConnectX-6]", nil, nil, cdb.GetStrPtr("Mellanox Technologies"), cdb.GetIntPtr(5), cdb.Ptr(cdbm.MachineCapabilityDeviceType("")), nil)
 
 	ibp2 := testBuildIBPartition(t, dbSession, "test-ibp-2", tnOrg1, st1, tn1, cdb.GetUUIDPtr(uuid.New()), cdb.GetStrPtr(cdbm.InfiniBandPartitionStatusReady), false)
 	assert.NotNil(t, ibp2)

--- a/api/pkg/api/handler/instancebatch.go
+++ b/api/pkg/api/handler/instancebatch.go
@@ -894,7 +894,7 @@ func (bcih BatchCreateInstanceHandler) Handle(c echo.Context) error {
 	// Validate InfiniBand interfaces (shared across all instances)
 	if len(apiRequest.InfiniBandInterfaces) > 0 {
 		// Get InfiniBand capabilities
-		itIbCaps, itIbCapCount, derr := mcDAO.GetAll(ctx, nil, nil, []uuid.UUID{apiInstanceTypeID}, cdb.GetStrPtr(cdbm.MachineCapabilityTypeInfiniBand), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		itIbCaps, itIbCapCount, derr := mcDAO.GetAll(ctx, nil, nil, []uuid.UUID{apiInstanceTypeID}, cdb.GetTypedStrPtr(cdbm.MachineCapabilityTypeInfiniBand), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		if derr != nil {
 			logger.Error().Err(derr).Msg("error retrieving InfiniBand Machine Capabilities from DB for Instance Type")
 			return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve InfiniBand Capabilities for Instance Type, DB error", nil)
@@ -978,8 +978,8 @@ func (bcih BatchCreateInstanceHandler) Handle(c echo.Context) error {
 	if isDeviceInfoPresent {
 		// Get DPU capabilities for validation
 		itDpuCaps, itDpuCapCount, derr := mcDAO.GetAll(ctx, nil, nil, []uuid.UUID{apiInstanceTypeID},
-			cdb.GetStrPtr(cdbm.MachineCapabilityTypeNetwork), nil, nil, nil, nil, nil,
-			cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeDPU), nil, nil, nil, nil, nil)
+			cdb.GetTypedStrPtr(cdbm.MachineCapabilityTypeNetwork), nil, nil, nil, nil, nil,
+			cdb.GetTypedStrPtr(cdbm.MachineCapabilityDeviceTypeDPU), nil, nil, nil, nil, nil)
 		if derr != nil {
 			logger.Error().Err(derr).Msg("error retrieving DPU Machine Capabilities")
 			return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError,
@@ -1004,7 +1004,7 @@ func (bcih BatchCreateInstanceHandler) Handle(c echo.Context) error {
 
 	// Validate NVLink interfaces (shared across all instances)
 	// Get GPU (NVLink) capabilities
-	itNvlCaps, itNvlCapCount, err := mcDAO.GetAll(ctx, nil, nil, []uuid.UUID{apiInstanceTypeID}, cdb.GetStrPtr(cdbm.MachineCapabilityTypeGPU), nil, nil, nil, nil, nil, cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink), nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
+	itNvlCaps, itNvlCapCount, err := mcDAO.GetAll(ctx, nil, nil, []uuid.UUID{apiInstanceTypeID}, cdb.GetTypedStrPtr(cdbm.MachineCapabilityTypeGPU), nil, nil, nil, nil, nil, cdb.GetTypedStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink), nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("error retrieving GPU (NVLink) Machine Capabilities from DB for Instance Type")
 		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve GPU Capabilities for Instance Type, DB error", nil)

--- a/api/pkg/api/handler/instancebatch_test.go
+++ b/api/pkg/api/handler/instancebatch_test.go
@@ -99,8 +99,8 @@ func TestBatchCreateInstanceHandler_Handle(t *testing.T) {
 	assert.NotNil(t, ist1)
 
 	// Add InfiniBand capability to Instance Type 1 for InfiniBand interface tests
-	common.TestBuildMachineCapability(t, dbSession, nil, &ist1.ID, cdbm.MachineCapabilityTypeInfiniBand, "MT28908 Family [ConnectX-6]", nil, nil, cdb.GetStrPtr("Mellanox Technologies"), cdb.GetIntPtr(3), cdb.GetStrPtr(""), nil)
-	common.TestBuildMachineCapability(t, dbSession, nil, &ist1.ID, cdbm.MachineCapabilityTypeNetwork, "MT42822 BlueField-2 integrated ConnectX-6 Dx network controller", nil, nil, cdb.GetStrPtr("Mellanox Technologies"), cdb.GetIntPtr(2), cdb.GetStrPtr("DPU"), nil)
+	common.TestBuildMachineCapability(t, dbSession, nil, &ist1.ID, cdbm.MachineCapabilityTypeInfiniBand, "MT28908 Family [ConnectX-6]", nil, nil, cdb.GetStrPtr("Mellanox Technologies"), cdb.GetIntPtr(3), cdb.Ptr(cdbm.MachineCapabilityDeviceType("")), nil)
+	common.TestBuildMachineCapability(t, dbSession, nil, &ist1.ID, cdbm.MachineCapabilityTypeNetwork, "MT42822 BlueField-2 integrated ConnectX-6 Dx network controller", nil, nil, cdb.GetStrPtr("Mellanox Technologies"), cdb.GetIntPtr(2), cdb.Ptr(cdbm.MachineCapabilityDeviceTypeDPU), nil)
 
 	// Allocation constraint for ist1 with quota of 15
 	alc1 := testInstanceSiteBuildAllocationContraints(t, dbSession, al1, cdbm.AllocationResourceTypeInstanceType, ist1.ID, cdbm.AllocationConstraintTypeReserved, 15, ipu)
@@ -144,7 +144,7 @@ func TestBatchCreateInstanceHandler_Handle(t *testing.T) {
 	assert.NotNil(t, nvllp1)
 
 	// Add NVLink GPU capability to Instance Type 1 for NVLink interface tests
-	mcNvlType := common.TestBuildMachineCapability(t, dbSession, nil, &ist1.ID, cdbm.MachineCapabilityTypeGPU, "NVIDIA GB200", nil, nil, cdb.GetStrPtr("NVIDIA"), cdb.GetIntPtr(4), cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink), nil)
+	mcNvlType := common.TestBuildMachineCapability(t, dbSession, nil, &ist1.ID, cdbm.MachineCapabilityTypeGPU, "NVIDIA GB200", nil, nil, cdb.GetStrPtr("NVIDIA"), cdb.GetIntPtr(4), (*cdbm.MachineCapabilityDeviceType)(cdb.GetTypedStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink)), nil)
 	assert.NotNil(t, mcNvlType)
 
 	// DPU Extension Service for testing DPU Extension Service Deployments

--- a/api/pkg/api/handler/instancetype.go
+++ b/api/pkg/api/handler/instancetype.go
@@ -1055,12 +1055,13 @@ func (uith UpdateInstanceTypeHandler) Handle(c echo.Context) error {
 			// Create a map to track capabilities that already exist
 			// in the DB so we can compare against the incoming request.
 			existingMacCapMap := map[string]*cdbm.MachineCapability{}
-			for _, mc := range existingMcs {
-				existingMacCapMap[mc.Type+"-"+mc.Name] = &mc
+			for i := range existingMcs {
+				mc := &existingMcs[i]
+				existingMacCapMap[mc.MapKey()] = mc
 			}
 
 			for pos, reqMacCap := range apiRequest.MachineCapabilities {
-				capKey := reqMacCap.Type + "-" + reqMacCap.Name
+				capKey := reqMacCap.MapKey()
 
 				existingCap := existingMacCapMap[capKey]
 				// The incoming requested capability doesn't exist at all currently,

--- a/api/pkg/api/handler/instancetype_test.go
+++ b/api/pkg/api/handler/instancetype_test.go
@@ -103,7 +103,7 @@ func TestCreateInstanceTypeHandler_Handle(t *testing.T) {
 				Type:       cdbm.MachineCapabilityTypeNetwork,
 				Name:       "MT43244 BlueField-3 integrated ConnectX-7 network controller",
 				Vendor:     cdb.GetStrPtr("Mellanox Technologies"),
-				DeviceType: cdb.GetStrPtr("DPU"),
+				DeviceType: cdb.Ptr(cdbm.MachineCapabilityDeviceTypeDPU),
 				Count:      cdb.GetIntPtr(2),
 			},
 		},
@@ -157,7 +157,7 @@ func TestCreateInstanceTypeHandler_Handle(t *testing.T) {
 				Name:       "NVIDIA GB200",
 				Capacity:   cdb.GetStrPtr("189471 MiB"),
 				Frequency:  cdb.GetStrPtr("2062 MHz"),
-				DeviceType: cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink),
+				DeviceType: cdb.Ptr(cdbm.MachineCapabilityDeviceTypeNVLink),
 				Count:      cdb.GetIntPtr(4),
 			},
 		},
@@ -171,7 +171,7 @@ func TestCreateInstanceTypeHandler_Handle(t *testing.T) {
 			{
 				Type:       cdbm.MachineCapabilityTypeGPU,
 				Name:       "NVIDIA GB200",
-				DeviceType: cdb.GetStrPtr("DPU"),
+				DeviceType: cdb.Ptr(cdbm.MachineCapabilityDeviceTypeDPU),
 				Count:      cdb.GetIntPtr(4),
 			},
 		},
@@ -185,7 +185,7 @@ func TestCreateInstanceTypeHandler_Handle(t *testing.T) {
 			{
 				Type:       cdbm.MachineCapabilityTypeNetwork,
 				Name:       "MT43244 BlueField-3 integrated ConnectX-7 network controller",
-				DeviceType: cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink),
+				DeviceType: cdb.Ptr(cdbm.MachineCapabilityDeviceTypeNVLink),
 				Count:      cdb.GetIntPtr(2),
 			},
 		},
@@ -199,7 +199,7 @@ func TestCreateInstanceTypeHandler_Handle(t *testing.T) {
 			{
 				Type:       cdbm.MachineCapabilityTypeCPU,
 				Name:       "Intel Xeon Gold 6354",
-				DeviceType: cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeDPU),
+				DeviceType: cdb.Ptr(cdbm.MachineCapabilityDeviceTypeDPU),
 				Count:      cdb.GetIntPtr(2),
 			},
 		},
@@ -704,7 +704,7 @@ func TestGetAllInstanceTypeHandler_Handle(t *testing.T) {
 			"name":        fmt.Sprintf("test-instance-type-%02d", i),
 			"description": fmt.Sprintf("Test Instance Type %02d Description", i),
 		}, ipu)
-		common.TestBuildMachineCapability(t, dbSession, nil, &it.ID, cdbm.MachineCapabilityTypeCPU, "Intel Xeon E5-2650v2", cdb.GetStrPtr("3.0Hz"), nil, nil, cdb.GetIntPtr(2), cdb.GetStrPtr(""), nil)
+		common.TestBuildMachineCapability(t, dbSession, nil, &it.ID, cdbm.MachineCapabilityTypeCPU, "Intel Xeon E5-2650v2", cdb.GetStrPtr("3.0Hz"), nil, nil, cdb.GetIntPtr(2), cdb.Ptr(cdbm.MachineCapabilityDeviceType("")), nil)
 		its = append(its, *it)
 	}
 
@@ -767,7 +767,7 @@ func TestGetAllInstanceTypeHandler_Handle(t *testing.T) {
 			"name":        fmt.Sprintf("test-org-instance-type-%02d", i),
 			"description": fmt.Sprintf("Test Org Instance Type %02d", i),
 		}, orgUser)
-		common.TestBuildMachineCapability(t, dbSession, nil, &it.ID, cdbm.MachineCapabilityTypeCPU, "Intel Xeon E5-2650v2", cdb.GetStrPtr("3.0Hz"), nil, nil, cdb.GetIntPtr(2), cdb.GetStrPtr(""), nil)
+		common.TestBuildMachineCapability(t, dbSession, nil, &it.ID, cdbm.MachineCapabilityTypeCPU, "Intel Xeon E5-2650v2", cdb.GetStrPtr("3.0Hz"), nil, nil, cdb.GetIntPtr(2), cdb.Ptr(cdbm.MachineCapabilityDeviceType("")), nil)
 		if i == 0 {
 			orgAllocatedIT = it
 		}
@@ -790,7 +790,7 @@ func TestGetAllInstanceTypeHandler_Handle(t *testing.T) {
 		it := common.TestBuildInstanceType(t, dbSession, fmt.Sprintf("test-ext-site-it-%02d", i), cdb.GetUUIDPtr(uuid.New()), externalSite, map[string]string{
 			"name": fmt.Sprintf("test-ext-site-it-%02d", i),
 		}, ipu)
-		common.TestBuildMachineCapability(t, dbSession, nil, &it.ID, cdbm.MachineCapabilityTypeCPU, "Intel Xeon E5-2650v2", cdb.GetStrPtr("3.0Hz"), nil, nil, cdb.GetIntPtr(2), cdb.GetStrPtr(""), nil)
+		common.TestBuildMachineCapability(t, dbSession, nil, &it.ID, cdbm.MachineCapabilityTypeCPU, "Intel Xeon E5-2650v2", cdb.GetStrPtr("3.0Hz"), nil, nil, cdb.GetIntPtr(2), cdb.Ptr(cdbm.MachineCapabilityDeviceType("")), nil)
 	}
 
 	// Create a second site owned by orgProvider but where orgTenant does NOT have a TenantSite.
@@ -802,7 +802,7 @@ func TestGetAllInstanceTypeHandler_Handle(t *testing.T) {
 		it := common.TestBuildInstanceType(t, dbSession, fmt.Sprintf("test-org-no-tenant-it-%02d", i), cdb.GetUUIDPtr(uuid.New()), orgSiteNoTenant, map[string]string{
 			"name": fmt.Sprintf("test-org-no-tenant-it-%02d", i),
 		}, orgUser)
-		common.TestBuildMachineCapability(t, dbSession, nil, &it.ID, cdbm.MachineCapabilityTypeCPU, "Intel Xeon E5-2650v2", cdb.GetStrPtr("3.0Hz"), nil, nil, cdb.GetIntPtr(2), cdb.GetStrPtr(""), nil)
+		common.TestBuildMachineCapability(t, dbSession, nil, &it.ID, cdbm.MachineCapabilityTypeCPU, "Intel Xeon E5-2650v2", cdb.GetStrPtr("3.0Hz"), nil, nil, cdb.GetIntPtr(2), cdb.Ptr(cdbm.MachineCapabilityDeviceType("")), nil)
 	}
 
 	e := echo.New()
@@ -2149,7 +2149,7 @@ func TestUpdateInstanceTypeHandler_Handle(t *testing.T) {
 				instanceTypeID: it2.ID,
 				reqData: &model.APIInstanceTypeUpdateRequest{
 					MachineCapabilities: []model.APIMachineCapability{
-						{Type: "Network", DeviceType: cdb.GetStrPtr("ETHERNET")},
+						{Type: cdbm.MachineCapabilityTypeNetwork, DeviceType: cdb.Ptr(cdbm.MachineCapabilityDeviceType("ETHERNET"))},
 					},
 				},
 			},
@@ -2253,7 +2253,7 @@ func TestUpdateInstanceTypeHandler_Handle(t *testing.T) {
 						{
 							Type:       "Network",
 							Name:       "MT43244 BlueField-3 integrated ConnectX-7 network controller",
-							DeviceType: cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeDPU),
+							DeviceType: cdb.Ptr(cdbm.MachineCapabilityDeviceTypeDPU),
 							Count:      cdb.GetIntPtr(2),
 						},
 					},
@@ -2280,7 +2280,7 @@ func TestUpdateInstanceTypeHandler_Handle(t *testing.T) {
 							Name:       "NVIDIA GB200",
 							Capacity:   cdb.GetStrPtr("189471 MiB"),
 							Frequency:  cdb.GetStrPtr("2062 MHz"),
-							DeviceType: cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink),
+							DeviceType: cdb.Ptr(cdbm.MachineCapabilityDeviceTypeNVLink),
 							Count:      cdb.GetIntPtr(4),
 						},
 					},
@@ -2305,7 +2305,7 @@ func TestUpdateInstanceTypeHandler_Handle(t *testing.T) {
 						{
 							Type:       cdbm.MachineCapabilityTypeGPU,
 							Name:       "NVIDIA GB200",
-							DeviceType: cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeDPU),
+							DeviceType: cdb.Ptr(cdbm.MachineCapabilityDeviceTypeDPU),
 							Count:      cdb.GetIntPtr(4),
 						},
 					},
@@ -2331,7 +2331,7 @@ func TestUpdateInstanceTypeHandler_Handle(t *testing.T) {
 						{
 							Type:       cdbm.MachineCapabilityTypeNetwork,
 							Name:       "MT43244 BlueField-3 integrated ConnectX-7 network controller",
-							DeviceType: cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink),
+							DeviceType: cdb.Ptr(cdbm.MachineCapabilityDeviceTypeNVLink),
 							Count:      cdb.GetIntPtr(2),
 						},
 					},
@@ -2357,7 +2357,7 @@ func TestUpdateInstanceTypeHandler_Handle(t *testing.T) {
 						{
 							Type:       cdbm.MachineCapabilityTypeCPU,
 							Name:       "Intel Xeon Gold 6354",
-							DeviceType: cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeDPU),
+							DeviceType: cdb.Ptr(cdbm.MachineCapabilityDeviceTypeDPU),
 							Count:      cdb.GetIntPtr(2),
 						},
 					},
@@ -2383,14 +2383,14 @@ func TestUpdateInstanceTypeHandler_Handle(t *testing.T) {
 						{
 							Type:       cdbm.MachineCapabilityTypeNetwork,
 							Name:       "MT43244 BlueField-3 integrated ConnectX-7 network controller",
-							DeviceType: cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeDPU),
+							DeviceType: cdb.Ptr(cdbm.MachineCapabilityDeviceTypeDPU),
 							Count:      cdb.GetIntPtr(2),
 						},
 						{
 							Type:       cdbm.MachineCapabilityTypeGPU,
 							Name:       "NVIDIA GB200",
 							Capacity:   cdb.GetStrPtr("189471 MiB"),
-							DeviceType: cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink),
+							DeviceType: cdb.Ptr(cdbm.MachineCapabilityDeviceTypeNVLink),
 							Count:      cdb.GetIntPtr(4),
 						},
 						{

--- a/api/pkg/api/handler/machine.go
+++ b/api/pkg/api/handler/machine.go
@@ -417,7 +417,7 @@ func (gamh GetAllMachineHandler) Handle(c echo.Context) error {
 	// Validate capability type from query param if it is provided
 	qCPtype := c.QueryParam("capabilityType")
 	if qCPtype != "" {
-		_, ok := cdbm.MachineCapabilityTypeChoiceMap[qCPtype]
+		_, ok := cdbm.MachineCapabilityTypeChoiceMap[cdbm.MachineCapabilityType(qCPtype)]
 		if !ok {
 			logger.Warn().Msg(fmt.Sprintf("invalid capabilityType value in query: %v", qCPtype))
 			return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, fmt.Sprintf("Invalid capabilityType value in query: %v", qCPtype), nil)

--- a/api/pkg/api/handler/machine_test.go
+++ b/api/pkg/api/handler/machine_test.go
@@ -132,7 +132,7 @@ func testMachineBuildMachine(t *testing.T, dbSession *cdb.Session, ip uuid.UUID,
 	return m
 }
 
-func testMachineBuildMachineCapability(t *testing.T, dbSession *cdb.Session, mID *string, capabilityType string, name string, capacity *string, count *int) *cdbm.MachineCapability {
+func testMachineBuildMachineCapability(t *testing.T, dbSession *cdb.Session, mID *string, capabilityType cdbm.MachineCapabilityType, name string, capacity *string, count *int) *cdbm.MachineCapability {
 	mc := &cdbm.MachineCapability{
 		ID:             uuid.New(),
 		MachineID:      mID,
@@ -1262,7 +1262,7 @@ func TestMachineHandler_GetAll(t *testing.T) {
 			name:                "success when valid capability type is specified in query",
 			reqOrgName:          ipOrg1,
 			user:                ipu,
-			queryCapabilityType: cdb.GetStrPtr(cdbm.MachineCapabilityTypeCPU),
+			queryCapabilityType: cdb.GetTypedStrPtr(cdbm.MachineCapabilityTypeCPU),
 			expectedErr:         false,
 			expectedStatus:      http.StatusOK,
 			expectedCnt:         totalCount / 2,

--- a/api/pkg/api/handler/machinecapability_test.go
+++ b/api/pkg/api/handler/machinecapability_test.go
@@ -52,28 +52,28 @@ func TestGetAllMachineCapabilityHandler_Handle(t *testing.T) {
 	}, ipu)
 
 	m1 := common.TestBuildMachine(t, dbSession, ip, st1, nil, nil, cdbm.MachineStatusReady)
-	common.TestBuildMachineCapability(t, dbSession, &m1.ID, nil, cdbm.MachineCapabilityTypeCPU, "Intel Xeon 6345", cdb.GetStrPtr("3.8Ghz"), nil, cdb.GetStrPtr("Genuine Intel"), cdb.GetIntPtr(2), cdb.GetStrPtr(""), nil)
-	common.TestBuildMachineCapability(t, dbSession, &m1.ID, nil, cdbm.MachineCapabilityTypeGPU, "Nvidia V100", nil, cdb.GetStrPtr("128GB"), cdb.GetStrPtr("Nvidia"), cdb.GetIntPtr(2), cdb.GetStrPtr(""), nil)
-	common.TestBuildMachineCapability(t, dbSession, &m1.ID, nil, cdbm.MachineCapabilityTypeStorage, "Dell Ent NVMe CM6 RI 1.92TB", nil, nil, nil, cdb.GetIntPtr(3), cdb.GetStrPtr(""), nil)
+	common.TestBuildMachineCapability(t, dbSession, &m1.ID, nil, cdbm.MachineCapabilityTypeCPU, "Intel Xeon 6345", cdb.GetStrPtr("3.8Ghz"), nil, cdb.GetStrPtr("Genuine Intel"), cdb.GetIntPtr(2), cdb.Ptr(cdbm.MachineCapabilityDeviceType("")), nil)
+	common.TestBuildMachineCapability(t, dbSession, &m1.ID, nil, cdbm.MachineCapabilityTypeGPU, "Nvidia V100", nil, cdb.GetStrPtr("128GB"), cdb.GetStrPtr("Nvidia"), cdb.GetIntPtr(2), cdb.Ptr(cdbm.MachineCapabilityDeviceType("")), nil)
+	common.TestBuildMachineCapability(t, dbSession, &m1.ID, nil, cdbm.MachineCapabilityTypeStorage, "Dell Ent NVMe CM6 RI 1.92TB", nil, nil, nil, cdb.GetIntPtr(3), cdb.Ptr(cdbm.MachineCapabilityDeviceType("")), nil)
 
 	m2 := common.TestBuildMachine(t, dbSession, ip, st1, &it.ID, nil, cdbm.MachineStatusReady)
-	common.TestBuildMachineCapability(t, dbSession, &m2.ID, nil, cdbm.MachineCapabilityTypeCPU, "Intel Xeon 6345", cdb.GetStrPtr("3.8Ghz"), nil, cdb.GetStrPtr("Genuine Intel"), cdb.GetIntPtr(2), cdb.GetStrPtr(""), nil)
-	common.TestBuildMachineCapability(t, dbSession, &m2.ID, nil, cdbm.MachineCapabilityTypeMemory, "DDR4", nil, cdb.GetStrPtr("16GB"), nil, cdb.GetIntPtr(4), cdb.GetStrPtr(""), nil)
-	common.TestBuildMachineCapability(t, dbSession, &m1.ID, nil, cdbm.MachineCapabilityTypeStorage, "SSDPF2KE016T9L", nil, nil, nil, cdb.GetIntPtr(2), cdb.GetStrPtr(""), nil)
-	common.TestBuildMachineCapability(t, dbSession, &m2.ID, nil, cdbm.MachineCapabilityTypeNetwork, "BCM57414 NetXtreme-E 10Gb/25Gb RDMA Ethernet Controller", nil, nil, nil, cdb.GetIntPtr(2), cdb.GetStrPtr(""), nil)
+	common.TestBuildMachineCapability(t, dbSession, &m2.ID, nil, cdbm.MachineCapabilityTypeCPU, "Intel Xeon 6345", cdb.GetStrPtr("3.8Ghz"), nil, cdb.GetStrPtr("Genuine Intel"), cdb.GetIntPtr(2), cdb.Ptr(cdbm.MachineCapabilityDeviceType("")), nil)
+	common.TestBuildMachineCapability(t, dbSession, &m2.ID, nil, cdbm.MachineCapabilityTypeMemory, "DDR4", nil, cdb.GetStrPtr("16GB"), nil, cdb.GetIntPtr(4), cdb.Ptr(cdbm.MachineCapabilityDeviceType("")), nil)
+	common.TestBuildMachineCapability(t, dbSession, &m1.ID, nil, cdbm.MachineCapabilityTypeStorage, "SSDPF2KE016T9L", nil, nil, nil, cdb.GetIntPtr(2), cdb.Ptr(cdbm.MachineCapabilityDeviceType("")), nil)
+	common.TestBuildMachineCapability(t, dbSession, &m2.ID, nil, cdbm.MachineCapabilityTypeNetwork, "BCM57414 NetXtreme-E 10Gb/25Gb RDMA Ethernet Controller", nil, nil, nil, cdb.GetIntPtr(2), cdb.Ptr(cdbm.MachineCapabilityDeviceType("")), nil)
 
 	common.TestBuildMachineInstanceType(t, dbSession, m2, it)
 
 	m3 := common.TestBuildMachine(t, dbSession, ip, st2, nil, nil, cdbm.MachineStatusReady)
-	common.TestBuildMachineCapability(t, dbSession, &m3.ID, nil, cdbm.MachineCapabilityTypeCPU, "Intel Celeron CX", cdb.GetStrPtr("2.4Ghz"), nil, cdb.GetStrPtr("Genuine Intel"), cdb.GetIntPtr(2), cdb.GetStrPtr(""), nil)
-	common.TestBuildMachineCapability(t, dbSession, &m3.ID, nil, cdbm.MachineCapabilityTypeMemory, "DDR4", nil, cdb.GetStrPtr("16GB"), nil, cdb.GetIntPtr(4), cdb.GetStrPtr(""), nil)
-	common.TestBuildMachineCapability(t, dbSession, &m3.ID, nil, cdbm.MachineCapabilityTypeInfiniBand, "MT28908 Family [ConnectX-6]", nil, nil, cdb.GetStrPtr("Mellanox Technologies"), cdb.GetIntPtr(2), cdb.GetStrPtr(""), []int{1, 3})
+	common.TestBuildMachineCapability(t, dbSession, &m3.ID, nil, cdbm.MachineCapabilityTypeCPU, "Intel Celeron CX", cdb.GetStrPtr("2.4Ghz"), nil, cdb.GetStrPtr("Genuine Intel"), cdb.GetIntPtr(2), cdb.Ptr(cdbm.MachineCapabilityDeviceType("")), nil)
+	common.TestBuildMachineCapability(t, dbSession, &m3.ID, nil, cdbm.MachineCapabilityTypeMemory, "DDR4", nil, cdb.GetStrPtr("16GB"), nil, cdb.GetIntPtr(4), cdb.Ptr(cdbm.MachineCapabilityDeviceType("")), nil)
+	common.TestBuildMachineCapability(t, dbSession, &m3.ID, nil, cdbm.MachineCapabilityTypeInfiniBand, "MT28908 Family [ConnectX-6]", nil, nil, cdb.GetStrPtr("Mellanox Technologies"), cdb.GetIntPtr(2), cdb.Ptr(cdbm.MachineCapabilityDeviceType("")), []int{1, 3})
 
 	m4 := common.TestBuildMachine(t, dbSession, ip, st2, nil, nil, cdbm.MachineStatusReady)
-	common.TestBuildMachineCapability(t, dbSession, &m4.ID, nil, cdbm.MachineCapabilityTypeCPU, "Intel Celeron DX", cdb.GetStrPtr("2.4Ghz"), nil, cdb.GetStrPtr("Genuine Intel"), cdb.GetIntPtr(2), cdb.GetStrPtr(""), nil)
-	common.TestBuildMachineCapability(t, dbSession, &m4.ID, nil, cdbm.MachineCapabilityTypeMemory, "DDR4", nil, cdb.GetStrPtr("16GB"), nil, cdb.GetIntPtr(4), cdb.GetStrPtr(""), nil)
-	common.TestBuildMachineCapability(t, dbSession, &m4.ID, nil, cdbm.MachineCapabilityTypeNetwork, "MT43244 BlueField-3 integrated ConnectX-7 network controller", nil, nil, cdb.GetStrPtr("Mellanox Technologies"), cdb.GetIntPtr(2), cdb.GetStrPtr("DPU"), nil)
-	common.TestBuildMachineCapability(t, dbSession, &m4.ID, nil, cdbm.MachineCapabilityTypeInfiniBand, "MT28908 Family [ConnectX-7]", nil, nil, cdb.GetStrPtr("Mellanox Technologies"), cdb.GetIntPtr(2), cdb.GetStrPtr(""), nil)
+	common.TestBuildMachineCapability(t, dbSession, &m4.ID, nil, cdbm.MachineCapabilityTypeCPU, "Intel Celeron DX", cdb.GetStrPtr("2.4Ghz"), nil, cdb.GetStrPtr("Genuine Intel"), cdb.GetIntPtr(2), cdb.Ptr(cdbm.MachineCapabilityDeviceType("")), nil)
+	common.TestBuildMachineCapability(t, dbSession, &m4.ID, nil, cdbm.MachineCapabilityTypeMemory, "DDR4", nil, cdb.GetStrPtr("16GB"), nil, cdb.GetIntPtr(4), cdb.Ptr(cdbm.MachineCapabilityDeviceType("")), nil)
+	common.TestBuildMachineCapability(t, dbSession, &m4.ID, nil, cdbm.MachineCapabilityTypeNetwork, "MT43244 BlueField-3 integrated ConnectX-7 network controller", nil, nil, cdb.GetStrPtr("Mellanox Technologies"), cdb.GetIntPtr(2), cdb.Ptr(cdbm.MachineCapabilityDeviceTypeDPU), nil)
+	common.TestBuildMachineCapability(t, dbSession, &m4.ID, nil, cdbm.MachineCapabilityTypeInfiniBand, "MT28908 Family [ConnectX-7]", nil, nil, cdb.GetStrPtr("Mellanox Technologies"), cdb.GetIntPtr(2), cdb.Ptr(cdbm.MachineCapabilityDeviceType("")), nil)
 
 	// OTEL Spanner configuration
 	tracer, _, ctx := common.TestCommonTraceProviderSetup(t, ctx)
@@ -100,13 +100,13 @@ func TestGetAllMachineCapabilityHandler_Handle(t *testing.T) {
 		user                *cdbm.User
 		wantRespCode        int
 		wantRespCount       int
-		wantType            *string
+		wantType            *cdbm.MachineCapabilityType
 		wantName            *string
 		wantFrequency       *string
 		wantCapacity        *string
 		wantVendor          *string
 		wantCount           *int
-		wantDeviceType      *string
+		wantDeviceType      *cdbm.MachineCapabilityDeviceType
 		wantInactiveDevices []int
 	}{
 		{
@@ -124,12 +124,12 @@ func TestGetAllMachineCapabilityHandler_Handle(t *testing.T) {
 			org:  ipOrg,
 			args: args{
 				siteID:         cdb.GetUUIDPtr(st1.ID),
-				capabilityType: cdb.GetStrPtr(string(cdbm.MachineCapabilityTypeStorage)),
+				capabilityType: cdb.GetTypedStrPtr(cdbm.MachineCapabilityTypeStorage),
 			},
 			user:          ipu,
 			wantRespCode:  http.StatusOK,
 			wantRespCount: 2,
-			wantType:      cdb.GetStrPtr(string(cdbm.MachineCapabilityTypeStorage)),
+			wantType:      cdb.Ptr(cdbm.MachineCapabilityTypeStorage),
 		},
 		{
 			name: "success retrieving & filtering by Capability type and hasInstanceType set to true",
@@ -137,12 +137,12 @@ func TestGetAllMachineCapabilityHandler_Handle(t *testing.T) {
 			args: args{
 				siteID:          cdb.GetUUIDPtr(st1.ID),
 				hasInstanceType: cdb.GetBoolPtr(true),
-				capabilityType:  cdb.GetStrPtr(string(cdbm.MachineCapabilityTypeMemory)),
+				capabilityType:  cdb.GetTypedStrPtr(cdbm.MachineCapabilityTypeMemory),
 			},
 			user:          ipu,
 			wantRespCode:  http.StatusOK,
 			wantRespCount: 1,
-			wantType:      cdb.GetStrPtr(string(cdbm.MachineCapabilityTypeMemory)),
+			wantType:      cdb.Ptr(cdbm.MachineCapabilityTypeMemory),
 		},
 		{
 			name: "success retrieving & filtering by Capability type and hasInstanceType set to true",
@@ -150,7 +150,7 @@ func TestGetAllMachineCapabilityHandler_Handle(t *testing.T) {
 			args: args{
 				siteID:          cdb.GetUUIDPtr(st1.ID),
 				hasInstanceType: cdb.GetBoolPtr(false),
-				capabilityType:  cdb.GetStrPtr(string(cdbm.MachineCapabilityTypeMemory)),
+				capabilityType:  cdb.GetTypedStrPtr(cdbm.MachineCapabilityTypeMemory),
 			},
 			user:          ipu,
 			wantRespCode:  http.StatusOK,
@@ -205,7 +205,7 @@ func TestGetAllMachineCapabilityHandler_Handle(t *testing.T) {
 			user:           ipu,
 			wantRespCode:   http.StatusOK,
 			wantRespCount:  1,
-			wantDeviceType: cdb.GetStrPtr("DPU"),
+			wantDeviceType: cdb.Ptr(cdbm.MachineCapabilityDeviceTypeDPU),
 			wantCount:      cdb.GetIntPtr(2),
 		},
 		{

--- a/api/pkg/api/handler/stats.go
+++ b/api/pkg/api/handler/stats.go
@@ -94,8 +94,7 @@ func (gmgsh GetMachineGPUStatsHandler) Handle(c echo.Context) error {
 
 	// Fetch GPU capabilities for all machines
 	mcDAO := cdbm.NewMachineCapabilityDAO(gmgsh.dbSession)
-	gpuType := cdbm.MachineCapabilityTypeGPU
-	capabilities, _, err := mcDAO.GetAll(ctx, nil, machineIDs, nil, &gpuType,
+	capabilities, _, err := mcDAO.GetAll(ctx, nil, machineIDs, nil, cdb.GetTypedStrPtr(cdbm.MachineCapabilityTypeGPU),
 		nil, nil, nil, nil, nil, nil, nil, nil, nil, cdb.GetIntPtr(cdbp.TotalLimit), nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("error retrieving GPU capabilities")

--- a/api/pkg/api/handler/stats_test.go
+++ b/api/pkg/api/handler/stats_test.go
@@ -135,7 +135,7 @@ func testStatsBuildMachine(t *testing.T, dbSession *cdb.Session, ip *cdbm.Infras
 	return m
 }
 
-func testStatsBuildMachineCapability(t *testing.T, dbSession *cdb.Session, machineID string, capType, name string, count int) *cdbm.MachineCapability {
+func testStatsBuildMachineCapability(t *testing.T, dbSession *cdb.Session, machineID string, capType cdbm.MachineCapabilityType, name string, count int) *cdbm.MachineCapability {
 	mc := &cdbm.MachineCapability{
 		ID:        uuid.New(),
 		MachineID: &machineID,

--- a/api/pkg/api/handler/util/common/common.go
+++ b/api/pkg/api/handler/util/common/common.go
@@ -915,7 +915,7 @@ func MatchInstanceTypeCapabilitiesForMachines(ctx context.Context, logger zerolo
 		//
 		// If we can assume that name+type can never have a duplicate,
 		// we can rely on prefixing the map entries with type.
-		mmcCapMapByMachinId[*mmc.MachineID][mmc.Type+"-"+mmc.Name] = &cmmc
+		mmcCapMapByMachinId[*mmc.MachineID][mmc.MapKey()] = &cmmc
 	}
 
 	// Loop through Capabilities of Instance Type with Machines
@@ -924,7 +924,7 @@ func MatchInstanceTypeCapabilitiesForMachines(ctx context.Context, logger zerolo
 		for mID, mCapMap := range mmcCapMapByMachinId {
 
 			// See earlier comments above about prefixing with type.
-			mmc, found := mCapMap[imc.Type+"-"+imc.Name]
+			mmc, found := mCapMap[imc.MapKey()]
 			if !found {
 				return false, &mID, nil
 			}

--- a/api/pkg/api/handler/util/common/common_test.go
+++ b/api/pkg/api/handler/util/common/common_test.go
@@ -2027,7 +2027,7 @@ func TestMatchInstanceTypeCapabilitiesForMachines(t *testing.T) {
 	icap2 := TestCommonBuildMachineCapability(t, dbSession, nil, &inst1.ID, cdbm.MachineCapabilityTypeInfiniBand, "MT28908 Family [ConnectX-7]", nil, nil, cdb.GetStrPtr("Mellanox Technologies"), cdb.GetIntPtr(2), nil, nil)
 	assert.NotNil(t, icap2)
 
-	icap3 := TestCommonBuildMachineCapability(t, dbSession, nil, &inst1.ID, cdbm.MachineCapabilityTypeNetwork, "MT28908 Family [ConnectX-7]", nil, nil, cdb.GetStrPtr("Mellanox Technologies"), cdb.GetIntPtr(2), cdb.GetStrPtr("DPU"), nil)
+	icap3 := TestCommonBuildMachineCapability(t, dbSession, nil, &inst1.ID, cdbm.MachineCapabilityTypeNetwork, "MT28908 Family [ConnectX-7]", nil, nil, cdb.GetStrPtr("Mellanox Technologies"), cdb.GetIntPtr(2), cdb.Ptr(cdbm.MachineCapabilityDeviceTypeDPU), nil)
 	assert.NotNil(t, icap3)
 
 	mc1 := testCommonBuildMachine(t, dbSession, ip.ID, site1.ID, cdb.GetUUIDPtr(inst1.ID), uuid.New(), nil, nil, nil, cdbm.MachineStatusReady)
@@ -2039,7 +2039,7 @@ func TestMatchInstanceTypeCapabilitiesForMachines(t *testing.T) {
 	mcap1 := TestCommonBuildMachineCapability(t, dbSession, &mc1.ID, nil, cdbm.MachineCapabilityTypeCPU, "AMD Opteron Series x10", cdb.GetStrPtr("3.0Hz"), cdb.GetStrPtr("32GB"), nil, cdb.GetIntPtr(4), nil, nil)
 	assert.NotNil(t, mcap1)
 
-	mcap3 := TestCommonBuildMachineCapability(t, dbSession, &mc1.ID, nil, cdbm.MachineCapabilityTypeNetwork, "MT28908 Family [ConnectX-7]", nil, nil, cdb.GetStrPtr("Mellanox Technologies"), cdb.GetIntPtr(2), cdb.GetStrPtr("DPU"), nil)
+	mcap3 := TestCommonBuildMachineCapability(t, dbSession, &mc1.ID, nil, cdbm.MachineCapabilityTypeNetwork, "MT28908 Family [ConnectX-7]", nil, nil, cdb.GetStrPtr("Mellanox Technologies"), cdb.GetIntPtr(2), cdb.Ptr(cdbm.MachineCapabilityDeviceTypeDPU), nil)
 	assert.NotNil(t, mcap3)
 
 	mc2 := testCommonBuildMachine(t, dbSession, ip.ID, site1.ID, cdb.GetUUIDPtr(inst1.ID), uuid.New(), nil, nil, nil, cdbm.MachineStatusReady)

--- a/api/pkg/api/handler/util/common/testing.go
+++ b/api/pkg/api/handler/util/common/testing.go
@@ -400,7 +400,7 @@ func TestBuildMachineInstanceType(t *testing.T, dbSession *cdb.Session, m *cdbm.
 }
 
 // TestBuildMachineCapability creates a test Machine Capability
-func TestBuildMachineCapability(t *testing.T, dbSession *cdb.Session, mID *string, itID *uuid.UUID, capabilityType string, name string, frequency *string, capacity *string, vendor *string, count *int, deviceType *string, inactiveDevices []int) *cdbm.MachineCapability {
+func TestBuildMachineCapability(t *testing.T, dbSession *cdb.Session, mID *string, itID *uuid.UUID, capabilityType cdbm.MachineCapabilityType, name string, frequency *string, capacity *string, vendor *string, count *int, deviceType *cdbm.MachineCapabilityDeviceType, inactiveDevices []int) *cdbm.MachineCapability {
 	mcDAO := cdbm.NewMachineCapabilityDAO(dbSession)
 
 	mc, err := mcDAO.Create(context.Background(), nil, cdbm.MachineCapabilityCreateInput{
@@ -539,7 +539,7 @@ func TestBuildNetworkSecurityGroup(t *testing.T, dbSession *cdb.Session, name st
 }
 
 // TestCommonBuildMachineCapability creates a machine capability
-func TestCommonBuildMachineCapability(t *testing.T, dbSession *cdb.Session, machineID *string, instanceTypeID *uuid.UUID, cptype string, name string, freq *string, cap *string, vendor *string, count *int, deviceType *string, info map[string]interface{}) *cdbm.MachineCapability {
+func TestCommonBuildMachineCapability(t *testing.T, dbSession *cdb.Session, machineID *string, instanceTypeID *uuid.UUID, cptype cdbm.MachineCapabilityType, name string, freq *string, cap *string, vendor *string, count *int, deviceType *cdbm.MachineCapabilityDeviceType, info map[string]interface{}) *cdbm.MachineCapability {
 	mcDAO := cdbm.NewMachineCapabilityDAO(dbSession)
 	mc, err := mcDAO.Create(context.Background(), nil, cdbm.MachineCapabilityCreateInput{MachineID: machineID, InstanceTypeID: instanceTypeID, Type: cptype, Name: name, Frequency: freq, Capacity: cap, Vendor: vendor, Count: count, DeviceType: deviceType, Info: info})
 	assert.Nil(t, err)

--- a/api/pkg/api/model/instancetype_test.go
+++ b/api/pkg/api/model/instancetype_test.go
@@ -285,7 +285,7 @@ func TestAPIInstanceTypeCreateRequest_Validate(t *testing.T) {
 					{
 						Type:       cdbm.MachineCapabilityTypeNetwork,
 						Name:       "test-name",
-						DeviceType: cdb.GetStrPtr("test-device-type"),
+						DeviceType: cdb.Ptr(cdbm.MachineCapabilityDeviceType("test-device-type")),
 						Count:      cdb.GetIntPtr(1),
 					},
 				},
@@ -301,7 +301,7 @@ func TestAPIInstanceTypeCreateRequest_Validate(t *testing.T) {
 					{
 						Type:       cdbm.MachineCapabilityTypeGPU,
 						Name:       "gpu-0",
-						DeviceType: cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeDPU),
+						DeviceType: cdb.Ptr(cdbm.MachineCapabilityDeviceTypeDPU),
 					},
 				},
 			},
@@ -316,7 +316,7 @@ func TestAPIInstanceTypeCreateRequest_Validate(t *testing.T) {
 					{
 						Type:       cdbm.MachineCapabilityTypeGPU,
 						Name:       "gpu-0",
-						DeviceType: cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink),
+						DeviceType: cdb.Ptr(cdbm.MachineCapabilityDeviceTypeNVLink),
 					},
 				},
 			},
@@ -331,7 +331,7 @@ func TestAPIInstanceTypeCreateRequest_Validate(t *testing.T) {
 					{
 						Type:       cdbm.MachineCapabilityTypeCPU,
 						Name:       "cpu-0",
-						DeviceType: cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeDPU),
+						DeviceType: cdb.Ptr(cdbm.MachineCapabilityDeviceTypeDPU),
 					},
 				},
 			},

--- a/api/pkg/api/model/machinecapability.go
+++ b/api/pkg/api/model/machinecapability.go
@@ -29,7 +29,7 @@ func (caps APIMachineCapabilities) Validate() error {
 	}
 	seen := map[string]bool{}
 	for _, mc := range caps {
-		key := mc.Type + "-" + mc.Name
+		key := mc.MapKey()
 		if seen[key] {
 			return validation.Errors{
 				"machineCapabilities": fmt.Errorf("requested Capability type `%s` cannot contain duplicate Capability name: %s", mc.Type, mc.Name),
@@ -43,7 +43,7 @@ func (caps APIMachineCapabilities) Validate() error {
 // APIMachineCapability is the datastructure to capture API representation of a MachineCapability
 type APIMachineCapability struct {
 	// Type is the type of the machine capability
-	Type string `json:"type"`
+	Type cdbm.MachineCapabilityType `json:"type"`
 	// Name describes the capability
 	Name string `json:"name"`
 	// Frequency describes the frequency of the capability
@@ -63,7 +63,16 @@ type APIMachineCapability struct {
 	// Count describes the number of items present for this capability
 	Count *int `json:"count"`
 	// DeviceType describes the type of the device
-	DeviceType *string `json:"deviceType,omitempty"`
+	DeviceType *cdbm.MachineCapabilityDeviceType `json:"deviceType,omitempty"`
+}
+
+// MapKey returns the canonical `Type-Name` string used as a map key
+// for dedup or `(Type, Name)` lookups against the DB-side
+// `(*cdbm.MachineCapability).MapKey()`. Both methods produce the same
+// shape so an API request capability and its DB counterpart hash to
+// the same key.
+func (mc APIMachineCapability) MapKey() string {
+	return string(mc.Type) + "-" + mc.Name
 }
 
 // Validate ensures the values on a single capability are acceptable
@@ -107,18 +116,18 @@ func (mc APIMachineCapability) Validate() error {
 // every other Type must not carry a DeviceType. A nil DeviceType is
 // always allowed.
 func (mc APIMachineCapability) validateDeviceType(value interface{}) error {
-	dt, ok := value.(*string)
+	dt, ok := value.(*cdbm.MachineCapabilityDeviceType)
 	if !ok || dt == nil {
 		return nil
 	}
 	switch mc.Type {
 	case cdbm.MachineCapabilityTypeNetwork:
 		if *dt != cdbm.MachineCapabilityDeviceTypeDPU {
-			return errors.New("Unsupported Device Type specified for Network Capability " + *dt)
+			return fmt.Errorf("Unsupported Device Type specified for Network Capability %s", *dt)
 		}
 	case cdbm.MachineCapabilityTypeGPU:
 		if *dt != cdbm.MachineCapabilityDeviceTypeNVLink {
-			return errors.New("Unsupported Device Type specified for GPU Capability " + *dt)
+			return fmt.Errorf("Unsupported Device Type specified for GPU Capability %s", *dt)
 		}
 	default:
 		return fmt.Errorf("Unsupported Device Type: %s specified for Capability type %s", *dt, mc.Type)

--- a/common/pkg/util/converter.go
+++ b/common/pkg/util/converter.go
@@ -17,3 +17,18 @@ func IntPtrToUint32Ptr(i *int) *uint32 {
 	u := uint32(*i) //nolint:gosec // bounded upstream by Validate / proto-source.
 	return &u
 }
+
+// Uint32PtrToIntPtr converts a `*uint32` to a `*int`. nil in, nil out.
+// The cast is always safe on 64-bit platforms (the only ones we target);
+// on a hypothetical 32-bit build it would wrap on values above
+// `MaxInt32`. Under the proto-conversion convention this is a trusted
+// cast used inside `FromProto` mappers — the upstream value originates
+// from a proto `uint32` field, and any bounds checks that would gate it
+// belong in `Validate` upstream.
+func Uint32PtrToIntPtr(u *uint32) *int {
+	if u == nil {
+		return nil
+	}
+	i := int(*u) //nolint:gosec // bounded by uint32 range; safe on 64-bit targets.
+	return &i
+}

--- a/common/pkg/util/converter_test.go
+++ b/common/pkg/util/converter_test.go
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package util
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntPtrToUint32Ptr(t *testing.T) {
+	t.Run("nil in yields nil out", func(t *testing.T) {
+		assert.Nil(t, IntPtrToUint32Ptr(nil))
+	})
+
+	cases := []struct {
+		name string
+		in   int
+		want uint32
+	}{
+		{"zero", 0, 0},
+		{"typical", 42, 42},
+		{"max uint32", math.MaxUint32, math.MaxUint32},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IntPtrToUint32Ptr(&tc.in)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.want, *got)
+		})
+	}
+}
+
+func TestUint32PtrToIntPtr(t *testing.T) {
+	t.Run("nil in yields nil out", func(t *testing.T) {
+		assert.Nil(t, Uint32PtrToIntPtr(nil))
+	})
+
+	cases := []struct {
+		name string
+		in   uint32
+		want int
+	}{
+		{"zero", 0, 0},
+		{"typical", 42, 42},
+		{"max uint32 fits in int on 64-bit", math.MaxUint32, math.MaxUint32},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Uint32PtrToIntPtr(&tc.in)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.want, *got)
+		})
+	}
+}

--- a/db/pkg/db/model/machine_test.go
+++ b/db/pkg/db/model/machine_test.go
@@ -892,7 +892,7 @@ func TestMachineSQLDAO_GetAll(t *testing.T) {
 		{
 			desc: "GetAll with infiniband capabilitytype filters returns objects",
 			filter: MachineFilterInput{
-				CapabilityType: db.GetStrPtr(MachineCapabilityTypeInfiniBand),
+				CapabilityType: db.GetTypedStrPtr(MachineCapabilityTypeInfiniBand),
 			},
 			pageInput: paginator.PageInput{
 				OrderBy: &paginator.OrderBy{
@@ -907,7 +907,7 @@ func TestMachineSQLDAO_GetAll(t *testing.T) {
 		{
 			desc: "GetAll with cpu capabilitytype filters returns objects",
 			filter: MachineFilterInput{
-				CapabilityType: db.GetStrPtr(MachineCapabilityTypeCPU),
+				CapabilityType: db.GetTypedStrPtr(MachineCapabilityTypeCPU),
 			},
 			expectedCount: 1,
 			firstEntry:    &ms1[1],
@@ -1811,7 +1811,7 @@ func TestMachineSQLDAO_GetCount(t *testing.T) {
 		{
 			desc: "filter with CapabilityType",
 			filter: MachineFilterInput{
-				CapabilityType: db.GetStrPtr(MachineCapabilityTypeInfiniBand),
+				CapabilityType: db.GetTypedStrPtr(MachineCapabilityTypeInfiniBand),
 			},
 			expectedCount: 2,
 		},

--- a/db/pkg/db/model/machinecapability.go
+++ b/db/pkg/db/model/machinecapability.go
@@ -15,6 +15,7 @@ import (
 	cutil "github.com/NVIDIA/infra-controller-rest/common/pkg/util"
 	"github.com/NVIDIA/infra-controller-rest/db/pkg/db"
 	"github.com/NVIDIA/infra-controller-rest/db/pkg/db/paginator"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 
@@ -24,19 +25,40 @@ import (
 	cwssaws "github.com/NVIDIA/infra-controller-rest/workflow-schema/schema/site-agent/workflows/v1"
 )
 
-// MachineCapabilityType
-const (
-	MachineCapabilityTypeCPU           = "CPU"
-	MachineCapabilityTypeMemory        = "Memory"
-	MachineCapabilityTypeGPU           = "GPU"
-	MachineCapabilityTypeStorage       = "Storage"
-	MachineCapabilityTypeNetwork       = "Network"
-	MachineCapabilityTypeInfiniBand    = "InfiniBand"
-	MachineCapabilityTypeDPU           = "DPU"
-	MachineCapabilityDeviceTypeDPU     = "DPU"
-	MachineCapabilityDeviceTypeNVLink  = "NVLink"
-	MachineCapabilityDeviceTypeUnknown = "Unknown"
+// MachineCapabilityType is the domain enum for the kind of capability a
+// `MachineCapability` describes. Defining it as a named string lets us
+// hang the workflow-proto conversion on it as methods (`(t).ToProto`,
+// `(*t).FromProto`), and keeps the DB column comparable as a plain
+// string at the storage layer.
+type MachineCapabilityType string
 
+// MachineCapabilityType values. Stored as plain strings in the DB
+// column `machine_capability.type`.
+const (
+	MachineCapabilityTypeCPU        MachineCapabilityType = "CPU"
+	MachineCapabilityTypeMemory     MachineCapabilityType = "Memory"
+	MachineCapabilityTypeGPU        MachineCapabilityType = "GPU"
+	MachineCapabilityTypeStorage    MachineCapabilityType = "Storage"
+	MachineCapabilityTypeNetwork    MachineCapabilityType = "Network"
+	MachineCapabilityTypeInfiniBand MachineCapabilityType = "InfiniBand"
+	MachineCapabilityTypeDPU        MachineCapabilityType = "DPU"
+)
+
+// MachineCapabilityDeviceType is the domain enum for the device class a
+// capability targets when the capability type alone is ambiguous (e.g.
+// a Network capability against a DPU vs. against an NVLink). Defined
+// as a named string for the same reason as `MachineCapabilityType`.
+type MachineCapabilityDeviceType string
+
+// MachineCapabilityDeviceType values. Stored as plain strings in the DB
+// column `machine_capability.device_type`.
+const (
+	MachineCapabilityDeviceTypeDPU     MachineCapabilityDeviceType = "DPU"
+	MachineCapabilityDeviceTypeNVLink  MachineCapabilityDeviceType = "NVLink"
+	MachineCapabilityDeviceTypeUnknown MachineCapabilityDeviceType = "Unknown"
+)
+
+const (
 	// MachineCapabilityRelationName is the relation name for the MachineCapability model
 	MachineCapabilityRelationName = "MachineCapability"
 
@@ -47,7 +69,7 @@ const (
 var (
 
 	// MachineCapabilityTypeChoiceMap is a map of valid MachineCapability types
-	MachineCapabilityTypeChoiceMap = map[string]bool{
+	MachineCapabilityTypeChoiceMap = map[MachineCapabilityType]bool{
 		MachineCapabilityTypeCPU:        true,
 		MachineCapabilityTypeMemory:     true,
 		MachineCapabilityTypeGPU:        true,
@@ -61,17 +83,97 @@ var (
 	MachineCapabilityOrderByFields = []string{"type", "created", "updated"}
 
 	// MachineCapabilityDeviceTypeChoiceMap is a map of valid MachineCapability device types
-	MachineCapabilityDeviceTypeChoiceMap = map[string]bool{
+	MachineCapabilityDeviceTypeChoiceMap = map[MachineCapabilityDeviceType]bool{
 		MachineCapabilityDeviceTypeDPU:    true,
 		MachineCapabilityDeviceTypeNVLink: true,
 	}
 )
 
+// ToProto converts a `MachineCapabilityType` into its workflow proto
+// enum. Returns the zero proto value (`MACHINE_CAPABILITY_TYPE_UNSPECIFIED`)
+// for an unknown DB value with a warning logged; `MachineCapability.Validate`
+// is the gate that rejects such values upstream of the wire.
+func (t MachineCapabilityType) ToProto() cwssaws.MachineCapabilityType {
+	switch t {
+	case MachineCapabilityTypeCPU:
+		return cwssaws.MachineCapabilityType_CAP_TYPE_CPU
+	case MachineCapabilityTypeMemory:
+		return cwssaws.MachineCapabilityType_CAP_TYPE_MEMORY
+	case MachineCapabilityTypeGPU:
+		return cwssaws.MachineCapabilityType_CAP_TYPE_GPU
+	case MachineCapabilityTypeStorage:
+		return cwssaws.MachineCapabilityType_CAP_TYPE_STORAGE
+	case MachineCapabilityTypeNetwork:
+		return cwssaws.MachineCapabilityType_CAP_TYPE_NETWORK
+	case MachineCapabilityTypeInfiniBand:
+		return cwssaws.MachineCapabilityType_CAP_TYPE_INFINIBAND
+	case MachineCapabilityTypeDPU:
+		return cwssaws.MachineCapabilityType_CAP_TYPE_DPU
+	}
+	log.Warn().Str("Type", string(t)).Msg("unsupported MachineCapabilityType requested")
+	return cwssaws.MachineCapabilityType(0)
+}
+
+// FromProto populates the receiver from a workflow proto enum,
+// mirroring `(MachineCapabilityType).ToProto`. An unknown proto enum
+// silently leaves the receiver as the empty string; `(*MachineCapability).Validate`
+// rejects that downstream.
+func (t *MachineCapabilityType) FromProto(p cwssaws.MachineCapabilityType) {
+	switch p {
+	case cwssaws.MachineCapabilityType_CAP_TYPE_CPU:
+		*t = MachineCapabilityTypeCPU
+	case cwssaws.MachineCapabilityType_CAP_TYPE_MEMORY:
+		*t = MachineCapabilityTypeMemory
+	case cwssaws.MachineCapabilityType_CAP_TYPE_GPU:
+		*t = MachineCapabilityTypeGPU
+	case cwssaws.MachineCapabilityType_CAP_TYPE_STORAGE:
+		*t = MachineCapabilityTypeStorage
+	case cwssaws.MachineCapabilityType_CAP_TYPE_NETWORK:
+		*t = MachineCapabilityTypeNetwork
+	case cwssaws.MachineCapabilityType_CAP_TYPE_INFINIBAND:
+		*t = MachineCapabilityTypeInfiniBand
+	case cwssaws.MachineCapabilityType_CAP_TYPE_DPU:
+		*t = MachineCapabilityTypeDPU
+	default:
+		log.Warn().Str("MachineCapabilityType", p.String()).Msg("unsupported MachineCapabilityType requested")
+		*t = ""
+	}
+}
+
+// ToProto converts a `MachineCapabilityDeviceType` into its workflow
+// proto enum. Returns the zero proto value with a warning logged for
+// unknown DB values; `MachineCapability.Validate` is the upstream gate.
+func (d MachineCapabilityDeviceType) ToProto() cwssaws.MachineCapabilityDeviceType {
+	switch d {
+	case MachineCapabilityDeviceTypeDPU:
+		return cwssaws.MachineCapabilityDeviceType_MACHINE_CAPABILITY_DEVICE_TYPE_DPU
+	case MachineCapabilityDeviceTypeNVLink:
+		return cwssaws.MachineCapabilityDeviceType_MACHINE_CAPABILITY_DEVICE_TYPE_NVLINK
+	}
+	log.Warn().Str("DeviceType", string(d)).Msg("unsupported MachineCapabilityDeviceType requested")
+	return cwssaws.MachineCapabilityDeviceType(0)
+}
+
+// FromProto populates the receiver from a workflow proto enum,
+// mirroring `(MachineCapabilityDeviceType).ToProto`. An unknown proto
+// enum leaves the receiver as the empty string with a warning logged.
+func (d *MachineCapabilityDeviceType) FromProto(p cwssaws.MachineCapabilityDeviceType) {
+	switch p {
+	case cwssaws.MachineCapabilityDeviceType_MACHINE_CAPABILITY_DEVICE_TYPE_DPU:
+		*d = MachineCapabilityDeviceTypeDPU
+	case cwssaws.MachineCapabilityDeviceType_MACHINE_CAPABILITY_DEVICE_TYPE_NVLINK:
+		*d = MachineCapabilityDeviceTypeNVLink
+	default:
+		log.Warn().Str("DeviceType", p.String()).Msg("unsupported MachineCapabilityDeviceType requested")
+		*d = ""
+	}
+}
+
 // MachineCapabilityCreateInput input parameters for Create method
 type MachineCapabilityCreateInput struct {
 	MachineID        *string
 	InstanceTypeID   *uuid.UUID
-	Type             string
+	Type             MachineCapabilityType
 	Name             string
 	Frequency        *string
 	Capacity         *string
@@ -80,7 +182,7 @@ type MachineCapabilityCreateInput struct {
 	Threads          *int
 	Vendor           *string
 	Count            *int
-	DeviceType       *string
+	DeviceType       *MachineCapabilityDeviceType
 	InactiveDevices  []int
 	Index            int
 	Info             map[string]interface{}
@@ -91,7 +193,7 @@ type MachineCapabilityUpdateInput struct {
 	ID               uuid.UUID
 	MachineID        *string
 	InstanceTypeID   *uuid.UUID
-	Type             *string
+	Type             *MachineCapabilityType
 	Name             *string
 	Frequency        *string
 	Capacity         *string
@@ -100,7 +202,7 @@ type MachineCapabilityUpdateInput struct {
 	Threads          *int
 	Vendor           *string
 	Count            *int
-	DeviceType       *string
+	DeviceType       *MachineCapabilityDeviceType
 	InactiveDevices  []int
 	Index            *int
 	Info             map[string]interface{}
@@ -111,26 +213,26 @@ type MachineCapabilityUpdateInput struct {
 type MachineCapability struct {
 	bun.BaseModel `bun:"table:machine_capability,alias:mc"`
 
-	ID               uuid.UUID              `bun:"type:uuid,pk"`
-	MachineID        *string                `bun:"machine_id"`
-	InstanceTypeID   *uuid.UUID             `bun:"instance_type_id,type:uuid"`
-	InstanceType     *InstanceType          `bun:"rel:belongs-to,join:instance_type_id=id"`
-	Type             string                 `bun:"type,notnull"`
-	Name             string                 `bun:"name,notnull"`
-	Frequency        *string                `bun:"frequency"`
-	Capacity         *string                `bun:"capacity"`
-	HardwareRevision *string                `bun:"hardware_revision"`
-	Cores            *int                   `bun:"cores"`
-	Threads          *int                   `bun:"threads"`
-	Vendor           *string                `bun:"vendor"`
-	Count            *int                   `bun:"count"`
-	DeviceType       *string                `bun:"device_type"`
-	InactiveDevices  []int                  `bun:"inactive_devices"`
-	Index            int                    `bun:"index"`
-	Info             map[string]interface{} `bun:"info,json_use_number"` // Any other attribute of the capability
-	Created          time.Time              `bun:"created,nullzero,notnull,default:current_timestamp"`
-	Updated          time.Time              `bun:"updated,nullzero,notnull,default:current_timestamp"`
-	Deleted          *time.Time             `bun:"deleted,soft_delete"`
+	ID               uuid.UUID                    `bun:"type:uuid,pk"`
+	MachineID        *string                      `bun:"machine_id"`
+	InstanceTypeID   *uuid.UUID                   `bun:"instance_type_id,type:uuid"`
+	InstanceType     *InstanceType                `bun:"rel:belongs-to,join:instance_type_id=id"`
+	Type             MachineCapabilityType        `bun:"type,notnull"`
+	Name             string                       `bun:"name,notnull"`
+	Frequency        *string                      `bun:"frequency"`
+	Capacity         *string                      `bun:"capacity"`
+	HardwareRevision *string                      `bun:"hardware_revision"`
+	Cores            *int                         `bun:"cores"`
+	Threads          *int                         `bun:"threads"`
+	Vendor           *string                      `bun:"vendor"`
+	Count            *int                         `bun:"count"`
+	DeviceType       *MachineCapabilityDeviceType `bun:"device_type"`
+	InactiveDevices  []int                        `bun:"inactive_devices"`
+	Index            int                          `bun:"index"`
+	Info             map[string]interface{}       `bun:"info,json_use_number"` // Any other attribute of the capability
+	Created          time.Time                    `bun:"created,nullzero,notnull,default:current_timestamp"`
+	Updated          time.Time                    `bun:"updated,nullzero,notnull,default:current_timestamp"`
+	Deleted          *time.Time                   `bun:"deleted,soft_delete"`
 
 	// Deprecated fields: To be deleted
 	ValueStr    *string `bun:"value_str"`
@@ -142,38 +244,10 @@ type MachineCapability struct {
 // representation used in InstanceType filter attributes.
 //
 // Per the proto-conversion convention, this is a pure mapper and does
-// not return errors. An unknown Type leaves the proto's CapabilityType
-// as the zero enum value with a warning logged; an unknown DeviceType is
-// dropped to nil. Numeric width casts are inline and rely on request-side
-// `Validate` having bounded the values to uint32 before they ever reach
-// the DB.
-//
-// The string-to-enum mappings are inlined as switches because the
-// underlying DB columns are plain strings — there is no
-// `MachineCapabilityType` Go type to hang a method on. If those columns
-// ever become typed-string enums, this is the natural place to swap to
-// `mc.Type.ToProto()`.
+// not return errors. Per-enum mapping lives on `MachineCapabilityType`
+// and `MachineCapabilityDeviceType`; numeric width casts trust the
+// request-side `Validate` upstream.
 func (mc *MachineCapability) ToProto() *cwssaws.InstanceTypeMachineCapabilityFilterAttributes {
-	var capType cwssaws.MachineCapabilityType
-	switch mc.Type {
-	case MachineCapabilityTypeCPU:
-		capType = cwssaws.MachineCapabilityType_CAP_TYPE_CPU
-	case MachineCapabilityTypeMemory:
-		capType = cwssaws.MachineCapabilityType_CAP_TYPE_MEMORY
-	case MachineCapabilityTypeGPU:
-		capType = cwssaws.MachineCapabilityType_CAP_TYPE_GPU
-	case MachineCapabilityTypeStorage:
-		capType = cwssaws.MachineCapabilityType_CAP_TYPE_STORAGE
-	case MachineCapabilityTypeNetwork:
-		capType = cwssaws.MachineCapabilityType_CAP_TYPE_NETWORK
-	case MachineCapabilityTypeInfiniBand:
-		capType = cwssaws.MachineCapabilityType_CAP_TYPE_INFINIBAND
-	case MachineCapabilityTypeDPU:
-		capType = cwssaws.MachineCapabilityType_CAP_TYPE_DPU
-	default:
-		log.Warn().Str("Type", mc.Type).Msg("unsupported MachineCapabilityType requested")
-	}
-
 	var inactiveDevices *cwssaws.Uint32List
 	if mc.InactiveDevices != nil {
 		inactiveDevices = &cwssaws.Uint32List{}
@@ -185,20 +259,13 @@ func (mc *MachineCapability) ToProto() *cwssaws.InstanceTypeMachineCapabilityFil
 
 	var deviceType *cwssaws.MachineCapabilityDeviceType
 	if mc.DeviceType != nil {
-		switch *mc.DeviceType {
-		case MachineCapabilityDeviceTypeDPU:
-			dt := cwssaws.MachineCapabilityDeviceType_MACHINE_CAPABILITY_DEVICE_TYPE_DPU
+		if dt := mc.DeviceType.ToProto(); dt != cwssaws.MachineCapabilityDeviceType_MACHINE_CAPABILITY_DEVICE_TYPE_UNKNOWN {
 			deviceType = &dt
-		case MachineCapabilityDeviceTypeNVLink:
-			dt := cwssaws.MachineCapabilityDeviceType_MACHINE_CAPABILITY_DEVICE_TYPE_NVLINK
-			deviceType = &dt
-		default:
-			log.Warn().Str("DeviceType", *mc.DeviceType).Msg("unsupported MachineCapabilityDeviceType requested")
 		}
 	}
 
 	return &cwssaws.InstanceTypeMachineCapabilityFilterAttributes{
-		CapabilityType:   capType,
+		CapabilityType:   mc.Type.ToProto(),
 		Name:             &mc.Name,
 		Frequency:        mc.Frequency,
 		Capacity:         mc.Capacity,
@@ -210,6 +277,147 @@ func (mc *MachineCapability) ToProto() *cwssaws.InstanceTypeMachineCapabilityFil
 		Cores:            cutil.IntPtrToUint32Ptr(mc.Cores),
 		Threads:          cutil.IntPtrToUint32Ptr(mc.Threads),
 	}
+}
+
+// FromProto populates this MachineCapability from workflow proto filter
+// attributes. idx is the per-InstanceType ordering index (NICo rejects
+// updates that re-order capabilities).
+//
+// Per the proto-conversion convention, this is a pure mapper and does
+// not return errors. Per-enum mapping lives on `MachineCapabilityType`
+// and `MachineCapabilityDeviceType`. An unknown CapabilityType or nil
+// Name silently leaves Type / Name as their zero values; callers that
+// need to reject such cases should call `(*MachineCapability).Validate()`
+// after `FromProto`. A nil attrs is a no-op (receiver untouched).
+func (mc *MachineCapability) FromProto(attrs *cwssaws.InstanceTypeMachineCapabilityFilterAttributes, idx int) {
+	if attrs == nil {
+		return
+	}
+
+	mc.Type.FromProto(attrs.CapabilityType)
+
+	var name string
+	if attrs.Name != nil {
+		name = *attrs.Name
+	}
+
+	var inactiveDevices []int
+	if attrs.InactiveDevices != nil {
+		for _, d := range attrs.InactiveDevices.Items {
+			inactiveDevices = append(inactiveDevices, int(d))
+		}
+	}
+
+	var deviceType *MachineCapabilityDeviceType
+	if attrs.DeviceType != nil {
+		var dt MachineCapabilityDeviceType
+		dt.FromProto(*attrs.DeviceType)
+		// Preserve presence even when the proto enum is unsupported
+		// (dt stays the empty string) so the post-`FromProto`
+		// `Validate()` can reject it instead of silently dropping it.
+		deviceType = &dt
+	}
+
+	mc.Name = name
+	mc.Frequency = attrs.Frequency
+	mc.Capacity = attrs.Capacity
+	mc.Vendor = attrs.Vendor
+	mc.Count = cutil.Uint32PtrToIntPtr(attrs.Count)
+	mc.HardwareRevision = attrs.HardwareRevision
+	mc.Cores = cutil.Uint32PtrToIntPtr(attrs.Cores)
+	mc.Threads = cutil.Uint32PtrToIntPtr(attrs.Threads)
+	mc.InactiveDevices = inactiveDevices
+	mc.DeviceType = deviceType
+	mc.Index = idx
+}
+
+// Validate checks that the populated MachineCapability is wire-safe
+// for the workflow proto conversion. Pairs with `FromProto`: callers
+// that build a MachineCapability from site-supplied proto data should
+// run `Validate` afterwards to reject unknown CapabilityType enums
+// (which `FromProto` leaves as the empty Type), missing Names, and
+// cross-field combinations the wire shape can't represent — DeviceType
+// must pair with Network (DPU) or GPU (NVLink), and InactiveDevices is
+// only valid on InfiniBand. These mirror the API-side
+// `(APIMachineCapability).Validate` rules so the workflow-inventory
+// path and the API path enforce the same invariants.
+func (mc *MachineCapability) Validate() error {
+	mctypes := make([]any, 0, len(MachineCapabilityTypeChoiceMap))
+	for mctype := range MachineCapabilityTypeChoiceMap {
+		mctypes = append(mctypes, mctype)
+	}
+	return validation.ValidateStruct(mc,
+		validation.Field(&mc.Type,
+			validation.Required.Error("MachineCapability Type must be specified"),
+			validation.In(mctypes...).Error(fmt.Sprintf("invalid MachineCapability Type: %q", mc.Type))),
+		validation.Field(&mc.Name,
+			validation.Required.Error("MachineCapability Name must be specified"),
+			validation.Length(2, 256).Error("MachineCapability Name must be at least 2 characters and maximum 256 characters"),
+			validation.By(mc.validateNameWhitespace)),
+		validation.Field(&mc.DeviceType, validation.By(mc.validateDeviceType)),
+		validation.Field(&mc.InactiveDevices, validation.By(mc.validateInactiveDevices)),
+	)
+}
+
+// validateNameWhitespace rejects Names with leading or trailing
+// whitespace, mirroring the API-side `util.ValidateNameCharacters`
+// rule so the wire-bound DB-model gate matches the API one.
+func (mc *MachineCapability) validateNameWhitespace(value interface{}) error {
+	s, ok := value.(string)
+	if !ok {
+		return errors.New("MachineCapability Name must be a string")
+	}
+	if strings.TrimSpace(s) != s {
+		return errors.New("MachineCapability Name must not contain leading or trailing whitespace")
+	}
+	return nil
+}
+
+// validateDeviceType enforces the Type/DeviceType compatibility rules:
+// Network capabilities require DPU, GPU capabilities require NVLink,
+// every other Type must not carry a DeviceType. A nil DeviceType is
+// always allowed.
+func (mc *MachineCapability) validateDeviceType(value interface{}) error {
+	dt, ok := value.(*MachineCapabilityDeviceType)
+	if !ok || dt == nil {
+		return nil
+	}
+	switch mc.Type {
+	case MachineCapabilityTypeNetwork:
+		if *dt != MachineCapabilityDeviceTypeDPU {
+			return fmt.Errorf("Unsupported Device Type specified for Network Capability %s", *dt)
+		}
+	case MachineCapabilityTypeGPU:
+		if *dt != MachineCapabilityDeviceTypeNVLink {
+			return fmt.Errorf("Unsupported Device Type specified for GPU Capability %s", *dt)
+		}
+	default:
+		return fmt.Errorf("Unsupported Device Type: %s specified for Capability type %s", *dt, mc.Type)
+	}
+	return nil
+}
+
+// validateInactiveDevices enforces that InactiveDevices is only set on
+// InfiniBand capabilities.
+func (mc *MachineCapability) validateInactiveDevices(value interface{}) error {
+	ids, ok := value.([]int)
+	if !ok || len(ids) == 0 {
+		return nil
+	}
+	if mc.Type != MachineCapabilityTypeInfiniBand {
+		return errors.New("InactiveDevices specified for non-InfiniBand Capability Type")
+	}
+	return nil
+}
+
+// MapKey returns the canonical `Type-Name` string used as a map key
+// when callers need to dedupe or look up capabilities by their
+// `(Type, Name)` pair (e.g. cloud↔site diffing during instance-type
+// sync, instance-type update planning). Centralizing the format here
+// avoids drift across the call sites and keeps the typed-string cast
+// in one place.
+func (mc *MachineCapability) MapKey() string {
+	return string(mc.Type) + "-" + mc.Name
 }
 
 // GetStrInfo returns the string value of the given key in the Info map
@@ -338,8 +546,11 @@ func (mcd MachineCapabilitySQLDAO) Create(
 		mcd.tracerSpan.SetAttribute(MachineCapabilityDAOSpan, "name", input.Name)
 	}
 
-	if len(strings.TrimSpace(input.Type)) == 0 {
+	if len(strings.TrimSpace(string(input.Type))) == 0 {
 		return nil, errors.New("capabilityType is empty")
+	}
+	if !MachineCapabilityTypeChoiceMap[input.Type] {
+		return nil, fmt.Errorf("invalid capabilityType: %q", input.Type)
 	}
 
 	if input.MachineID == nil && input.InstanceTypeID == nil {
@@ -681,8 +892,11 @@ func (mcd MachineCapabilitySQLDAO) Update(
 		}
 	}
 	if input.Type != nil {
-		if len(strings.TrimSpace(*input.Type)) == 0 {
+		if len(strings.TrimSpace(string(*input.Type))) == 0 {
 			return nil, errors.New("capabilityType is empty")
+		}
+		if !MachineCapabilityTypeChoiceMap[*input.Type] {
+			return nil, fmt.Errorf("invalid capabilityType: %q", *input.Type)
 		}
 		m.Type = *input.Type
 		updatedFields = append(updatedFields, "type")

--- a/db/pkg/db/model/machinecapability_test.go
+++ b/db/pkg/db/model/machinecapability_test.go
@@ -90,7 +90,7 @@ func TestMachineCapabilitySQLDAO_Create(t *testing.T) {
 					Name:           "MT42822 BlueField-2 integrated ConnectX-6 Dx network controller",
 					Capacity:       db.GetStrPtr("100GB"),
 					Count:          db.GetIntPtr(2),
-					DeviceType:     db.GetStrPtr("DPU"),
+					DeviceType:     (*MachineCapabilityDeviceType)(db.GetStrPtr("DPU")),
 				},
 			},
 			expectError: false,
@@ -135,6 +135,20 @@ func TestMachineCapabilitySQLDAO_Create(t *testing.T) {
 					MachineID:      &mach.ID,
 					InstanceTypeID: nil,
 					Type:           "",
+					Name:           "AMD Opteron Series x10",
+					Frequency:      db.GetStrPtr("3.0 Ghz"),
+					Count:          db.GetIntPtr(2),
+				},
+			},
+			expectError: true,
+		},
+		{
+			desc: "create with non-empty but unknown capability type",
+			mcs: []MachineCapability{
+				{
+					MachineID:      &mach.ID,
+					InstanceTypeID: nil,
+					Type:           "Mystery",
 					Name:           "AMD Opteron Series x10",
 					Frequency:      db.GetStrPtr("3.0 Ghz"),
 					Count:          db.GetIntPtr(2),
@@ -239,7 +253,7 @@ func testMachineCapabilitySQLDAOCreateSlice(ctx context.Context, t *testing.T, d
 			Name:           "MT42822 BlueField-2 integrated ConnectX-6 Dx network controller",
 			Capacity:       db.GetStrPtr("100GB"),
 			Count:          db.GetIntPtr(2),
-			DeviceType:     db.GetStrPtr(""),
+			DeviceType:     (*MachineCapabilityDeviceType)(db.GetStrPtr("")),
 		},
 		{
 			MachineID:      &mach.ID,
@@ -390,27 +404,29 @@ func TestMachineCapabilitySQLDAO_GetAll(t *testing.T) {
 
 		capTypes := make([]string, 0, len(MachineCapabilityTypeChoiceMap))
 		for cap := range MachineCapabilityTypeChoiceMap {
-			capTypes = append(capTypes, cap)
+			capTypes = append(capTypes, string(cap))
 		}
 		sort.Strings(capTypes)
 
 		for _, cap := range capTypes {
+			capType := MachineCapabilityType(cap)
 			var vendor *string
-			var deviceType *string
-			if cap == MachineCapabilityTypeInfiniBand {
+			var deviceType *MachineCapabilityDeviceType
+			if capType == MachineCapabilityTypeInfiniBand {
 				vendor = db.GetStrPtr("Test Vendor")
 			}
-			if i == 0 && cap == MachineCapabilityTypeNetwork {
-				deviceType = db.GetStrPtr("DPU")
+			if i == 0 && capType == MachineCapabilityTypeNetwork {
+				dt := MachineCapabilityDeviceTypeDPU
+				deviceType = &dt
 			}
 
 			var inactiveDevices []int
-			if cap == MachineCapabilityTypeInfiniBand {
+			if capType == MachineCapabilityTypeInfiniBand {
 				inactiveDevices = []int{1, 3}
 			}
 
 			mc, err := mcd.Create(ctx, nil, MachineCapabilityCreateInput{
-				MachineID: &m.ID, Type: cap,
+				MachineID: &m.ID, Type: capType,
 				Name:            "Test Capability",
 				Frequency:       db.GetStrPtr("3 GHz"),
 				Capacity:        db.GetStrPtr("12 TB"),
@@ -527,7 +543,7 @@ func TestMachineCapabilitySQLDAO_GetAll(t *testing.T) {
 			desc:            "GetAll with Type filter",
 			MachineIDs:      nil,
 			InstanceTypeIDs: nil,
-			Type:            db.GetStrPtr(MachineCapabilityTypeGPU),
+			Type:            db.GetTypedStrPtr(MachineCapabilityTypeGPU),
 			Name:            nil,
 			Frequency:       nil,
 			Capacity:        nil,
@@ -539,7 +555,7 @@ func TestMachineCapabilitySQLDAO_GetAll(t *testing.T) {
 			desc:            "GetAll with Type and Name filter",
 			MachineIDs:      nil,
 			InstanceTypeIDs: nil,
-			Type:            db.GetStrPtr(MachineCapabilityTypeGPU),
+			Type:            db.GetTypedStrPtr(MachineCapabilityTypeGPU),
 			Name:            &mcs[0].Name,
 			Frequency:       nil,
 			Capacity:        nil,
@@ -552,7 +568,7 @@ func TestMachineCapabilitySQLDAO_GetAll(t *testing.T) {
 			desc:            "GetAll with Type and Capacity filter",
 			MachineIDs:      nil,
 			InstanceTypeIDs: nil,
-			Type:            &mcs[1].Type,
+			Type:            db.GetStrPtr(string(mcs[1].Type)),
 			Name:            nil,
 			Frequency:       nil,
 			Capacity:        mcs[1].Capacity,
@@ -565,7 +581,7 @@ func TestMachineCapabilitySQLDAO_GetAll(t *testing.T) {
 			desc:            "GetAll with Type and Frequency filter",
 			MachineIDs:      nil,
 			InstanceTypeIDs: nil,
-			Type:            &mcs[1].Type,
+			Type:            db.GetStrPtr(string(mcs[1].Type)),
 			Name:            nil,
 			Frequency:       mcs[1].Frequency,
 			Vendor:          nil,
@@ -578,7 +594,7 @@ func TestMachineCapabilitySQLDAO_GetAll(t *testing.T) {
 			desc:            "GetAll with Type and Count filter",
 			MachineIDs:      nil,
 			InstanceTypeIDs: nil,
-			Type:            db.GetStrPtr(MachineCapabilityTypeGPU),
+			Type:            db.GetTypedStrPtr(MachineCapabilityTypeGPU),
 			Name:            nil,
 			Frequency:       nil,
 			Capacity:        nil,
@@ -701,23 +717,25 @@ func TestMachineCapabilitySQLDAO_GetAllDistinct(t *testing.T) {
 
 		capTypes := make([]string, 0, len(MachineCapabilityTypeChoiceMap))
 		for cap := range MachineCapabilityTypeChoiceMap {
-			capTypes = append(capTypes, cap)
+			capTypes = append(capTypes, string(cap))
 		}
 		sort.Strings(capTypes)
 
 		for _, cap := range capTypes {
-			var deviceType *string
-			if i == 0 && cap == MachineCapabilityTypeNetwork {
-				deviceType = db.GetStrPtr("DPU")
+			capType := MachineCapabilityType(cap)
+			var deviceType *MachineCapabilityDeviceType
+			if i == 0 && capType == MachineCapabilityTypeNetwork {
+				dt := MachineCapabilityDeviceTypeDPU
+				deviceType = &dt
 			}
 			var inactiveDevices []int
-			if cap == MachineCapabilityTypeInfiniBand {
+			if capType == MachineCapabilityTypeInfiniBand {
 				inactiveDevices = []int{1, 3}
 			}
 			mc, err := mcd.Create(ctx, nil, MachineCapabilityCreateInput{
 				MachineID:       &m.ID,
 				InstanceTypeID:  &it.ID,
-				Type:            cap,
+				Type:            capType,
 				Name:            "Test Capability",
 				Frequency:       db.GetStrPtr("3 GHz"),
 				Capacity:        db.GetStrPtr("12 TB"),
@@ -809,7 +827,7 @@ func TestMachineCapabilitySQLDAO_GetAllDistinct(t *testing.T) {
 			desc:           "GetAll with Type filter",
 			MachineIDs:     nil,
 			InstanceTypeID: nil,
-			Type:           db.GetStrPtr(MachineCapabilityTypeCPU),
+			Type:           db.GetTypedStrPtr(MachineCapabilityTypeCPU),
 			Name:           nil,
 			Frequency:      nil,
 			Capacity:       nil,
@@ -822,7 +840,7 @@ func TestMachineCapabilitySQLDAO_GetAllDistinct(t *testing.T) {
 			desc:           "GetAll with Type and Name filter",
 			MachineIDs:     nil,
 			InstanceTypeID: nil,
-			Type:           &mcs[0].Type,
+			Type:           db.GetStrPtr(string(mcs[0].Type)),
 			Name:           &mcs[0].Name,
 			Frequency:      nil,
 			Capacity:       nil,
@@ -835,7 +853,7 @@ func TestMachineCapabilitySQLDAO_GetAllDistinct(t *testing.T) {
 			desc:           "GetAll with Type and Capacity filter",
 			MachineIDs:     nil,
 			InstanceTypeID: nil,
-			Type:           &mcs[1].Type,
+			Type:           db.GetStrPtr(string(mcs[1].Type)),
 			Name:           nil,
 			Frequency:      nil,
 			Capacity:       mcs[1].Capacity,
@@ -848,7 +866,7 @@ func TestMachineCapabilitySQLDAO_GetAllDistinct(t *testing.T) {
 			desc:           "GetAll with Type and Frequency filter",
 			MachineIDs:     nil,
 			InstanceTypeID: nil,
-			Type:           &mcs[1].Type,
+			Type:           db.GetStrPtr(string(mcs[1].Type)),
 			Name:           nil,
 			Frequency:      mcs[1].Frequency,
 			Vendor:         nil,
@@ -861,7 +879,7 @@ func TestMachineCapabilitySQLDAO_GetAllDistinct(t *testing.T) {
 			desc:           "GetAll with Type and Count filter",
 			MachineIDs:     nil,
 			InstanceTypeID: nil,
-			Type:           &mcs[1].Type,
+			Type:           db.GetStrPtr(string(mcs[1].Type)),
 			Name:           nil,
 			Frequency:      nil,
 			Capacity:       nil,
@@ -949,13 +967,13 @@ func TestMachineCapabilitySQLDAO_Update(t *testing.T) {
 		mc                 *MachineCapability
 		MachineID          *string
 		InstanceTypeID     *uuid.UUID
-		Type               *string
+		Type               *MachineCapabilityType
 		Name               *string
 		Frequency          *string
 		Capacity           *string
 		Vendor             *string
 		Count              *int
-		DeviceType         *string
+		DeviceType         *MachineCapabilityDeviceType
 		Info               map[string]interface{}
 		Index              *int
 		Threads            *int
@@ -998,7 +1016,7 @@ func TestMachineCapabilitySQLDAO_Update(t *testing.T) {
 			mc:               &mcsExp[2],
 			MachineID:        nil,
 			InstanceTypeID:   nil,
-			Type:             db.GetStrPtr(MachineCapabilityTypeMemory),
+			Type:             db.Ptr(MachineCapabilityTypeMemory),
 			Name:             db.GetStrPtr(name),
 			Frequency:        db.GetStrPtr(frequency),
 			Capacity:         db.GetStrPtr(capacity),
@@ -1035,7 +1053,7 @@ func TestMachineCapabilitySQLDAO_Update(t *testing.T) {
 			Frequency:      nil,
 			Capacity:       nil,
 			Vendor:         nil,
-			DeviceType:     db.GetStrPtr(deviceType),
+			DeviceType:     db.Ptr(MachineCapabilityDeviceType(deviceType)),
 			Count:          nil,
 			expectedError:  false,
 		},
@@ -1045,7 +1063,7 @@ func TestMachineCapabilitySQLDAO_Update(t *testing.T) {
 			mc:             &mcsExp[2],
 			MachineID:      nil,
 			InstanceTypeID: nil,
-			Type:           db.GetStrPtr("invalid-type"),
+			Type:           db.Ptr(MachineCapabilityType("invalid-type")),
 			Name:           &name,
 			Frequency:      &frequency,
 			Capacity:       &capacity,
@@ -1559,10 +1577,156 @@ func TestMachineCapability_ToProto(t *testing.T) {
 	})
 
 	t.Run("unknown type leaves CapabilityType as zero, unknown device type drops to nil", func(t *testing.T) {
-		unknown := "Unknown"
+		unknown := MachineCapabilityDeviceType("Unknown")
 		mc := &MachineCapability{Type: "Mystery", Name: "x", DeviceType: &unknown}
 		proto := mc.ToProto()
 		assert.Equal(t, cwssaws.MachineCapabilityType(0), proto.CapabilityType)
 		assert.Nil(t, proto.DeviceType)
+	})
+}
+
+func TestMachineCapability_FromProto(t *testing.T) {
+	name := "cpu-0"
+	freq := "3.5GHz"
+	capacity := "1024"
+	vendor := "ACME"
+	hwRev := "v1"
+	var count, cores, threads uint32 = 8, 16, 32
+	deviceType := cwssaws.MachineCapabilityDeviceType_MACHINE_CAPABILITY_DEVICE_TYPE_DPU
+
+	t.Run("nil attrs is no-op", func(t *testing.T) {
+		mc := &MachineCapability{Type: MachineCapabilityTypeGPU}
+		mc.FromProto(nil, 5)
+		assert.Equal(t, MachineCapabilityTypeGPU, mc.Type)
+		assert.Equal(t, 0, mc.Index)
+	})
+
+	t.Run("happy path with all fields", func(t *testing.T) {
+		mc := &MachineCapability{}
+		mc.FromProto(&cwssaws.InstanceTypeMachineCapabilityFilterAttributes{
+			CapabilityType:   cwssaws.MachineCapabilityType_CAP_TYPE_CPU,
+			Name:             &name,
+			Frequency:        &freq,
+			Capacity:         &capacity,
+			Vendor:           &vendor,
+			HardwareRevision: &hwRev,
+			Count:            &count,
+			Cores:            &cores,
+			Threads:          &threads,
+			DeviceType:       &deviceType,
+			InactiveDevices:  &cwssaws.Uint32List{Items: []uint32{0, 1}},
+		}, 7)
+
+		assert.Equal(t, MachineCapabilityTypeCPU, mc.Type)
+		assert.Equal(t, "cpu-0", mc.Name)
+		assert.Equal(t, &freq, mc.Frequency)
+		assert.Equal(t, &capacity, mc.Capacity)
+		assert.Equal(t, &vendor, mc.Vendor)
+		assert.Equal(t, &hwRev, mc.HardwareRevision)
+		require.NotNil(t, mc.Count)
+		assert.Equal(t, 8, *mc.Count)
+		require.NotNil(t, mc.Cores)
+		assert.Equal(t, 16, *mc.Cores)
+		require.NotNil(t, mc.Threads)
+		assert.Equal(t, 32, *mc.Threads)
+		require.NotNil(t, mc.DeviceType)
+		assert.Equal(t, MachineCapabilityDeviceTypeDPU, *mc.DeviceType)
+		assert.Equal(t, []int{0, 1}, mc.InactiveDevices)
+		assert.Equal(t, 7, mc.Index)
+	})
+
+	t.Run("unknown CapabilityType leaves Type empty (caller must Validate)", func(t *testing.T) {
+		mc := &MachineCapability{}
+		mc.FromProto(&cwssaws.InstanceTypeMachineCapabilityFilterAttributes{
+			CapabilityType: cwssaws.MachineCapabilityType(9999),
+			Name:           &name,
+		}, 0)
+		assert.Equal(t, MachineCapabilityType(""), mc.Type)
+		assert.Equal(t, "cpu-0", mc.Name)
+	})
+
+	t.Run("nil Name leaves Name empty (caller must Validate)", func(t *testing.T) {
+		mc := &MachineCapability{}
+		mc.FromProto(&cwssaws.InstanceTypeMachineCapabilityFilterAttributes{
+			CapabilityType: cwssaws.MachineCapabilityType_CAP_TYPE_CPU,
+		}, 0)
+		assert.Equal(t, MachineCapabilityTypeCPU, mc.Type)
+		assert.Equal(t, "", mc.Name)
+	})
+
+	t.Run("unknown DeviceType is preserved (caller must Validate)", func(t *testing.T) {
+		unknown := cwssaws.MachineCapabilityDeviceType(9999)
+		mc := &MachineCapability{}
+		mc.FromProto(&cwssaws.InstanceTypeMachineCapabilityFilterAttributes{
+			CapabilityType: cwssaws.MachineCapabilityType_CAP_TYPE_GPU,
+			Name:           &name,
+			DeviceType:     &unknown,
+		}, 0)
+		require.NotNil(t, mc.DeviceType)
+		assert.Equal(t, MachineCapabilityDeviceType(""), *mc.DeviceType)
+	})
+}
+
+func TestMachineCapability_Validate(t *testing.T) {
+	dpu := MachineCapabilityDeviceTypeDPU
+	nvlink := MachineCapabilityDeviceTypeNVLink
+
+	t.Run("populated capability is valid", func(t *testing.T) {
+		mc := &MachineCapability{Type: MachineCapabilityTypeCPU, Name: "cpu-0"}
+		assert.NoError(t, mc.Validate())
+	})
+	t.Run("empty Type errors", func(t *testing.T) {
+		mc := &MachineCapability{Type: "", Name: "cpu-0"}
+		assert.Error(t, mc.Validate())
+	})
+	t.Run("invalid Type errors", func(t *testing.T) {
+		mc := &MachineCapability{Type: "Bogus", Name: "cpu-0"}
+		assert.Error(t, mc.Validate())
+	})
+	t.Run("empty Name errors", func(t *testing.T) {
+		mc := &MachineCapability{Type: MachineCapabilityTypeCPU, Name: ""}
+		assert.Error(t, mc.Validate())
+	})
+	t.Run("Name with leading whitespace errors", func(t *testing.T) {
+		mc := &MachineCapability{Type: MachineCapabilityTypeCPU, Name: " cpu-0"}
+		assert.Error(t, mc.Validate())
+	})
+	t.Run("Name with trailing whitespace errors", func(t *testing.T) {
+		mc := &MachineCapability{Type: MachineCapabilityTypeCPU, Name: "cpu-0 "}
+		assert.Error(t, mc.Validate())
+	})
+	t.Run("single-character Name errors (too short)", func(t *testing.T) {
+		mc := &MachineCapability{Type: MachineCapabilityTypeCPU, Name: "x"}
+		assert.Error(t, mc.Validate())
+	})
+
+	t.Run("Network with DPU device type is valid", func(t *testing.T) {
+		mc := &MachineCapability{Type: MachineCapabilityTypeNetwork, Name: "net-0", DeviceType: &dpu}
+		assert.NoError(t, mc.Validate())
+	})
+	t.Run("Network with NVLink device type errors", func(t *testing.T) {
+		mc := &MachineCapability{Type: MachineCapabilityTypeNetwork, Name: "net-0", DeviceType: &nvlink}
+		assert.Error(t, mc.Validate())
+	})
+	t.Run("GPU with NVLink device type is valid", func(t *testing.T) {
+		mc := &MachineCapability{Type: MachineCapabilityTypeGPU, Name: "gpu-0", DeviceType: &nvlink}
+		assert.NoError(t, mc.Validate())
+	})
+	t.Run("GPU with DPU device type errors", func(t *testing.T) {
+		mc := &MachineCapability{Type: MachineCapabilityTypeGPU, Name: "gpu-0", DeviceType: &dpu}
+		assert.Error(t, mc.Validate())
+	})
+	t.Run("CPU with any device type errors", func(t *testing.T) {
+		mc := &MachineCapability{Type: MachineCapabilityTypeCPU, Name: "cpu-0", DeviceType: &dpu}
+		assert.Error(t, mc.Validate())
+	})
+
+	t.Run("InfiniBand with InactiveDevices is valid", func(t *testing.T) {
+		mc := &MachineCapability{Type: MachineCapabilityTypeInfiniBand, Name: "ib-0", InactiveDevices: []int{0, 1}}
+		assert.NoError(t, mc.Validate())
+	})
+	t.Run("CPU with InactiveDevices errors", func(t *testing.T) {
+		mc := &MachineCapability{Type: MachineCapabilityTypeCPU, Name: "cpu-0", InactiveDevices: []int{0, 1}}
+		assert.Error(t, mc.Validate())
 	})
 }

--- a/db/pkg/db/util.go
+++ b/db/pkg/db/util.go
@@ -18,6 +18,24 @@ func GetStrPtr(s string) *string {
 	return &sp
 }
 
+// GetTypedStrPtr returns a `*string` pointing to a copy of v's
+// underlying string value. Mirrors `GetStrPtr` but accepts any type
+// whose underlying type is `string` — typically a typed-string domain
+// enum like `cdbm.MachineCapabilityType` — so callers can pass typed
+// values to DAO filter params that take `*string` without an explicit
+// `string(...)` cast at the call site.
+func GetTypedStrPtr[T ~string](v T) *string {
+	s := string(v)
+	return &s
+}
+
+// Ptr returns a pointer to a copy of v. Useful when you need to pass
+// a non-addressable constant (typically a typed-string domain enum
+// value) where a `*T` is expected.
+func Ptr[T any](v T) *T {
+	return &v
+}
+
 // GetBoolPtr returns a pointer for the provided bool
 func GetBoolPtr(b bool) *bool {
 	bp := b

--- a/workflow/pkg/activity/instancetype/instancetype.go
+++ b/workflow/pkg/activity/instancetype/instancetype.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/google/uuid"
@@ -24,34 +23,6 @@ import (
 
 	cwutil "github.com/NVIDIA/infra-controller-rest/common/pkg/util"
 )
-
-var CloudCapabilityTypeToProtobufType = map[string]cwssaws.MachineCapabilityType{
-	cdbm.MachineCapabilityTypeCPU:        cwssaws.MachineCapabilityType_CAP_TYPE_CPU,
-	cdbm.MachineCapabilityTypeMemory:     cwssaws.MachineCapabilityType_CAP_TYPE_MEMORY,
-	cdbm.MachineCapabilityTypeGPU:        cwssaws.MachineCapabilityType_CAP_TYPE_GPU,
-	cdbm.MachineCapabilityTypeStorage:    cwssaws.MachineCapabilityType_CAP_TYPE_STORAGE,
-	cdbm.MachineCapabilityTypeNetwork:    cwssaws.MachineCapabilityType_CAP_TYPE_NETWORK,
-	cdbm.MachineCapabilityTypeInfiniBand: cwssaws.MachineCapabilityType_CAP_TYPE_INFINIBAND,
-	cdbm.MachineCapabilityTypeDPU:        cwssaws.MachineCapabilityType_CAP_TYPE_DPU,
-}
-
-var ProtobufCapabilityTypeToCloudType = map[cwssaws.MachineCapabilityType]string{
-	cwssaws.MachineCapabilityType_CAP_TYPE_CPU:        cdbm.MachineCapabilityTypeCPU,
-	cwssaws.MachineCapabilityType_CAP_TYPE_MEMORY:     cdbm.MachineCapabilityTypeMemory,
-	cwssaws.MachineCapabilityType_CAP_TYPE_GPU:        cdbm.MachineCapabilityTypeGPU,
-	cwssaws.MachineCapabilityType_CAP_TYPE_STORAGE:    cdbm.MachineCapabilityTypeStorage,
-	cwssaws.MachineCapabilityType_CAP_TYPE_NETWORK:    cdbm.MachineCapabilityTypeNetwork,
-	cwssaws.MachineCapabilityType_CAP_TYPE_INFINIBAND: cdbm.MachineCapabilityTypeInfiniBand,
-	cwssaws.MachineCapabilityType_CAP_TYPE_DPU:        cdbm.MachineCapabilityTypeDPU,
-}
-
-var CloudCapabilityDeviceTypeToProtobufType = map[string]cwssaws.MachineCapabilityDeviceType{
-	cdbm.MachineCapabilityDeviceTypeDPU: cwssaws.MachineCapabilityDeviceType_MACHINE_CAPABILITY_DEVICE_TYPE_DPU,
-}
-
-var ProtobufCapabilityDeviceTypeToCloudType = map[cwssaws.MachineCapabilityDeviceType]string{
-	cwssaws.MachineCapabilityDeviceType_MACHINE_CAPABILITY_DEVICE_TYPE_DPU: cdbm.MachineCapabilityDeviceTypeDPU,
-}
 
 // ManageInstanceType is an activity wrapper for managing InstanceType lifecycle that allows
 // injecting DB access
@@ -199,7 +170,9 @@ func (mv ManageInstanceType) UpdateInstanceTypeInCloud(ctx context.Context, site
 			return errors.New("site returned multiple capabilities with the same name")
 		}
 
-		machineCap, err := MachineCapabilityFromProtobufMachineCapability(controllerCap, idx)
+		machineCap := &cdbm.MachineCapability{}
+		machineCap.FromProto(controllerCap, idx)
+		err := machineCap.Validate()
 		if err != nil {
 			return fmt.Errorf("failed to convert NICo machine capability into MachineCapability: %w", err)
 		}
@@ -362,44 +335,30 @@ func (mv ManageInstanceType) AddInstanceTypeToCloud(ctx context.Context, site *c
 
 		controllerCapMap[controllerCap.GetName()] = true
 
-		var count *int = nil
-
-		if controllerCap.Count != nil {
-			c := int(controllerCap.GetCount())
-			count = &c
-		}
-
-		var inactiveDevices []int
-		if controllerCap.InactiveDevices != nil {
-			for _, d := range controllerCap.InactiveDevices.Items {
-				inactiveDevices = append(inactiveDevices, int(d))
-			}
-		}
-
-		var deviceType *string
-		if controllerCap.DeviceType != nil {
-			deviceTypeValue, found := ProtobufCapabilityDeviceTypeToCloudType[*controllerCap.DeviceType]
-			if !found {
-				log.Warn().Str("DeviceType", controllerCap.GetDeviceType().String()).Msg("unsupported MachineCapabilityDeviceType requested")
-				deviceType = nil
-			}
-			deviceType = &deviceTypeValue
+		// Build the entity, then Validate before going to the DB --
+		// mirrors the UpdateInstanceTypeInCloud flow so unsupported
+		// site-supplied enums get rejected here rather than landing as
+		// empty strings in the DB.
+		machineCap := &cdbm.MachineCapability{}
+		machineCap.FromProto(controllerCap, idx)
+		if err := machineCap.Validate(); err != nil {
+			return nil, fmt.Errorf("failed to convert NICo machine capability into MachineCapability: %w", err)
 		}
 
 		_, err := macCapDAO.Create(ctx, tx, cdbm.MachineCapabilityCreateInput{
 			InstanceTypeID:   &instanceType.ID,
-			Type:             controllerCap.GetCapabilityType().String(),
-			Name:             controllerCap.GetName(),
-			Frequency:        controllerCap.Frequency,
-			Capacity:         controllerCap.Capacity,
-			Vendor:           controllerCap.Vendor,
-			Cores:            util.GetUint32PtrToIntPtr(controllerCap.Cores),
-			Threads:          util.GetUint32PtrToIntPtr(controllerCap.Threads),
-			HardwareRevision: controllerCap.HardwareRevision,
-			InactiveDevices:  inactiveDevices,
-			Count:            count,
-			DeviceType:       deviceType,
-			Index:            idx,
+			Type:             machineCap.Type,
+			Name:             machineCap.Name,
+			Frequency:        machineCap.Frequency,
+			Capacity:         machineCap.Capacity,
+			Vendor:           machineCap.Vendor,
+			Cores:            machineCap.Cores,
+			Threads:          machineCap.Threads,
+			HardwareRevision: machineCap.HardwareRevision,
+			InactiveDevices:  machineCap.InactiveDevices,
+			Count:            machineCap.Count,
+			DeviceType:       machineCap.DeviceType,
+			Index:            machineCap.Index,
 		})
 
 		if err != nil {
@@ -415,142 +374,6 @@ func (mv ManageInstanceType) AddInstanceTypeToCloud(ctx context.Context, site *c
 	txCommitted = true
 
 	return instanceType, err
-}
-
-func (mv ManageInstanceType) ProtobufCapabilitiesFromCloudCapabilities(mcs []cdbm.MachineCapability) ([]*cwssaws.InstanceTypeMachineCapabilityFilterAttributes, error) {
-
-	// Get the caps for the instance type
-	capabilities := make([]*cwssaws.InstanceTypeMachineCapabilityFilterAttributes, len(mcs))
-
-	// Sort the capabilities list.  NICo will deny later updates
-	// if an InstanceType is associated with machines and a change
-	// in capabilities is attempted, so we'll sort here and
-	// in the update handler so that users can update metadata
-	// as long as capabilities are the same, and order matters.
-	slices.SortFunc(mcs, func(a, b cdbm.MachineCapability) int {
-		if a.Index < b.Index {
-			return -1
-		}
-
-		if a.Index > b.Index {
-			return 1
-		}
-
-		return 0
-	})
-
-	for i, machineCap := range mcs {
-
-		count, err := util.GetIntPtrToUint32Ptr(machineCap.Count)
-		if err != nil {
-			return nil, err
-		}
-
-		cores, err := util.GetIntPtrToUint32Ptr(machineCap.Cores)
-		if err != nil {
-			return nil, err
-		}
-
-		threads, err := util.GetIntPtrToUint32Ptr(machineCap.Threads)
-		if err != nil {
-			return nil, err
-		}
-
-		capType, found := CloudCapabilityTypeToProtobufType[machineCap.Type]
-
-		if !found {
-			return nil, errors.New("unsupported MachineCapabilityType requested")
-		}
-
-		var inactiveDevices *cwssaws.Uint32List
-
-		if machineCap.InactiveDevices != nil {
-			inactiveDevices = &cwssaws.Uint32List{}
-
-			for _, d := range machineCap.InactiveDevices {
-				u, err := util.GetIntPtrToUint32Ptr(&d)
-				if err != nil {
-					return nil, fmt.Errorf("unable to convert cloud machine capability to profobuf capability: %w", err)
-				}
-				inactiveDevices.Items = append(inactiveDevices.Items, *u)
-			}
-		}
-
-		var deviceType *cwssaws.MachineCapabilityDeviceType
-		if machineCap.DeviceType != nil {
-			deviceTypeValue, found := CloudCapabilityDeviceTypeToProtobufType[*machineCap.DeviceType]
-			if !found {
-				log.Warn().Str("DeviceType", *machineCap.DeviceType).Msg("unsupported MachineCapabilityDeviceType requested")
-				deviceType = nil
-			}
-			deviceType = &deviceTypeValue
-		}
-
-		capabilities[i] = &cwssaws.InstanceTypeMachineCapabilityFilterAttributes{
-			CapabilityType:   capType,
-			Name:             &machineCap.Name,
-			Frequency:        machineCap.Frequency,
-			Capacity:         machineCap.Capacity,
-			Vendor:           machineCap.Vendor,
-			Count:            count,
-			DeviceType:       deviceType,
-			HardwareRevision: machineCap.HardwareRevision,
-			InactiveDevices:  inactiveDevices,
-			Cores:            cores,
-			Threads:          threads,
-		}
-	}
-
-	return capabilities, nil
-}
-
-func MachineCapabilityFromProtobufMachineCapability(cap *cwssaws.InstanceTypeMachineCapabilityFilterAttributes, idx int) (*cdbm.MachineCapability, error) {
-
-	var capType string
-
-	capType, found := ProtobufCapabilityTypeToCloudType[cap.CapabilityType]
-
-	if !found {
-		return nil, errors.New("unsupported MachineCapabilityType requested")
-	}
-
-	if cap.Name == nil {
-		return nil, errors.New("unsupported empty capability name requested")
-	}
-
-	var inactiveDevices []int
-	if cap.InactiveDevices != nil {
-		for _, d := range cap.InactiveDevices.Items {
-			inactiveDevices = append(inactiveDevices, int(d))
-		}
-	}
-
-	var deviceType *string
-	if cap.DeviceType != nil {
-		deviceTypeValue, found := ProtobufCapabilityDeviceTypeToCloudType[*cap.DeviceType]
-		if !found {
-			log.Warn().Str("DeviceType", cap.GetDeviceType().String()).Msg("unsupported MachineCapabilityDeviceType requested")
-			deviceType = nil
-		}
-		deviceType = &deviceTypeValue
-	}
-
-	macCap := &cdbm.MachineCapability{
-		Type:             capType,
-		Name:             *cap.Name,
-		Frequency:        cap.Frequency,
-		Capacity:         cap.Capacity,
-		Vendor:           cap.Vendor,
-		Count:            util.GetUint32PtrToIntPtr(cap.Count),
-		HardwareRevision: cap.HardwareRevision,
-		Cores:            util.GetUint32PtrToIntPtr(cap.Cores),
-		Threads:          util.GetUint32PtrToIntPtr(cap.Threads),
-		InactiveDevices:  inactiveDevices,
-		DeviceType:       deviceType,
-		Index:            idx,
-	}
-
-	return macCap, nil
 }
 
 // NewManageInstanceType returns a new ManageInstanceType activity

--- a/workflow/pkg/activity/instancetype/instancetype_test.go
+++ b/workflow/pkg/activity/instancetype/instancetype_test.go
@@ -155,7 +155,7 @@ func testInstanceTypeBuildInstanceType(t *testing.T, dbSession *cdb.Session, nam
 	return instanceType
 }
 
-func testInstanceTypeBuildMachineCapability(t *testing.T, dbSession *cdb.Session, iID *uuid.UUID, typ string, name string, capacity *string, count *int, deviceType *string) *cdbm.MachineCapability {
+func testInstanceTypeBuildMachineCapability(t *testing.T, dbSession *cdb.Session, iID *uuid.UUID, typ cdbm.MachineCapabilityType, name string, capacity *string, count *int, deviceType *cdbm.MachineCapabilityDeviceType) *cdbm.MachineCapability {
 	mc := &cdbm.MachineCapability{
 		ID:             uuid.New(),
 		InstanceTypeID: iID,
@@ -557,7 +557,16 @@ func TestManageInstanceType_UpdateInstanceTypesInDB(t *testing.T) {
 						for i := range tot {
 							assert.Equal(t, cloudCaps[i].Name, *siteCaps[i].Name)
 							if cloudCaps[i].Type == cdbm.MachineCapabilityTypeNetwork && cloudCaps[i].DeviceType != nil {
-								assert.Equal(t, *siteCaps[i].DeviceType, CloudCapabilityDeviceTypeToProtobufType[cloudCaps[i].Type])
+								var protoDeviceType cwssaws.MachineCapabilityDeviceType
+								switch *cloudCaps[i].DeviceType {
+								case cdbm.MachineCapabilityDeviceTypeDPU:
+									protoDeviceType = cwssaws.MachineCapabilityDeviceType_MACHINE_CAPABILITY_DEVICE_TYPE_DPU
+								case cdbm.MachineCapabilityDeviceTypeNVLink:
+									protoDeviceType = cwssaws.MachineCapabilityDeviceType_MACHINE_CAPABILITY_DEVICE_TYPE_NVLINK
+								default:
+									t.Fatalf("unsupported DeviceType %q in test fixture", *cloudCaps[i].DeviceType)
+								}
+								assert.Equal(t, *siteCaps[i].DeviceType, protoDeviceType)
 							}
 						}
 					}

--- a/workflow/pkg/activity/machine/machine.go
+++ b/workflow/pkg/activity/machine/machine.go
@@ -779,10 +779,23 @@ func processMachineCapabilities(ctx context.Context, logger zerolog.Logger, dbSe
 	for _, gpuCap := range controllerCapsGpu {
 		mapId := fmt.Sprintf(`%s:%s`, cdbm.MachineCapabilityTypeGPU, gpuCap.Name)
 
-		// Set the device type to DPU if it's a DPU network capability
-		deviceType := cdb.GetStrPtr("")
-		if gpuCap.DeviceType != nil && *gpuCap.DeviceType == cwssaws.MachineCapabilityDeviceType_MACHINE_CAPABILITY_DEVICE_TYPE_NVLINK {
-			deviceType = cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeNVLink)
+		// Set the device type to NVLink if it's an NVLink GPU capability.
+		// Unknown wire values are coerced to the empty string with a
+		// warning logged — preserve the explicit `default` branch so
+		// schema drift is surfaced rather than silently swallowed.
+		// TODO: support other GPU device-type variants as the wire enum
+		// grows; currently only NVLink is recognized.
+		var deviceType *cdbm.MachineCapabilityDeviceType
+		dtEmpty := cdbm.MachineCapabilityDeviceType("")
+		deviceType = &dtEmpty
+		if gpuCap.DeviceType != nil {
+			switch *gpuCap.DeviceType {
+			case cwssaws.MachineCapabilityDeviceType_MACHINE_CAPABILITY_DEVICE_TYPE_NVLINK:
+				dt := cdbm.MachineCapabilityDeviceTypeNVLink
+				deviceType = &dt
+			default:
+				logger.Warn().Str("DeviceType", gpuCap.DeviceType.String()).Msg("unsupported MachineCapabilityDeviceType for GPU capability; defaulting to empty")
+			}
 		}
 
 		siteCapMap[mapId] = &cdbm.MachineCapability{
@@ -850,10 +863,23 @@ func processMachineCapabilities(ctx context.Context, logger zerolog.Logger, dbSe
 	for _, netCap := range controllerCapsNetwork {
 		mapId := fmt.Sprintf(`%s:%s`, cdbm.MachineCapabilityTypeNetwork, netCap.Name)
 
-		// Set the device type to DPU if it's a DPU network capability
-		deviceType := cdb.GetStrPtr("")
-		if netCap.DeviceType != nil && *netCap.DeviceType == cwssaws.MachineCapabilityDeviceType_MACHINE_CAPABILITY_DEVICE_TYPE_DPU {
-			deviceType = cdb.GetStrPtr(cdbm.MachineCapabilityDeviceTypeDPU)
+		// Set the device type to DPU if it's a DPU network capability.
+		// Unknown wire values are coerced to the empty string with a
+		// warning logged — preserve the explicit `default` branch so
+		// schema drift is surfaced rather than silently swallowed.
+		// TODO: support other Network device-type variants as the wire
+		// enum grows; currently only DPU is recognized.
+		var deviceType *cdbm.MachineCapabilityDeviceType
+		dtEmpty := cdbm.MachineCapabilityDeviceType("")
+		deviceType = &dtEmpty
+		if netCap.DeviceType != nil {
+			switch *netCap.DeviceType {
+			case cwssaws.MachineCapabilityDeviceType_MACHINE_CAPABILITY_DEVICE_TYPE_DPU:
+				dt := cdbm.MachineCapabilityDeviceTypeDPU
+				deviceType = &dt
+			default:
+				logger.Warn().Str("DeviceType", netCap.DeviceType.String()).Msg("unsupported MachineCapabilityDeviceType for Network capability; defaulting to empty")
+			}
 		}
 
 		siteCapMap[mapId] = &cdbm.MachineCapability{

--- a/workflow/pkg/activity/machine/machine_test.go
+++ b/workflow/pkg/activity/machine/machine_test.go
@@ -201,7 +201,7 @@ func testMachineBuildMachine(t *testing.T, dbSession *cdb.Session, ip uuid.UUID,
 	return m
 }
 
-func testMachineBuildMachineCapability(t *testing.T, dbSession *cdb.Session, mID *string, typ string, name string, capacity *string, count *int) *cdbm.MachineCapability {
+func testMachineBuildMachineCapability(t *testing.T, dbSession *cdb.Session, mID *string, typ cdbm.MachineCapabilityType, name string, capacity *string, count *int) *cdbm.MachineCapability {
 	mc := &cdbm.MachineCapability{
 		ID:             uuid.New(),
 		MachineID:      mID,
@@ -1070,7 +1070,7 @@ func TestManageMachine_UpdateMachinesInDB(t *testing.T) {
 
 				// Verify reported DPU count is correct
 				if tt.args.isDPUCountReported != nil && *tt.args.isDPUCountReported {
-					mctd1s, mctd1Total, mtdserr := mcDAO.GetAll(tt.args.ctx, nil, []string{um1.ID}, nil, nil, cdb.GetStrPtr(cdbm.MachineCapabilityTypeDPU), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+					mctd1s, mctd1Total, mtdserr := mcDAO.GetAll(tt.args.ctx, nil, []string{um1.ID}, nil, nil, cdb.GetTypedStrPtr(cdbm.MachineCapabilityTypeDPU), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 					assert.Nil(t, mtdserr)
 					if mctd1Total > 0 {
 						assert.Equal(t, *mctd1s[0].Count, 2)

--- a/workflow/pkg/util/conv.go
+++ b/workflow/pkg/util/conv.go
@@ -3,33 +3,6 @@
 
 package util
 
-import (
-	"errors"
-	"math"
-)
-
-// A convenience function for converting a pointer to
-// a native Go integer to a pointer to a uint32 for
-// use with a protobuf message. Accepts a pointer to
-// an int and returns a uint32 pointer.
-//
-// If the input is nil, nil will be returned.
-// If a pointer to a value greater than
-// uint32 max is submitted, an error will be returned.
-func GetIntPtrToUint32Ptr(i *int) (*uint32, error) {
-	if i == nil {
-		return nil, nil
-	}
-
-	if *i > math.MaxUint32 {
-		return nil, errors.New("conversion to uint32 pointer would exceed uint32 max")
-	}
-
-	i32 := uint32(*i)
-
-	return &i32, nil
-}
-
 // A convenience function for converting a pointer to
 // a uint32 to a pointer to a an int.
 //


### PR DESCRIPTION
## Description

Brings `MachineCapability` in line with the proto-modeling changes.

Primary callouts are:
- `MachineCapabilityType` and `MachineCapabilityDeviceType` are now typed strings with their own `.ToProto()` and `.FromProto(...)` methods.
- `MachineCapability.ToProto` / `FromProto` collapse to one-liner calls for the aforementioned types (exciting).
- There is now a separate `MachineCapability.Validate()` that callers run alongside `.FromProto(..)` -- similar to how we `.Validate()` before going `.ToProto()`.
- `UpdateInstanceTypeInCloud` becomes a `FromProto` + `Validate` pair, and `AddInstanceTypeToCloud` now uses `MachineCapabilityType.FromProto` for its DB enum conversion

As part of the new `MachineCapabilityType` and `MachineCapabilityDeviceType`, I did make some subsequent changes to ensure the typing was better handled through the flow (and not me just type-casting everything as `string`). While this did affect the API layer, nothing is changed on the wire -- JSON serialization/deserialization of type X string is identical to string, OpenAPI spec still just says "string", and the SDK is unaffected.

Updated `AGENTS.md` with some notes about named types owning their own `ToProto/FromProto` behavior (like I did here for `MachineCapabilityType` and `MachineCapabilityDeviceType`).

Tests added!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [x] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **API** - API models or endpoints updated
- [x] **Workflow** - Workflow service updated
- [x] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **Flow** - Flow service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
