### PR TITLE
docs: Add Core compatibility matrix, image rename & repo migration notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Each release lists pull requests grouped by category, with the most recent versi
 > [!NOTE]
 > This release is compatible with Core **v0.9.x**.
 
+> [!IMPORTANT]
+> In our effort to unify the product name, starting from `v1.5.0` the image names are now prefixed with `nico-` instead of `carbide-`. Docker images produced by the make commands will now have the `nico-` prefix.
+
 ### Features
 - **Rename carbide/forge to NVIDIA Infrastructure Controller (NICo)** ([#432](https://github.com/NVIDIA/infra-controller-rest/pull/432))
   Comprehensive rebranding of the project from Carbide/Forge to NVIDIA Infrastructure Controller (NICo). All API path segments, CLI binary names, Helm chart names, configuration keys, and documentation are updated. The OpenAPI schema now uses the NICo naming throughout — see the updated [API reference](https://nvidia.github.io/infra-controller-rest/).

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ The REST layer can be deployed in the datacenter with NVIDIA Infrastructure Cont
 
 View latest OpenAPI schema on [GitHub pages](https://nvidia.github.io/infra-controller-rest/).
 
+> [!IMPORTANT]
+> To ensure a unified entry point to the NVIDIA Infra Controller, the REST API repo is being merged into the [infra-controller](https://github.com/NVIDIA/infra-controller) repo under `rest-api` directory. This transition will be completed on June 2nd, 2026.
+
 ## Prerequisites
 
 - Go 1.25.4 or later
@@ -21,6 +24,16 @@ View latest OpenAPI schema on [GitHub pages](https://nvidia.github.io/infra-cont
 - [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (for local deployment)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) (for local deployment)
 - [jq](https://stedolan.github.io/jq/) (optional, for parsing JSON responses)
+
+## Core Compatibility Matrix
+
+| NICo REST Version | NICo Core Version |
+|------------------|------------------|
+| v1.5.x           | v0.9.x           |
+| v1.4.x           | v0.8.x           |
+| v1.3.x           | v0.7.x           |
+
+Versions older than v1.3.0 are no longer supported.
 
 ## Quick Start
 


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
- Starting from `v1.5.x` images produced by REST repo have a `nico-` prefix instead of `carbide-`
- REST repo is migrating to be in the primary repo
- Adding higehr visibility for REST/Core compatibility

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Docs** - Changes in documentation or OpenAPI schema (docs:)

## Services Affected
<!-- Check one or more if appropriate -->
None

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->
https://github.com/NVIDIA/infra-controller/issues/1890

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
None