### PR TITLE
refactor: Split component manager operation interfaces

### DIFF
--- a/flow/docs/component-manager-architecture.md
+++ b/flow/docs/component-manager-architecture.md
@@ -72,13 +72,52 @@ provider, err := providerapi.GetTyped[*nico.Provider](
 ```go
 type ComponentManager interface {
     Descriptor() cmcatalog.Descriptor
+}
+
+type ExpectationInjector interface {
+    // CapabilityInjectExpectation
     InjectExpectation(ctx, target, info) error
+}
+
+type PowerController interface {
+    // CapabilityPowerControl
     PowerControl(ctx, target, info) error
-    FirmwareControl(ctx, target, info) error
-    GetFirmwareStatus(ctx, target) (map, error)
+}
+
+type PowerStatusReader interface {
+    // CapabilityPowerStatus
     GetPowerStatus(ctx, target) (map, error)
 }
+
+type FirmwareController interface {
+    // CapabilityFirmwareControl
+    FirmwareControl(ctx, target, info) error
+}
+
+type FirmwareStatusReader interface {
+    // CapabilityFirmwareStatus
+    GetFirmwareStatus(ctx, target) (map, error)
+}
+
+type BringUpController interface {
+    // CapabilityBringUpControl
+    BringUpControl(ctx, target) error
+}
+
+type BringUpStatusReader interface {
+    // CapabilityBringUpStatus
+    GetBringUpStatus(ctx, target) (map, error)
+}
+
+type FirmwareConsistencyChecker interface {
+    // CapabilityFirmwareConsistencyCheck
+    VerifyFirmwareConsistency(ctx, target) error
+}
 ```
+
+The base interface only carries descriptor metadata. Operation methods are
+capability-specific interfaces, so implementations only define the operations
+they advertise in `catalog.Descriptor.Capabilities`.
 
 ### ManagerFactory
 
@@ -261,6 +300,7 @@ import (
     "fmt"
 
     "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager"
+    "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/capability"
     cmcatalog "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/catalog"
     "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/providerapi"
     myapiprovider "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/providers/myapi"
@@ -299,6 +339,11 @@ func Descriptor() cmcatalog.Descriptor {
         Type:              devicetypes.ComponentTypeCompute,
         Implementation:    ImplementationName,
         RequiredProviders: []string{myapiprovider.ProviderName},
+        Capabilities: capability.CapabilitySet{
+            capability.CapabilityInjectExpectation,
+            capability.CapabilityPowerControl,
+            capability.CapabilityFirmwareControl,
+        },
     }
 }
 
@@ -315,17 +360,17 @@ func (m *Manager) Descriptor() cmcatalog.Descriptor {
     return Descriptor()
 }
 
-// InjectExpectation implements ComponentManager.
+// InjectExpectation implements componentmanager.ExpectationInjector.
 func (m *Manager) InjectExpectation(ctx context.Context, target common.Target, info operations.InjectExpectationTaskInfo) error {
     // Implementation here
 }
 
-// PowerControl implements ComponentManager.
+// PowerControl implements componentmanager.PowerController.
 func (m *Manager) PowerControl(ctx context.Context, target common.Target, info operations.PowerControlTaskInfo) error {
     // Implementation here
 }
 
-// FirmwareControl implements ComponentManager.
+// FirmwareControl implements componentmanager.FirmwareController.
 func (m *Manager) FirmwareControl(ctx context.Context, target common.Target, info operations.FirmwareControlTaskInfo) error {
     // Implementation here — initiate firmware update, return immediately
 }

--- a/flow/internal/task/componentmanager/errors.go
+++ b/flow/internal/task/componentmanager/errors.go
@@ -87,6 +87,10 @@ var (
 	// type does not support the requested operation capability.
 	ErrUnsupportedCapability = errors.New("component manager capability is not supported")
 
+	// ErrCapabilityInterfaceNotImplemented reports that a manager declares a
+	// capability but does not implement the matching operation interface.
+	ErrCapabilityInterfaceNotImplemented = errors.New("component manager capability interface is not implemented")
+
 	// ErrComponentManagersNotConfigured reports that the service config has no
 	// component manager entries.
 	ErrComponentManagersNotConfigured = cmconfig.ErrComponentManagersNotConfigured
@@ -288,6 +292,27 @@ func (e UnsupportedCapabilityError) Error() string {
 
 func (e UnsupportedCapabilityError) Is(target error) bool {
 	return target == ErrUnsupportedCapability
+}
+
+// CapabilityInterfaceNotImplementedError includes the manager and capability
+// whose descriptor metadata does not match the manager's operation interfaces.
+type CapabilityInterfaceNotImplementedError struct {
+	ComponentType  devicetypes.ComponentType
+	Implementation string
+	Capability     capability.Capability
+}
+
+func (e CapabilityInterfaceNotImplementedError) Error() string {
+	return fmt.Sprintf(
+		"component manager %s/%s declares capability %q but does not implement its operation interface",
+		devicetypes.ComponentTypeToString(e.ComponentType),
+		e.Implementation,
+		e.Capability,
+	)
+}
+
+func (e CapabilityInterfaceNotImplementedError) Is(target error) bool {
+	return target == ErrCapabilityInterfaceNotImplemented
 }
 
 // UnknownProviderError includes the unknown provider name.

--- a/flow/internal/task/componentmanager/manager.go
+++ b/flow/internal/task/componentmanager/manager.go
@@ -15,59 +15,19 @@
  * limitations under the License.
  */
 
+// Package componentmanager defines the manager contracts used to dispatch task
+// operations. Each manager owns its descriptor metadata, which is used by the
+// registry to validate configured implementations and supported capabilities.
 package componentmanager
 
 import (
-	"context"
-
 	cmcatalog "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/catalog"
-	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/executor/temporalworkflow/common"
-	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/operations"
 )
 
-// ComponentManager defines the interface for managing various types of
-// components. Implementations handle component-specific operations like
-// power control, firmware management, and status monitoring.
+// ComponentManager defines the common identity and metadata every component
+// manager must expose. Operation methods live on capability-specific
+// interfaces so managers only implement the operations they support.
 type ComponentManager interface {
 	// Descriptor returns the component manager metadata for this manager.
 	Descriptor() cmcatalog.Descriptor
-
-	// InjectExpectation registers expected component configurations with the
-	// component manager service for the target components.
-	InjectExpectation(ctx context.Context, target common.Target, info operations.InjectExpectationTaskInfo) error //nolint
-
-	// PowerControl applies a power state transition to the target components.
-	PowerControl(ctx context.Context, target common.Target, info operations.PowerControlTaskInfo) error //nolint
-
-	// GetPowerStatus queries the current power state of each component in the
-	// target. Returns a map of component ID to PowerStatus.
-	GetPowerStatus(ctx context.Context, target common.Target) (map[string]operations.PowerStatus, error) //nolint
-
-	// FirmwareControl initiates a firmware update without waiting for completion.
-	// Returns immediately after the update request is accepted.
-	FirmwareControl(ctx context.Context, target common.Target, info operations.FirmwareControlTaskInfo) error //nolint
-
-	// GetFirmwareStatus returns the current firmware update state for each
-	// component in the target. Returns a map of component ID to FirmwareUpdateStatus.
-	GetFirmwareStatus(ctx context.Context, target common.Target) (map[string]operations.FirmwareUpdateStatus, error) //nolint
-}
-
-// BringUpController is an optional interface for component managers that support
-// bring-up operations.
-type BringUpController interface {
-	// BringUpControl opens the power-on gate for the target components, allowing
-	// them to proceed through the bring-up sequence.
-	BringUpControl(ctx context.Context, target common.Target) error
-
-	// GetBringUpStatus returns the current bring-up state for each component in
-	// the target. Returns a map of component ID to MachineBringUpState.
-	GetBringUpStatus(ctx context.Context, target common.Target) (map[string]operations.MachineBringUpState, error)
-}
-
-// FirmwareConsistencyChecker is an optional interface for component managers
-// that can verify firmware version consistency across a set of components.
-type FirmwareConsistencyChecker interface {
-	// VerifyFirmwareConsistency checks that all target components report the same
-	// firmware version set. Returns an error if versions diverge.
-	VerifyFirmwareConsistency(ctx context.Context, target common.Target) error
 }

--- a/flow/internal/task/componentmanager/nvswitch/nico/nico.go
+++ b/flow/internal/task/componentmanager/nvswitch/nico/nico.go
@@ -530,31 +530,3 @@ func aggregateNICoStatuses(compID string, statuses []*pb.FirmwareUpdateStatus) o
 		State:       operations.FirmwareUpdateStateQueued,
 	}
 }
-
-func (m *Manager) BringUpControl(
-	ctx context.Context,
-	target common.Target,
-) error {
-	log.Info().
-		Str("components", target.String()).
-		Msg("NVSwitch BringUpControl: placeholder")
-	return nil
-}
-
-func (m *Manager) GetBringUpStatus(
-	ctx context.Context,
-	target common.Target,
-) (map[string]operations.MachineBringUpState, error) {
-	log.Info().
-		Str("components", target.String()).
-		Msg("NVSwitch GetBringUpStatus: placeholder")
-
-	result := make(
-		map[string]operations.MachineBringUpState,
-		len(target.ComponentIDs),
-	)
-	for _, id := range target.ComponentIDs {
-		result[id] = operations.MachineBringUpStateMachineCreated
-	}
-	return result, nil
-}

--- a/flow/internal/task/componentmanager/nvswitch/nvswitchmanager/nvswitchmanager.go
+++ b/flow/internal/task/componentmanager/nvswitch/nvswitchmanager/nvswitchmanager.go
@@ -94,15 +94,6 @@ func (m *Manager) Descriptor() cmcatalog.Descriptor {
 	return Descriptor()
 }
 
-// InjectExpectation injects expected configuration or state information for an NVLink switch.
-func (m *Manager) InjectExpectation(
-	_ context.Context,
-	_ common.Target,
-	_ operations.InjectExpectationTaskInfo,
-) error {
-	return fmt.Errorf("InjectExpectation not yet implemented for NVSwitch (nvswitchmanager)")
-}
-
 // PowerControl performs power operations on NVLink switches via the NV-Switch Manager API.
 func (m *Manager) PowerControl(
 	ctx context.Context,
@@ -215,16 +206,6 @@ func (m *Manager) FirmwareControl(ctx context.Context, target common.Target, inf
 	}
 
 	return nil
-}
-
-// GetPowerStatus is not currently supported by NV-Switch Manager.
-func (m *Manager) GetPowerStatus(
-	_ context.Context,
-	_ common.Target,
-) (map[string]operations.PowerStatus, error) {
-	return nil, fmt.Errorf(
-		"GetPowerStatus not supported for NV-Switch Manager",
-	)
 }
 
 // GetFirmwareStatus returns the current status of firmware updates for the target components.

--- a/flow/internal/task/componentmanager/operations.go
+++ b/flow/internal/task/componentmanager/operations.go
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package componentmanager
+
+import (
+	"context"
+
+	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/executor/temporalworkflow/common"
+	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/operations"
+)
+
+// Operation interfaces describe the optional callable behaviors behind
+// component manager capabilities. A manager should implement the interface that
+// matches each capability declared by its descriptor.
+
+// ExpectationInjector is implemented by component managers that support
+// registering expected component configuration.
+//
+// Required descriptor capability: capability.CapabilityInjectExpectation.
+type ExpectationInjector interface {
+	// InjectExpectation registers expected component configurations with the
+	// component manager service for the target components.
+	InjectExpectation(ctx context.Context, target common.Target, info operations.InjectExpectationTaskInfo) error //nolint
+}
+
+// PowerController is implemented by component managers that support power
+// state transitions.
+//
+// Required descriptor capability: capability.CapabilityPowerControl.
+type PowerController interface {
+	// PowerControl applies a power state transition to the target components.
+	PowerControl(ctx context.Context, target common.Target, info operations.PowerControlTaskInfo) error //nolint
+}
+
+// PowerStatusReader is implemented by component managers that can report power
+// state.
+//
+// Required descriptor capability: capability.CapabilityPowerStatus.
+type PowerStatusReader interface {
+	// GetPowerStatus queries the current power state of each component in the
+	// target. Returns a map of component ID to PowerStatus.
+	GetPowerStatus(ctx context.Context, target common.Target) (map[string]operations.PowerStatus, error) //nolint
+}
+
+// FirmwareController is implemented by component managers that support
+// initiating firmware operations.
+//
+// Required descriptor capability: capability.CapabilityFirmwareControl.
+type FirmwareController interface {
+	// FirmwareControl initiates a firmware update without waiting for completion.
+	// Returns immediately after the update request is accepted.
+	FirmwareControl(ctx context.Context, target common.Target, info operations.FirmwareControlTaskInfo) error //nolint
+}
+
+// FirmwareStatusReader is implemented by component managers that can report
+// firmware operation state.
+//
+// Required descriptor capability: capability.CapabilityFirmwareStatus.
+type FirmwareStatusReader interface {
+	// GetFirmwareStatus returns the current firmware update state for each
+	// component in the target. Returns a map of component ID to FirmwareUpdateStatus.
+	GetFirmwareStatus(ctx context.Context, target common.Target) (map[string]operations.FirmwareUpdateStatus, error) //nolint
+}
+
+// BringUpController is implemented by component managers that support bring-up
+// control operations.
+//
+// Required descriptor capability: capability.CapabilityBringUpControl.
+type BringUpController interface {
+	// BringUpControl opens the power-on gate for the target components, allowing
+	// them to proceed through the bring-up sequence.
+	BringUpControl(ctx context.Context, target common.Target) error
+}
+
+// BringUpStatusReader is implemented by component managers that can report
+// bring-up state.
+//
+// Required descriptor capability: capability.CapabilityBringUpStatus.
+type BringUpStatusReader interface {
+	// GetBringUpStatus returns the current bring-up state for each component in
+	// the target. Returns a map of component ID to MachineBringUpState.
+	GetBringUpStatus(ctx context.Context, target common.Target) (map[string]operations.MachineBringUpState, error)
+}
+
+// FirmwareConsistencyChecker is an optional interface for component managers
+// that can verify firmware version consistency across a set of components.
+//
+// Required descriptor capability: capability.CapabilityFirmwareConsistencyCheck.
+type FirmwareConsistencyChecker interface {
+	// VerifyFirmwareConsistency checks that all target components report the same
+	// firmware version set. Returns an error if versions diverge.
+	VerifyFirmwareConsistency(ctx context.Context, target common.Target) error
+}

--- a/flow/internal/task/componentmanager/powershelf/nico/nico.go
+++ b/flow/internal/task/componentmanager/powershelf/nico/nico.go
@@ -300,17 +300,3 @@ func (m *Manager) GetFirmwareStatus(
 
 	return result, nil
 }
-
-func (m *Manager) BringUpControl(
-	ctx context.Context,
-	target common.Target,
-) error {
-	return fmt.Errorf("BringUpControl not supported for PowerShelf")
-}
-
-func (m *Manager) GetBringUpStatus(
-	ctx context.Context,
-	target common.Target,
-) (map[string]operations.MachineBringUpState, error) {
-	return nil, fmt.Errorf("GetBringUpStatus not supported for PowerShelf")
-}

--- a/flow/internal/task/componentmanager/test_helpers_test.go
+++ b/flow/internal/task/componentmanager/test_helpers_test.go
@@ -18,62 +18,24 @@
 package componentmanager
 
 import (
-	"context"
-	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/capability"
 	"testing"
 
+	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/capability"
 	cmcatalog "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/catalog"
 	cmconfig "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/config"
 	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/providerapi"
-	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/executor/temporalworkflow/common"
-	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/operations"
 	"github.com/NVIDIA/infra-controller-rest/flow/pkg/common/devicetypes"
 )
 
+// testManager intentionally implements only ComponentManager descriptor
+// metadata. Tests that need operation interfaces should use focused helpers,
+// such as capabilityTestManager or descriptorOnlyManager in activity tests.
 type testManager struct {
 	descriptor cmcatalog.Descriptor
 }
 
 func (m testManager) Descriptor() cmcatalog.Descriptor {
 	return m.descriptor
-}
-
-func (m testManager) InjectExpectation(
-	context.Context,
-	common.Target,
-	operations.InjectExpectationTaskInfo,
-) error {
-	return nil
-}
-
-func (m testManager) PowerControl(
-	context.Context,
-	common.Target,
-	operations.PowerControlTaskInfo,
-) error {
-	return nil
-}
-
-func (m testManager) GetPowerStatus(
-	context.Context,
-	common.Target,
-) (map[string]operations.PowerStatus, error) {
-	return nil, nil
-}
-
-func (m testManager) FirmwareControl(
-	context.Context,
-	common.Target,
-	operations.FirmwareControlTaskInfo,
-) error {
-	return nil
-}
-
-func (m testManager) GetFirmwareStatus(
-	context.Context,
-	common.Target,
-) (map[string]operations.FirmwareUpdateStatus, error) {
-	return nil, nil
 }
 
 func managerFactory(

--- a/flow/internal/task/executor/temporalworkflow/README.md
+++ b/flow/internal/task/executor/temporalworkflow/README.md
@@ -106,6 +106,13 @@ func (i *HealthCheckTaskInfo) Validate() error {
 }
 ```
 
+**4. Define a component-manager capability and operation interface** when the
+operation calls into component managers. Add the capability in
+`componentmanager/capability`, advertise it from descriptors that support the
+operation, and add the matching operation-specific interface in
+`componentmanager`. The activity should check the capability first, then assert
+the interface.
+
 ### Step 1: Define Activity Methods
 
 Add methods to `*Activities` in `activity/activity.go`. Each method performs one unit of work and must be idempotent (Temporal may retry it).
@@ -116,16 +123,19 @@ func (a *Activities) HealthCheck(
     ctx context.Context,
     target common.Target,
 ) (operations.HealthStatus, error) {
-    cm, err := a.validAndGetComponentManager(target)
+    reader, err := a.requireHealthStatusReader(target)
     if err != nil {
         return operations.HealthStatusUnknown, err
     }
-    return cm.HealthCheck(ctx, target)
+
+    return reader.HealthCheck(ctx, target)
 }
 ```
 
 **Key points:**
-- Receiver is `*Activities`; use `a.validAndGetComponentManager` (not a free function)
+- Receiver is `*Activities`; use the typed capability helper (e.g., 
+  `a.requireHealthStatusReader`, `a.requirePowerController`) to obtain the 
+  operation interface before invoking methods
 - First non-receiver parameter is always `context.Context`
 - Activities are retried automatically per the workflow's retry policy
 - Validate inputs; return descriptive errors
@@ -250,11 +260,12 @@ const (
 )
 
 func (a *Activities) HealthCheck(ctx context.Context, target common.Target) (operations.HealthStatus, error) {
-    cm, err := a.validAndGetComponentManager(target)
+    reader, err := a.requireHealthStatusReader(target)
     if err != nil {
         return operations.HealthStatusUnknown, err
     }
-    return cm.HealthCheck(ctx, target)
+
+    return reader.HealthCheck(ctx, target)
 }
 ```
 

--- a/flow/internal/task/executor/temporalworkflow/activity/activity.go
+++ b/flow/internal/task/executor/temporalworkflow/activity/activity.go
@@ -23,8 +23,6 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager"
-	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/capability"
 	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/executor/temporalworkflow/common"
 	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/operations"
 	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/task"
@@ -52,15 +50,12 @@ func (a *Activities) InjectExpectation(
 	target common.Target,
 	info operations.InjectExpectationTaskInfo,
 ) error {
-	cm, err := a.validAndGetComponentManager(
-		target,
-		capability.CapabilityInjectExpectation,
-	)
+	injector, err := requireExpectationInjector(a.registry, target)
 	if err != nil {
 		return err
 	}
 
-	return cm.InjectExpectation(ctx, target, info)
+	return injector.InjectExpectation(ctx, target, info)
 }
 
 // PowerControl is a Temporal activity that applies a power state transition
@@ -70,15 +65,12 @@ func (a *Activities) PowerControl(
 	target common.Target,
 	info operations.PowerControlTaskInfo,
 ) error {
-	cm, err := a.validAndGetComponentManager(
-		target,
-		capability.CapabilityPowerControl,
-	)
+	controller, err := requirePowerController(a.registry, target)
 	if err != nil {
 		return err
 	}
 
-	return cm.PowerControl(ctx, target, info)
+	return controller.PowerControl(ctx, target, info)
 }
 
 // GetPowerStatus is a Temporal activity that queries current power states for
@@ -87,15 +79,12 @@ func (a *Activities) GetPowerStatus(
 	ctx context.Context,
 	target common.Target,
 ) (map[string]operations.PowerStatus, error) {
-	cm, err := a.validAndGetComponentManager(
-		target,
-		capability.CapabilityPowerStatus,
-	)
+	reader, err := requirePowerStatusReader(a.registry, target)
 	if err != nil {
 		return nil, err
 	}
 
-	return cm.GetPowerStatus(ctx, target)
+	return reader.GetPowerStatus(ctx, target)
 }
 
 // UpdateTaskStatus is a Temporal activity that updates task status by ID.
@@ -121,15 +110,12 @@ func (a *Activities) FirmwareControl(
 	target common.Target,
 	info operations.FirmwareControlTaskInfo,
 ) error {
-	cm, err := a.validAndGetComponentManager(
-		target,
-		capability.CapabilityFirmwareControl,
-	)
+	controller, err := requireFirmwareController(a.registry, target)
 	if err != nil {
 		return err
 	}
 
-	return cm.FirmwareControl(ctx, target, info)
+	return controller.FirmwareControl(ctx, target, info)
 }
 
 // GetFirmwareStatusResult is the result of GetFirmwareStatus activity.
@@ -144,15 +130,12 @@ func (a *Activities) GetFirmwareStatus(
 	ctx context.Context,
 	target common.Target,
 ) (*GetFirmwareStatusResult, error) {
-	cm, err := a.validAndGetComponentManager(
-		target,
-		capability.CapabilityFirmwareStatus,
-	)
+	reader, err := requireFirmwareStatusReader(a.registry, target)
 	if err != nil {
 		return nil, err
 	}
 
-	statuses, err := cm.GetFirmwareStatus(ctx, target)
+	statuses, err := reader.GetFirmwareStatus(ctx, target)
 	if err != nil {
 		return nil, err
 	}
@@ -165,20 +148,12 @@ func (a *Activities) BringUpControl(
 	ctx context.Context,
 	target common.Target,
 ) error {
-	cm, err := a.validAndGetComponentManager(
-		target,
-		capability.CapabilityBringUpControl,
-	)
+	controller, err := requireBringUpController(a.registry, target)
 	if err != nil {
 		return err
 	}
 
-	buc, ok := cm.(componentmanager.BringUpController)
-	if !ok {
-		return fmt.Errorf("component manager for %s does not support BringUpControl", target.Type)
-	}
-
-	return buc.BringUpControl(ctx, target)
+	return controller.BringUpControl(ctx, target)
 }
 
 // GetBringUpStatusResult is the result of GetBringUpStatus activity.
@@ -192,20 +167,12 @@ func (a *Activities) GetBringUpStatus(
 	ctx context.Context,
 	target common.Target,
 ) (*GetBringUpStatusResult, error) {
-	cm, err := a.validAndGetComponentManager(
-		target,
-		capability.CapabilityBringUpStatus,
-	)
+	reader, err := requireBringUpStatusReader(a.registry, target)
 	if err != nil {
 		return nil, err
 	}
 
-	buc, ok := cm.(componentmanager.BringUpController)
-	if !ok {
-		return nil, fmt.Errorf("component manager for %s does not support GetBringUpStatus", target.Type)
-	}
-
-	states, err := buc.GetBringUpStatus(ctx, target)
+	states, err := reader.GetBringUpStatus(ctx, target)
 	if err != nil {
 		return nil, err
 	}
@@ -220,33 +187,10 @@ func (a *Activities) VerifyFirmwareConsistency(
 	ctx context.Context,
 	target common.Target,
 ) error {
-	cm, err := a.validAndGetComponentManager(
-		target,
-		capability.CapabilityFirmwareConsistencyCheck,
-	)
+	checker, err := requireFirmwareConsistencyChecker(a.registry, target)
 	if err != nil {
 		return err
 	}
 
-	checker, ok := cm.(componentmanager.FirmwareConsistencyChecker)
-	if !ok {
-		return fmt.Errorf("component manager for %s does not support firmware consistency check",
-			target.Type)
-	}
-
 	return checker.VerifyFirmwareConsistency(ctx, target)
-}
-
-// validAndGetComponentManager validates the target and returns the component
-// manager registered for its type. Returns an error if the target is invalid
-// or no manager is found.
-func (a *Activities) validAndGetComponentManager(
-	target common.Target,
-	capability capability.Capability,
-) (componentmanager.ComponentManager, error) {
-	if err := target.Validate(); err != nil {
-		return nil, fmt.Errorf("target is invalid: %w", err)
-	}
-
-	return a.registry.GetCapableManager(target.Type, capability)
 }

--- a/flow/internal/task/executor/temporalworkflow/activity/activity_test.go
+++ b/flow/internal/task/executor/temporalworkflow/activity/activity_test.go
@@ -97,6 +97,27 @@ func TestActivityCallsManagerWhenCapabilityIsSupported(t *testing.T) {
 	require.True(t, manager.called)
 }
 
+func TestActivityRequiresOperationInterfaceAfterCapabilityValidation(t *testing.T) {
+	acts := newDescriptorOnlyActivities(
+		t,
+		capability.CapabilityPowerStatus,
+	)
+
+	_, err := acts.GetPowerStatus(
+		context.Background(),
+		newActivityTestTarget(),
+	)
+
+	require.Error(t, err)
+	require.False(t, errors.Is(err, componentmanager.ErrUnsupportedCapability))
+	require.True(t, errors.Is(err, componentmanager.ErrCapabilityInterfaceNotImplemented))
+	require.ErrorContains(
+		t,
+		err,
+		`declares capability "PowerStatus" but does not implement its operation interface`,
+	)
+}
+
 func activityCallsForMissingManagerTest(
 	t *testing.T,
 	acts *Activities,
@@ -293,6 +314,48 @@ func newCapabilityTestActivities(
 	require.NoError(t, err)
 
 	return New(nil, registry), manager
+}
+
+type descriptorOnlyManager struct {
+	descriptor cmcatalog.Descriptor
+}
+
+func (m descriptorOnlyManager) Descriptor() cmcatalog.Descriptor {
+	return m.descriptor
+}
+
+func newDescriptorOnlyActivities(
+	t *testing.T,
+	capabilities ...capability.Capability,
+) *Activities {
+	t.Helper()
+
+	descriptor := cmcatalog.Descriptor{
+		Type:           devicetypes.ComponentTypeCompute,
+		Implementation: "descriptor-only",
+		Capabilities:   capability.CapabilitySet(capabilities),
+	}
+	registry, err := componentmanager.NewRegistry(
+		[]componentmanager.FactorySpec{
+			{
+				Descriptor: descriptor,
+				Factory: func(
+					*providerapi.ProviderRegistry,
+				) (componentmanager.ComponentManager, error) {
+					return descriptorOnlyManager{descriptor: descriptor}, nil
+				},
+			},
+		},
+		cmconfig.Config{
+			ComponentManagers: map[devicetypes.ComponentType]string{
+				devicetypes.ComponentTypeCompute: "descriptor-only",
+			},
+		},
+		providerapi.NewProviderRegistry(),
+	)
+	require.NoError(t, err)
+
+	return New(nil, registry)
 }
 
 func newActivityTestTarget() common.Target {

--- a/flow/internal/task/executor/temporalworkflow/activity/capable_manager.go
+++ b/flow/internal/task/executor/temporalworkflow/activity/capable_manager.go
@@ -1,0 +1,173 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package activity
+
+import (
+	"fmt"
+
+	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager"
+	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/capability"
+	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/executor/temporalworkflow/common"
+)
+
+// Activity implementations use these helpers to bridge descriptor-level
+// capability validation and Go's operation-specific manager interfaces. The
+// registry verifies that the selected manager declares the capability, and the
+// typed wrappers verify that the implementation also satisfies the matching
+// interface before an operation is dispatched.
+
+// requireCapableManager validates the target, finds a manager that declares
+// the required capability, and returns it as the operation interface expected
+// by the caller.
+func requireCapableManager[T any](
+	registry *componentmanager.Registry,
+	target common.Target,
+	requiredCapability capability.Capability,
+) (T, error) {
+	var zero T
+
+	err := target.Validate()
+	if err != nil {
+		return zero, fmt.Errorf("target is invalid: %w", err)
+	}
+
+	// Registry owns nil-receiver handling so all manager lookups return the
+	// same configuration error when no registry is available.
+	cm, err := registry.GetCapableManager(target.Type, requiredCapability)
+	if err != nil {
+		return zero, err
+	}
+
+	// Capability metadata is validated before dispatch; this assertion catches
+	// implementation bugs where the descriptor and Go interface drift apart.
+	typedManager, ok := cm.(T)
+	if !ok {
+		descriptor := cm.Descriptor()
+		return zero, componentmanager.CapabilityInterfaceNotImplementedError{
+			ComponentType:  descriptor.Type,
+			Implementation: descriptor.Implementation,
+			Capability:     requiredCapability,
+		}
+	}
+
+	return typedManager, nil
+}
+
+// requireExpectationInjector returns the manager interface for expectation
+// injection operations.
+func requireExpectationInjector(
+	registry *componentmanager.Registry,
+	target common.Target,
+) (componentmanager.ExpectationInjector, error) {
+	return requireCapableManager[componentmanager.ExpectationInjector](
+		registry,
+		target,
+		capability.CapabilityInjectExpectation,
+	)
+}
+
+// requirePowerController returns the manager interface for power control
+// operations.
+func requirePowerController(
+	registry *componentmanager.Registry,
+	target common.Target,
+) (componentmanager.PowerController, error) {
+	return requireCapableManager[componentmanager.PowerController](
+		registry,
+		target,
+		capability.CapabilityPowerControl,
+	)
+}
+
+// requirePowerStatusReader returns the manager interface for power status
+// reads.
+func requirePowerStatusReader(
+	registry *componentmanager.Registry,
+	target common.Target,
+) (componentmanager.PowerStatusReader, error) {
+	return requireCapableManager[componentmanager.PowerStatusReader](
+		registry,
+		target,
+		capability.CapabilityPowerStatus,
+	)
+}
+
+// requireFirmwareController returns the manager interface for firmware control
+// operations.
+func requireFirmwareController(
+	registry *componentmanager.Registry,
+	target common.Target,
+) (componentmanager.FirmwareController, error) {
+	return requireCapableManager[componentmanager.FirmwareController](
+		registry,
+		target,
+		capability.CapabilityFirmwareControl,
+	)
+}
+
+// requireFirmwareStatusReader returns the manager interface for firmware
+// status reads.
+func requireFirmwareStatusReader(
+	registry *componentmanager.Registry,
+	target common.Target,
+) (componentmanager.FirmwareStatusReader, error) {
+	return requireCapableManager[componentmanager.FirmwareStatusReader](
+		registry,
+		target,
+		capability.CapabilityFirmwareStatus,
+	)
+}
+
+// requireBringUpController returns the manager interface for bring-up control
+// operations.
+func requireBringUpController(
+	registry *componentmanager.Registry,
+	target common.Target,
+) (componentmanager.BringUpController, error) {
+	return requireCapableManager[componentmanager.BringUpController](
+		registry,
+		target,
+		capability.CapabilityBringUpControl,
+	)
+}
+
+// requireBringUpStatusReader returns the manager interface for bring-up status
+// reads.
+func requireBringUpStatusReader(
+	registry *componentmanager.Registry,
+	target common.Target,
+) (componentmanager.BringUpStatusReader, error) {
+	return requireCapableManager[componentmanager.BringUpStatusReader](
+		registry,
+		target,
+		capability.CapabilityBringUpStatus,
+	)
+}
+
+// requireFirmwareConsistencyChecker returns the manager interface for firmware
+// consistency checks.
+func requireFirmwareConsistencyChecker(
+	registry *componentmanager.Registry,
+	target common.Target,
+) (componentmanager.FirmwareConsistencyChecker, error) {
+	return requireCapableManager[componentmanager.FirmwareConsistencyChecker](
+		registry,
+		target,
+		capability.CapabilityFirmwareConsistencyCheck,
+	)
+}

--- a/flow/internal/task/executor/temporalworkflow/activity/registry_test.go
+++ b/flow/internal/task/executor/temporalworkflow/activity/registry_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager"
-	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/capability"
 )
 
 // TestActivities_All_ContainsAllActivities verifies that All() returns every
@@ -80,13 +79,12 @@ func TestActivities_Isolation(t *testing.T) {
 	assert.NotContains(t, m2, "isolation-sentinel", "mutations to one instance's map must not bleed into another instance's map")
 }
 
-// TestActivities_ValidAndGetComponentManager_NilRegistry verifies that manager
-// lookup returns a clear configuration error when no registry is configured.
-func TestActivities_ValidAndGetComponentManager_NilRegistry(t *testing.T) {
-	acts := New(nil, nil)
-	_, err := acts.validAndGetComponentManager(
+// TestRequireCapableManager_NilRegistry verifies that manager lookup returns a
+// clear configuration error when no registry is configured.
+func TestRequireCapableManager_NilRegistry(t *testing.T) {
+	_, err := requirePowerController(
+		nil,
 		newActivityTestTarget(),
-		capability.CapabilityPowerControl,
 	)
 	assert.Error(t, err)
 	assert.True(t, errors.Is(err, componentmanager.ErrRegistryNotConfigured))

--- a/flow/internal/task/executor/temporalworkflow/manager/pre_dispatch_validation_test.go
+++ b/flow/internal/task/executor/temporalworkflow/manager/pre_dispatch_validation_test.go
@@ -32,7 +32,6 @@ import (
 	cmcatalog "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/catalog"
 	cmconfig "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/config"
 	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/providerapi"
-	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/executor/temporalworkflow/common"
 	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/operationrules"
 	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/operations"
 	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/task"
@@ -137,44 +136,6 @@ type preflightCapabilityManager struct {
 
 func (m preflightCapabilityManager) Descriptor() cmcatalog.Descriptor {
 	return m.descriptor
-}
-
-func (m preflightCapabilityManager) InjectExpectation(
-	context.Context,
-	common.Target,
-	operations.InjectExpectationTaskInfo,
-) error {
-	return nil
-}
-
-func (m preflightCapabilityManager) PowerControl(
-	context.Context,
-	common.Target,
-	operations.PowerControlTaskInfo,
-) error {
-	return nil
-}
-
-func (m preflightCapabilityManager) GetPowerStatus(
-	context.Context,
-	common.Target,
-) (map[string]operations.PowerStatus, error) {
-	return nil, nil
-}
-
-func (m preflightCapabilityManager) FirmwareControl(
-	context.Context,
-	common.Target,
-	operations.FirmwareControlTaskInfo,
-) error {
-	return nil
-}
-
-func (m preflightCapabilityManager) GetFirmwareStatus(
-	context.Context,
-	common.Target,
-) (map[string]operations.FirmwareUpdateStatus, error) {
-	return nil, nil
 }
 
 func newPreflightCapabilityRegistry(


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
- Keep the base ComponentManager contract focused on descriptor metadata and move capability-backed operation methods behind dedicated interfaces.
- Route Temporal activities through typed capability helpers so dispatch validates both descriptor capabilities and matching Go operation interfaces before invoking managers.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [x] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [ ] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [x] **Flow** - Flow service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
