### PR TITLE
fix: Create status detail for Instance when online repair is enabled/disabled for Machine 

### DIFF
--- a/api/pkg/api/handler/machine.go
+++ b/api/pkg/api/handler/machine.go
@@ -1467,9 +1467,17 @@ func (umh UpdateMachineHandler) Handle(c echo.Context) error {
 				logger.Info().Str("Workflow ID", wid).Msg("completed synchronous applying online repair health override workflow")
 			} else {
 				// Validate if Instance is in Repairing state, has the online repair marker label, or the Machine health includes the online repair health alert
-				_, hasOnlineRepairMarker := inst.Labels[model.InstanceLabelOnlineRepairAllowAutoDeletion]
-				hasOnlineRepairHealthAlert := common.MachineReportsOnlineRepairHealthAlert(machine)
-				if inst.Status != cdbm.InstanceStatusRepairing && !hasOnlineRepairMarker && !hasOnlineRepairHealthAlert {
+				_, hasOnlineRepairLabel := inst.Labels[model.InstanceLabelOnlineRepairAllowAutoDeletion]
+
+				// Check if Machine health includes the online repair health alert
+				hasOnlineRepairHealthAlert := false
+				health, err := machine.GetHealth()
+				if err == nil && health != nil {
+					hasOnlineRepairHealthAlert = health.HasAlertID(model.MachineHealthAlertIDOnlineRepair)
+				}
+
+				// Validate if Instance is in Repairing state, has the online repair marker label, or the Machine health includes the online repair health alert
+				if inst.Status != cdbm.InstanceStatusRepairing && !hasOnlineRepairLabel && !hasOnlineRepairHealthAlert {
 					return cutil.NewAPIError(http.StatusBadRequest, fmt.Sprintf(
 						"Instance must be in Repairing state, retain the online repair marker label (%s), or the Machine health must include the %s alert (synced from Site) to exit online repair (current instance state: %s)",
 						model.InstanceLabelOnlineRepairAllowAutoDeletion, model.MachineHealthAlertIDOnlineRepair, inst.Status), nil)

--- a/api/pkg/api/handler/machine.go
+++ b/api/pkg/api/handler/machine.go
@@ -19,6 +19,7 @@ package handler
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1361,6 +1362,8 @@ func (umh UpdateMachineHandler) Handle(c echo.Context) error {
 
 	// Enter or exit in-pool online repair (Site health override + Instance status / labels in Cloud DB)
 	if apiRequest.IsOnlineRepair() {
+		statusDetailDAO := cdbm.NewStatusDetailDAO(umh.dbSession)
+
 		// Validate if user has permission to enter/exit online repair mode for this Machine
 		if !isOwnerProvider && !isPrivilegedTenant {
 			return cutil.NewAPIErrorResponse(c, http.StatusForbidden, "User does not have permission to enter/exit online repair mode for this Machine", nil)
@@ -1374,167 +1377,167 @@ func (umh UpdateMachineHandler) Handle(c echo.Context) error {
 			return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "Machine must have an assigned Instance for online repair", nil)
 		}
 
-		// timeoutResp lets the closure signal a post-rollback handler — the
-		// TerminateWorkflow call has to run after the closure returns so that
-		// the DB tx unwinds before we make the second remote call. nil means
-		// no timeout occurred and the normal flow continues.
-		var timeoutResp func() error
+		orTx, err := cdb.BeginTx(ctx, umh.dbSession, &sql.TxOptions{})
+		if err != nil {
+			logger.Error().Err(err).Msg("unable to start transaction")
+			return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Error updating machine", nil)
+		}
+		orTxCommitted := false
+		defer common.RollbackTx(ctx, orTx, &orTxCommitted)
 
-		err := cdb.WithTx(ctx, umh.dbSession, func(orTx *cdb.Tx) error {
-			iDAO := cdbm.NewInstanceDAO(umh.dbSession)
-			instances, _, derr := iDAO.GetAll(ctx, orTx, cdbm.InstanceFilterInput{MachineIDs: []string{machine.ID}}, cdbp.PageInput{Limit: cdb.GetIntPtr(1)}, nil)
-			if derr != nil {
-				logger.Error().Err(derr).Msg("error retrieving Instance for Machine")
-				return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve Instance for Machine", nil)
+		iDAO := cdbm.NewInstanceDAO(umh.dbSession)
+		instances, _, ierr := iDAO.GetAll(ctx, orTx, cdbm.InstanceFilterInput{MachineIDs: []string{machine.ID}}, cdbp.PageInput{Limit: cdb.GetIntPtr(1)}, nil)
+		if ierr != nil {
+			logger.Error().Err(ierr).Msg("error retrieving Instance for Machine")
+			return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve Instance for Machine", nil)
+		}
+		if len(instances) == 0 {
+			return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "Machine must have an assigned Instance for online repair", nil)
+		}
+		inst := instances[0]
+
+		if apiRequest.OnlineRepairEnabled() {
+			if inst.Status != cdbm.InstanceStatusReady {
+				return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, fmt.Sprintf("Instance must be in Ready state to enter online repair (current state: %s)", inst.Status), nil)
 			}
-			if len(instances) == 0 {
-				return cutil.NewAPIError(http.StatusBadRequest, "Machine must have an assigned Instance for online repair", nil)
+
+			insReq, ierr := apiRequest.ToInsertHealthReportOverrideProto(machine.ID)
+			if ierr != nil {
+				logger.Error().Err(ierr).Msg("failed to build online repair health override request")
+				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to build online repair request", nil)
 			}
-			inst := instances[0]
 
-			if apiRequest.OnlineRepairEnabled() {
-				if inst.Status != cdbm.InstanceStatusReady {
-					return cutil.NewAPIError(http.StatusBadRequest, fmt.Sprintf("Instance must be in Ready state to enter online repair (current state: %s)", inst.Status), nil)
-				}
+			instanceLabels := maps.Clone(inst.Labels)
+			if instanceLabels == nil {
+				instanceLabels = map[string]string{}
+			}
 
-				insReq, perr := apiRequest.ToInsertHealthReportOverrideProto(machine.ID)
-				if perr != nil {
-					logger.Error().Err(perr).Msg("failed to build online repair health override request")
-					return cutil.NewAPIError(http.StatusInternalServerError, "Failed to build online repair request", nil)
-				}
-
-				instanceLabels := maps.Clone(inst.Labels)
-				if instanceLabels == nil {
-					instanceLabels = map[string]string{}
-				}
-
-				if *apiRequest.OnlineRepair.Policy.AllowAutoInstanceDeletionOnFailure {
-					instanceLabels[model.InstanceLabelOnlineRepairAllowAutoDeletion] = "true"
-				} else {
-					instanceLabels[model.InstanceLabelOnlineRepairAllowAutoDeletion] = "false"
-				}
-
-				_, derr = iDAO.Update(ctx, orTx, cdbm.InstanceUpdateInput{
-					InstanceID: inst.ID,
-					Status:     cdb.GetStrPtr(cdbm.InstanceStatusRepairing),
-					Labels:     instanceLabels,
-				})
-				if derr != nil {
-					logger.Error().Err(derr).Msg("error updating Instance for online repair in DB")
-					return cutil.NewAPIError(http.StatusInternalServerError, "Failed to update Instance for online repair", nil)
-				}
-
-				wfOpts := temporalClient.StartWorkflowOptions{
-					ID:                       "site-machine-online-repair-" + machine.ID,
-					WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
-					TaskQueue:                queue.SiteTaskQueue,
-				}
-
-				wfCtx, wfCancel := context.WithTimeout(ctx, cutil.WorkflowContextTimeout)
-				defer wfCancel()
-
-				we, wferr := stc.ExecuteWorkflow(wfCtx, wfOpts, "CreateMachineHealthReportOverride", insReq)
-				if wferr != nil {
-					logger.Error().Err(wferr).Msg("failed to start Temporal workflow for applying online repair health override")
-					return cutil.NewAPIError(http.StatusInternalServerError, fmt.Sprintf("Failed to start applying online repair health override workflow on Site: %s", wferr), nil)
-				}
-				wid := we.GetID()
-				logger.Info().Str("Workflow ID", wid).Msg("executed synchronous applying online repair health override workflow")
-				wferr = we.Get(wfCtx, nil)
-				if wferr != nil {
-					var timeoutErr *tp.TimeoutError
-					if errors.As(wferr, &timeoutErr) || wferr == context.DeadlineExceeded || wfCtx.Err() != nil || ctx.Err() != nil {
-						logger.Error().Err(wferr).Msg("failed to apply online repair health override, timeout occurred executing workflow on Site.")
-						timeoutCause := wferr // explicit capture; defensive against future refactors
-						timeoutResp = func() error {
-							return common.TerminateWorkflowOnTimeOut(c, logger, stc, wid, timeoutCause, "Machine", "CreateMachineHealthReportOverride")
-						}
-						return cutil.NewAPIError(http.StatusInternalServerError, "Applying online repair health override workflow timed out", nil)
-					}
-					code, werr := common.UnwrapWorkflowError(wferr)
-					logger.Error().Err(werr).Msg("applying online repair health override workflow failed")
-					return cutil.NewAPIError(code, fmt.Sprintf("Failed to execute applying online repair health override workflow on Site: %s", werr), nil)
-				}
-				logger.Info().Str("Workflow ID", wid).Msg("completed synchronous applying online repair health override workflow")
+			if *apiRequest.OnlineRepair.Policy.AllowAutoInstanceDeletionOnFailure {
+				instanceLabels[model.InstanceLabelOnlineRepairAllowAutoDeletion] = "true"
 			} else {
-				if inst.Status != cdbm.InstanceStatusRepairing {
-					return cutil.NewAPIError(http.StatusBadRequest, fmt.Sprintf("Instance must be in Repairing state to exit online repair (current state: %s)", inst.Status), nil)
-				}
-
-				instanceLabels := maps.Clone(inst.Labels)
-				if instanceLabels == nil {
-					instanceLabels = map[string]string{}
-				}
-
-				delete(instanceLabels, model.InstanceLabelOnlineRepairAllowAutoDeletion)
-
-				_, derr = iDAO.Update(ctx, orTx, cdbm.InstanceUpdateInput{
-					InstanceID: inst.ID,
-					Status:     cdb.GetStrPtr(cdbm.InstanceStatusReady),
-					Labels:     instanceLabels,
-				})
-				if derr != nil {
-					logger.Error().Err(derr).Msg("error updating Instance after clearing online repair in DB")
-					return cutil.NewAPIError(http.StatusInternalServerError, "Failed to update Instance after clearing online repair", nil)
-				}
-
-				rmReq, perr := apiRequest.ToRemoveHealthReportOverrideProto(machine.ID)
-				if perr != nil {
-					logger.Error().Err(perr).Msg("failed to build remove online repair health override request")
-					return cutil.NewAPIError(http.StatusInternalServerError, "Failed to build remove online repair request", nil)
-				}
-
-				wfOpts := temporalClient.StartWorkflowOptions{
-					ID:                       "site-clear-machine-online-repair-" + machine.ID,
-					WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
-					TaskQueue:                queue.SiteTaskQueue,
-				}
-
-				wfCtx, wfCancel := context.WithTimeout(ctx, cutil.WorkflowContextTimeout)
-				defer wfCancel()
-
-				we, wferr := stc.ExecuteWorkflow(wfCtx, wfOpts, "DeleteMachineHealthReportOverride", rmReq)
-				if wferr != nil {
-					logger.Error().Err(wferr).Msg("failed to start Temporal workflow to clear online repair health override")
-					return cutil.NewAPIError(http.StatusInternalServerError, fmt.Sprintf("Failed to start clear online repair workflow on Site: %s", wferr), nil)
-				}
-				wid := we.GetID()
-				logger.Info().Str("Workflow ID", wid).Msg("executed synchronous DeleteMachineHealthReportOverride workflow")
-				wferr = we.Get(wfCtx, nil)
-				if wferr != nil {
-					var timeoutErr *tp.TimeoutError
-					if errors.As(wferr, &timeoutErr) || wferr == context.DeadlineExceeded || wfCtx.Err() != nil || ctx.Err() != nil {
-						logger.Error().Err(wferr).Msg("failed to clear online repair health override, timeout occurred executing workflow on Site.")
-						timeoutCause := wferr // explicit capture; defensive against future refactors
-						timeoutResp = func() error {
-							return common.TerminateWorkflowOnTimeOut(c, logger, stc, wid, timeoutCause, "Machine", "DeleteMachineHealthReportOverride")
-						}
-						return cutil.NewAPIError(http.StatusInternalServerError, "Clear online repair workflow timed out", nil)
-					}
-					code, werr := common.UnwrapWorkflowError(wferr)
-					logger.Error().Err(werr).Msg("clear online repair health override workflow failed")
-					return cutil.NewAPIError(code, fmt.Sprintf("Failed to execute clear online repair workflow on Site: %s", werr), nil)
-				}
-				logger.Info().Str("Workflow ID", wid).Msg("completed synchronous DeleteMachineHealthReportOverride workflow")
+				instanceLabels[model.InstanceLabelOnlineRepairAllowAutoDeletion] = "false"
 			}
 
-			return nil
-		})
-		// Surface real tx-helper errors first so they aren't masked by the
-		// timeout response (commit/rollback failures wrap into something other
-		// than the cutil.APIError marker we returned for the timeout case).
-		if err != nil {
-			var apiErr *cutil.APIError
-			if !errors.As(err, &apiErr) {
-				return common.HandleTxError(c, logger, err, "Failed to update Machine, DB transaction error")
+			_, err = iDAO.Update(ctx, orTx, cdbm.InstanceUpdateInput{
+				InstanceID: inst.ID,
+				Status:     cdb.GetStrPtr(cdbm.InstanceStatusRepairing),
+				Labels:     instanceLabels,
+			})
+			if err != nil {
+				logger.Error().Err(err).Msg("error updating Instance for online repair in DB")
+				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to update Instance for online repair", nil)
 			}
+
+			// Update Instance status in StatusDetail
+			_, err = statusDetailDAO.CreateFromParams(ctx, orTx, inst.ID.String(), cdbm.InstanceStatusRepairing, cdb.GetStrPtr("Instance is currently being repaired"))
+			if err != nil {
+				logger.Error().Err(err).Msg("error updating Instance status in StatusDetail in DB")
+				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to update Instance status in StatusDetail", nil)
+			}
+
+			wfOpts := temporalClient.StartWorkflowOptions{
+				ID:                       "site-machine-online-repair-" + machine.ID,
+				WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
+				TaskQueue:                queue.SiteTaskQueue,
+			}
+
+			wfCtx, wfCancel := context.WithTimeout(ctx, cutil.WorkflowContextTimeout)
+			defer wfCancel()
+
+			we, err := stc.ExecuteWorkflow(wfCtx, wfOpts, "CreateMachineHealthReportOverride", insReq)
+			if err != nil {
+				logger.Error().Err(err).Msg("failed to start Temporal workflow for applying online repair health override")
+				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("Failed to start applying online repair health override workflow on Site: %s", err), nil)
+			}
+			wid := we.GetID()
+			logger.Info().Str("Workflow ID", wid).Msg("executed synchronous applying online repair health override workflow")
+			err = we.Get(wfCtx, nil)
+			if err != nil {
+				var timeoutErr *tp.TimeoutError
+				if errors.As(err, &timeoutErr) || err == context.DeadlineExceeded || wfCtx.Err() != nil || ctx.Err() != nil {
+					return common.TerminateWorkflowOnTimeOut(c, logger, stc, wid, err, "Machine", "CreateMachineHealthReportOverride")
+				}
+				code, werr := common.UnwrapWorkflowError(err)
+				logger.Error().Err(werr).Msg("applying online repair health override workflow failed")
+				return cutil.NewAPIErrorResponse(c, code, fmt.Sprintf("Failed to execute applying online repair health override workflow on Site: %s", werr), nil)
+			}
+			logger.Info().Str("Workflow ID", wid).Msg("completed synchronous applying online repair health override workflow")
+		} else {
+			_, hasOnlineRepairMarker := inst.Labels[model.InstanceLabelOnlineRepairAllowAutoDeletion]
+			hasOnlineRepairHealthAlert := common.MachineReportsOnlineRepairHealthAlert(machine)
+			if inst.Status != cdbm.InstanceStatusRepairing && !hasOnlineRepairMarker && !hasOnlineRepairHealthAlert {
+				return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, fmt.Sprintf(
+					"Instance must be in Repairing state, retain the online repair marker label (%s), or the Machine health must include the %s alert (synced from Site) to exit online repair (current instance state: %s)",
+					model.InstanceLabelOnlineRepairAllowAutoDeletion, model.MachineHealthAlertIDOnlineRepair, inst.Status), nil)
+			}
+
+			instanceLabels := maps.Clone(inst.Labels)
+			if instanceLabels == nil {
+				instanceLabels = map[string]string{}
+			}
+
+			delete(instanceLabels, model.InstanceLabelOnlineRepairAllowAutoDeletion)
+
+			_, err = iDAO.Update(ctx, orTx, cdbm.InstanceUpdateInput{
+				InstanceID: inst.ID,
+				Status:     cdb.GetStrPtr(cdbm.InstanceStatusReady),
+				Labels:     instanceLabels,
+			})
+			if err != nil {
+				logger.Error().Err(err).Msg("error updating Instance after clearing online repair in DB")
+				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to update Instance after clearing online repair", nil)
+			}
+
+			// Update Instance status in StatusDetail
+			_, err = statusDetailDAO.CreateFromParams(ctx, orTx, inst.ID.String(), cdbm.InstanceStatusReady, cdb.GetStrPtr("Instance repair has been completed, ready for use"))
+			if err != nil {
+				logger.Error().Err(err).Msg("error updating Instance status in StatusDetail in DB")
+				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to update Instance status in StatusDetail", nil)
+			}
+
+			// Remove health report override on Site
+			rmReq, err := apiRequest.ToRemoveHealthReportOverrideProto(machine.ID)
+			if err != nil {
+				logger.Error().Err(err).Msg("failed to build remove online repair health override request")
+				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to build remove online repair request", nil)
+			}
+
+			wfOpts := temporalClient.StartWorkflowOptions{
+				ID:                       "site-clear-machine-online-repair-" + machine.ID,
+				WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
+				TaskQueue:                queue.SiteTaskQueue,
+			}
+
+			wfCtx, wfCancel := context.WithTimeout(ctx, cutil.WorkflowContextTimeout)
+			defer wfCancel()
+
+			we, err := stc.ExecuteWorkflow(wfCtx, wfOpts, "DeleteMachineHealthReportOverride", rmReq)
+			if err != nil {
+				logger.Error().Err(err).Msg("failed to start Temporal workflow to clear online repair health override")
+				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("Failed to start clear online repair workflow on Site: %s", err), nil)
+			}
+			wid := we.GetID()
+			logger.Info().Str("Workflow ID", wid).Msg("executed synchronous DeleteMachineHealthReportOverride workflow")
+			err = we.Get(wfCtx, nil)
+			if err != nil {
+				var timeoutErr *tp.TimeoutError
+				if errors.As(err, &timeoutErr) || err == context.DeadlineExceeded || wfCtx.Err() != nil || ctx.Err() != nil {
+					return common.TerminateWorkflowOnTimeOut(c, logger, stc, wid, err, "Machine", "DeleteMachineHealthReportOverride")
+				}
+				code, werr := common.UnwrapWorkflowError(err)
+				logger.Error().Err(werr).Msg("clear online repair health override workflow failed")
+				return cutil.NewAPIErrorResponse(c, code, fmt.Sprintf("Failed to execute clear online repair workflow on Site: %s", werr), nil)
+			}
+			logger.Info().Str("Workflow ID", wid).Msg("completed synchronous DeleteMachineHealthReportOverride workflow")
 		}
-		if timeoutResp != nil {
-			return timeoutResp()
-		}
+
+		err = orTx.Commit()
 		if err != nil {
-			return common.HandleTxError(c, logger, err, "Failed to update Machine, DB transaction error")
+			logger.Error().Err(err).Msg("error committing transaction")
+			return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to update Machine, DB transaction error", nil)
 		}
+		orTxCommitted = true
+		um = machine
 	}
 
 	// Create response

--- a/api/pkg/api/handler/machine.go
+++ b/api/pkg/api/handler/machine.go
@@ -19,7 +19,6 @@ package handler
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1362,8 +1361,6 @@ func (umh UpdateMachineHandler) Handle(c echo.Context) error {
 
 	// Enter or exit in-pool online repair (Site health override + Instance status / labels in Cloud DB)
 	if apiRequest.IsOnlineRepair() {
-		statusDetailDAO := cdbm.NewStatusDetailDAO(umh.dbSession)
-
 		// Validate if user has permission to enter/exit online repair mode for this Machine
 		if !isOwnerProvider && !isPrivilegedTenant {
 			return cutil.NewAPIErrorResponse(c, http.StatusForbidden, "User does not have permission to enter/exit online repair mode for this Machine", nil)
@@ -1377,167 +1374,188 @@ func (umh UpdateMachineHandler) Handle(c echo.Context) error {
 			return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "Machine must have an assigned Instance for online repair", nil)
 		}
 
-		orTx, err := cdb.BeginTx(ctx, umh.dbSession, &sql.TxOptions{})
-		if err != nil {
-			logger.Error().Err(err).Msg("unable to start transaction")
-			return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Error updating machine", nil)
-		}
-		orTxCommitted := false
-		defer common.RollbackTx(ctx, orTx, &orTxCommitted)
+		// timeoutResp lets the closure signal a post-rollback handler — the
+		// TerminateWorkflow call has to run after the closure returns so that
+		// the DB tx unwinds before we make the second remote call. nil means
+		// no timeout occurred and the normal flow continues.
+		var timeoutResp func() error
 
-		iDAO := cdbm.NewInstanceDAO(umh.dbSession)
-		instances, _, ierr := iDAO.GetAll(ctx, orTx, cdbm.InstanceFilterInput{MachineIDs: []string{machine.ID}}, cdbp.PageInput{Limit: cdb.GetIntPtr(1)}, nil)
-		if ierr != nil {
-			logger.Error().Err(ierr).Msg("error retrieving Instance for Machine")
-			return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve Instance for Machine", nil)
-		}
-		if len(instances) == 0 {
-			return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "Machine must have an assigned Instance for online repair", nil)
-		}
-		inst := instances[0]
+		statusDetailDAO := cdbm.NewStatusDetailDAO(umh.dbSession)
 
-		if apiRequest.OnlineRepairEnabled() {
-			if inst.Status != cdbm.InstanceStatusReady {
-				return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, fmt.Sprintf("Instance must be in Ready state to enter online repair (current state: %s)", inst.Status), nil)
+		err := cdb.WithTx(ctx, umh.dbSession, func(orTx *cdb.Tx) error {
+			iDAO := cdbm.NewInstanceDAO(umh.dbSession)
+			instances, _, derr := iDAO.GetAll(ctx, orTx, cdbm.InstanceFilterInput{MachineIDs: []string{machine.ID}}, cdbp.PageInput{Limit: cdb.GetIntPtr(1)}, nil)
+			if derr != nil {
+				logger.Error().Err(derr).Msg("error retrieving Instance for Machine")
+				return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve Instance for Machine", nil)
 			}
-
-			insReq, ierr := apiRequest.ToInsertHealthReportOverrideProto(machine.ID)
-			if ierr != nil {
-				logger.Error().Err(ierr).Msg("failed to build online repair health override request")
-				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to build online repair request", nil)
+			if len(instances) == 0 {
+				return cutil.NewAPIError(http.StatusBadRequest, "Machine must have an assigned Instance for online repair", nil)
 			}
+			inst := instances[0]
 
-			instanceLabels := maps.Clone(inst.Labels)
-			if instanceLabels == nil {
-				instanceLabels = map[string]string{}
-			}
+			if apiRequest.OnlineRepairEnabled() {
+				if inst.Status != cdbm.InstanceStatusReady {
+					return cutil.NewAPIError(http.StatusBadRequest, fmt.Sprintf("Instance must be in Ready state to enter online repair (current state: %s)", inst.Status), nil)
+				}
 
-			if *apiRequest.OnlineRepair.Policy.AllowAutoInstanceDeletionOnFailure {
-				instanceLabels[model.InstanceLabelOnlineRepairAllowAutoDeletion] = "true"
+				insReq, perr := apiRequest.ToInsertHealthReportOverrideProto(machine.ID)
+				if perr != nil {
+					logger.Error().Err(perr).Msg("failed to build online repair health override request")
+					return cutil.NewAPIError(http.StatusInternalServerError, "Failed to build online repair request", nil)
+				}
+
+				instanceLabels := maps.Clone(inst.Labels)
+				if instanceLabels == nil {
+					instanceLabels = map[string]string{}
+				}
+
+				if *apiRequest.OnlineRepair.Policy.AllowAutoInstanceDeletionOnFailure {
+					instanceLabels[model.InstanceLabelOnlineRepairAllowAutoDeletion] = "true"
+				} else {
+					instanceLabels[model.InstanceLabelOnlineRepairAllowAutoDeletion] = "false"
+				}
+
+				_, derr = iDAO.Update(ctx, orTx, cdbm.InstanceUpdateInput{
+					InstanceID: inst.ID,
+					Status:     cdb.GetStrPtr(cdbm.InstanceStatusRepairing),
+					Labels:     instanceLabels,
+				})
+				if derr != nil {
+					logger.Error().Err(derr).Msg("error updating Instance for online repair in DB")
+					return cutil.NewAPIError(http.StatusInternalServerError, "Failed to update Instance for online repair", nil)
+				}
+
+				// Update Instance status in StatusDetail
+				_, derr = statusDetailDAO.CreateFromParams(ctx, orTx, inst.ID.String(), cdbm.InstanceStatusRepairing, cdb.GetStrPtr("Instance is currently being repaired"))
+				if derr != nil {
+					logger.Error().Err(derr).Msg("error updating Instance status in StatusDetail for online repair in DB")
+					return cutil.NewAPIError(http.StatusInternalServerError, "Failed to update Instance status in StatusDetail for online repair", nil)
+				}
+
+				wfOpts := temporalClient.StartWorkflowOptions{
+					ID:                       "site-machine-online-repair-" + machine.ID,
+					WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
+					TaskQueue:                queue.SiteTaskQueue,
+				}
+
+				wfCtx, wfCancel := context.WithTimeout(ctx, cutil.WorkflowContextTimeout)
+				defer wfCancel()
+
+				we, wferr := stc.ExecuteWorkflow(wfCtx, wfOpts, "CreateMachineHealthReportOverride", insReq)
+				if wferr != nil {
+					logger.Error().Err(wferr).Msg("failed to start Temporal workflow for applying online repair health override")
+					return cutil.NewAPIError(http.StatusInternalServerError, fmt.Sprintf("Failed to start applying online repair health override workflow on Site: %s", wferr), nil)
+				}
+				wid := we.GetID()
+				logger.Info().Str("Workflow ID", wid).Msg("executed synchronous applying online repair health override workflow")
+				wferr = we.Get(wfCtx, nil)
+				if wferr != nil {
+					var timeoutErr *tp.TimeoutError
+					if errors.As(wferr, &timeoutErr) || wferr == context.DeadlineExceeded || wfCtx.Err() != nil || ctx.Err() != nil {
+						logger.Error().Err(wferr).Msg("failed to apply online repair health override, timeout occurred executing workflow on Site.")
+						timeoutCause := wferr // explicit capture; defensive against future refactors
+						timeoutResp = func() error {
+							return common.TerminateWorkflowOnTimeOut(c, logger, stc, wid, timeoutCause, "Machine", "CreateMachineHealthReportOverride")
+						}
+						return cutil.NewAPIError(http.StatusInternalServerError, "Applying online repair health override workflow timed out", nil)
+					}
+					code, werr := common.UnwrapWorkflowError(wferr)
+					logger.Error().Err(werr).Msg("applying online repair health override workflow failed")
+					return cutil.NewAPIError(code, fmt.Sprintf("Failed to execute applying online repair health override workflow on Site: %s", werr), nil)
+				}
+				logger.Info().Str("Workflow ID", wid).Msg("completed synchronous applying online repair health override workflow")
 			} else {
-				instanceLabels[model.InstanceLabelOnlineRepairAllowAutoDeletion] = "false"
-			}
-
-			_, err = iDAO.Update(ctx, orTx, cdbm.InstanceUpdateInput{
-				InstanceID: inst.ID,
-				Status:     cdb.GetStrPtr(cdbm.InstanceStatusRepairing),
-				Labels:     instanceLabels,
-			})
-			if err != nil {
-				logger.Error().Err(err).Msg("error updating Instance for online repair in DB")
-				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to update Instance for online repair", nil)
-			}
-
-			// Update Instance status in StatusDetail
-			_, err = statusDetailDAO.CreateFromParams(ctx, orTx, inst.ID.String(), cdbm.InstanceStatusRepairing, cdb.GetStrPtr("Instance is currently being repaired"))
-			if err != nil {
-				logger.Error().Err(err).Msg("error updating Instance status in StatusDetail in DB")
-				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to update Instance status in StatusDetail", nil)
-			}
-
-			wfOpts := temporalClient.StartWorkflowOptions{
-				ID:                       "site-machine-online-repair-" + machine.ID,
-				WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
-				TaskQueue:                queue.SiteTaskQueue,
-			}
-
-			wfCtx, wfCancel := context.WithTimeout(ctx, cutil.WorkflowContextTimeout)
-			defer wfCancel()
-
-			we, err := stc.ExecuteWorkflow(wfCtx, wfOpts, "CreateMachineHealthReportOverride", insReq)
-			if err != nil {
-				logger.Error().Err(err).Msg("failed to start Temporal workflow for applying online repair health override")
-				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("Failed to start applying online repair health override workflow on Site: %s", err), nil)
-			}
-			wid := we.GetID()
-			logger.Info().Str("Workflow ID", wid).Msg("executed synchronous applying online repair health override workflow")
-			err = we.Get(wfCtx, nil)
-			if err != nil {
-				var timeoutErr *tp.TimeoutError
-				if errors.As(err, &timeoutErr) || err == context.DeadlineExceeded || wfCtx.Err() != nil || ctx.Err() != nil {
-					return common.TerminateWorkflowOnTimeOut(c, logger, stc, wid, err, "Machine", "CreateMachineHealthReportOverride")
+				// Validate if Instance is in Repairing state, has the online repair marker label, or the Machine health includes the online repair health alert
+				_, hasOnlineRepairMarker := inst.Labels[model.InstanceLabelOnlineRepairAllowAutoDeletion]
+				hasOnlineRepairHealthAlert := common.MachineReportsOnlineRepairHealthAlert(machine)
+				if inst.Status != cdbm.InstanceStatusRepairing && !hasOnlineRepairMarker && !hasOnlineRepairHealthAlert {
+					return cutil.NewAPIError(http.StatusBadRequest, fmt.Sprintf(
+						"Instance must be in Repairing state, retain the online repair marker label (%s), or the Machine health must include the %s alert (synced from Site) to exit online repair (current instance state: %s)",
+						model.InstanceLabelOnlineRepairAllowAutoDeletion, model.MachineHealthAlertIDOnlineRepair, inst.Status), nil)
 				}
-				code, werr := common.UnwrapWorkflowError(err)
-				logger.Error().Err(werr).Msg("applying online repair health override workflow failed")
-				return cutil.NewAPIErrorResponse(c, code, fmt.Sprintf("Failed to execute applying online repair health override workflow on Site: %s", werr), nil)
-			}
-			logger.Info().Str("Workflow ID", wid).Msg("completed synchronous applying online repair health override workflow")
-		} else {
-			_, hasOnlineRepairMarker := inst.Labels[model.InstanceLabelOnlineRepairAllowAutoDeletion]
-			hasOnlineRepairHealthAlert := common.MachineReportsOnlineRepairHealthAlert(machine)
-			if inst.Status != cdbm.InstanceStatusRepairing && !hasOnlineRepairMarker && !hasOnlineRepairHealthAlert {
-				return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, fmt.Sprintf(
-					"Instance must be in Repairing state, retain the online repair marker label (%s), or the Machine health must include the %s alert (synced from Site) to exit online repair (current instance state: %s)",
-					model.InstanceLabelOnlineRepairAllowAutoDeletion, model.MachineHealthAlertIDOnlineRepair, inst.Status), nil)
-			}
 
-			instanceLabels := maps.Clone(inst.Labels)
-			if instanceLabels == nil {
-				instanceLabels = map[string]string{}
-			}
-
-			delete(instanceLabels, model.InstanceLabelOnlineRepairAllowAutoDeletion)
-
-			_, err = iDAO.Update(ctx, orTx, cdbm.InstanceUpdateInput{
-				InstanceID: inst.ID,
-				Status:     cdb.GetStrPtr(cdbm.InstanceStatusReady),
-				Labels:     instanceLabels,
-			})
-			if err != nil {
-				logger.Error().Err(err).Msg("error updating Instance after clearing online repair in DB")
-				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to update Instance after clearing online repair", nil)
-			}
-
-			// Update Instance status in StatusDetail
-			_, err = statusDetailDAO.CreateFromParams(ctx, orTx, inst.ID.String(), cdbm.InstanceStatusReady, cdb.GetStrPtr("Instance repair has been completed, ready for use"))
-			if err != nil {
-				logger.Error().Err(err).Msg("error updating Instance status in StatusDetail in DB")
-				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to update Instance status in StatusDetail", nil)
-			}
-
-			// Remove health report override on Site
-			rmReq, err := apiRequest.ToRemoveHealthReportOverrideProto(machine.ID)
-			if err != nil {
-				logger.Error().Err(err).Msg("failed to build remove online repair health override request")
-				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to build remove online repair request", nil)
-			}
-
-			wfOpts := temporalClient.StartWorkflowOptions{
-				ID:                       "site-clear-machine-online-repair-" + machine.ID,
-				WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
-				TaskQueue:                queue.SiteTaskQueue,
-			}
-
-			wfCtx, wfCancel := context.WithTimeout(ctx, cutil.WorkflowContextTimeout)
-			defer wfCancel()
-
-			we, err := stc.ExecuteWorkflow(wfCtx, wfOpts, "DeleteMachineHealthReportOverride", rmReq)
-			if err != nil {
-				logger.Error().Err(err).Msg("failed to start Temporal workflow to clear online repair health override")
-				return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("Failed to start clear online repair workflow on Site: %s", err), nil)
-			}
-			wid := we.GetID()
-			logger.Info().Str("Workflow ID", wid).Msg("executed synchronous DeleteMachineHealthReportOverride workflow")
-			err = we.Get(wfCtx, nil)
-			if err != nil {
-				var timeoutErr *tp.TimeoutError
-				if errors.As(err, &timeoutErr) || err == context.DeadlineExceeded || wfCtx.Err() != nil || ctx.Err() != nil {
-					return common.TerminateWorkflowOnTimeOut(c, logger, stc, wid, err, "Machine", "DeleteMachineHealthReportOverride")
+				instanceLabels := maps.Clone(inst.Labels)
+				if instanceLabels == nil {
+					instanceLabels = map[string]string{}
 				}
-				code, werr := common.UnwrapWorkflowError(err)
-				logger.Error().Err(werr).Msg("clear online repair health override workflow failed")
-				return cutil.NewAPIErrorResponse(c, code, fmt.Sprintf("Failed to execute clear online repair workflow on Site: %s", werr), nil)
-			}
-			logger.Info().Str("Workflow ID", wid).Msg("completed synchronous DeleteMachineHealthReportOverride workflow")
-		}
 
-		err = orTx.Commit()
+				delete(instanceLabels, model.InstanceLabelOnlineRepairAllowAutoDeletion)
+
+				_, derr = iDAO.Update(ctx, orTx, cdbm.InstanceUpdateInput{
+					InstanceID: inst.ID,
+					Status:     cdb.GetStrPtr(cdbm.InstanceStatusReady),
+					Labels:     instanceLabels,
+				})
+				if derr != nil {
+					logger.Error().Err(derr).Msg("error updating Instance after clearing online repair in DB")
+					return cutil.NewAPIError(http.StatusInternalServerError, "Failed to update Instance after clearing online repair", nil)
+				}
+
+				// Update Instance status in StatusDetail
+				_, derr = statusDetailDAO.CreateFromParams(ctx, orTx, inst.ID.String(), cdbm.InstanceStatusReady, cdb.GetStrPtr("Instance repair has been completed, ready for use"))
+				if derr != nil {
+					logger.Error().Err(derr).Msg("error updating Instance status in StatusDetail for online repair exit in DB")
+					return cutil.NewAPIError(http.StatusInternalServerError, "Failed to update Instance status in StatusDetail for online repair exit", nil)
+				}
+
+				rmReq, perr := apiRequest.ToRemoveHealthReportOverrideProto(machine.ID)
+				if perr != nil {
+					logger.Error().Err(perr).Msg("failed to build remove online repair health override request")
+					return cutil.NewAPIError(http.StatusInternalServerError, "Failed to build remove online repair request", nil)
+				}
+
+				wfOpts := temporalClient.StartWorkflowOptions{
+					ID:                       "site-clear-machine-online-repair-" + machine.ID,
+					WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
+					TaskQueue:                queue.SiteTaskQueue,
+				}
+
+				wfCtx, wfCancel := context.WithTimeout(ctx, cutil.WorkflowContextTimeout)
+				defer wfCancel()
+
+				we, wferr := stc.ExecuteWorkflow(wfCtx, wfOpts, "DeleteMachineHealthReportOverride", rmReq)
+				if wferr != nil {
+					logger.Error().Err(wferr).Msg("failed to start Temporal workflow to clear online repair health override")
+					return cutil.NewAPIError(http.StatusInternalServerError, fmt.Sprintf("Failed to start clear online repair workflow on Site: %s", wferr), nil)
+				}
+				wid := we.GetID()
+				logger.Info().Str("Workflow ID", wid).Msg("executed synchronous DeleteMachineHealthReportOverride workflow")
+				wferr = we.Get(wfCtx, nil)
+				if wferr != nil {
+					var timeoutErr *tp.TimeoutError
+					if errors.As(wferr, &timeoutErr) || wferr == context.DeadlineExceeded || wfCtx.Err() != nil || ctx.Err() != nil {
+						logger.Error().Err(wferr).Msg("failed to clear online repair health override, timeout occurred executing workflow on Site.")
+						timeoutCause := wferr // explicit capture; defensive against future refactors
+						timeoutResp = func() error {
+							return common.TerminateWorkflowOnTimeOut(c, logger, stc, wid, timeoutCause, "Machine", "DeleteMachineHealthReportOverride")
+						}
+						return cutil.NewAPIError(http.StatusInternalServerError, "Clear online repair workflow timed out", nil)
+					}
+					code, werr := common.UnwrapWorkflowError(wferr)
+					logger.Error().Err(werr).Msg("clear online repair health override workflow failed")
+					return cutil.NewAPIError(code, fmt.Sprintf("Failed to execute clear online repair workflow on Site: %s", werr), nil)
+				}
+				logger.Info().Str("Workflow ID", wid).Msg("completed synchronous DeleteMachineHealthReportOverride workflow")
+			}
+
+			return nil
+		})
+		// Surface real tx-helper errors first so they aren't masked by the
+		// timeout response (commit/rollback failures wrap into something other
+		// than the cutil.APIError marker we returned for the timeout case).
 		if err != nil {
-			logger.Error().Err(err).Msg("error committing transaction")
-			return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to update Machine, DB transaction error", nil)
+			var apiErr *cutil.APIError
+			if !errors.As(err, &apiErr) {
+				return common.HandleTxError(c, logger, err, "Failed to update Machine, DB transaction error")
+			}
 		}
-		orTxCommitted = true
-		um = machine
+		if timeoutResp != nil {
+			return timeoutResp()
+		}
+		if err != nil {
+			return common.HandleTxError(c, logger, err, "Failed to update Machine, DB transaction error")
+		}
 	}
 
 	// Create response

--- a/api/pkg/api/handler/machine_test.go
+++ b/api/pkg/api/handler/machine_test.go
@@ -1829,6 +1829,17 @@ func TestMachineHandler_Update(t *testing.T) {
 		require.NoError(t, uerr)
 	}
 
+	assertOnlineRepairLatestStatusDetail := func(t *testing.T, wantStatus, wantMessage string) {
+		t.Helper()
+		sdDAO := cdbm.NewStatusDetailDAO(dbSession)
+		recent, rerr := sdDAO.GetRecentByEntityIDs(context.Background(), nil, []string{iOnlineRepairReady.ID.String()}, 1)
+		require.NoError(t, rerr)
+		require.Len(t, recent, 1)
+		assert.Equal(t, wantStatus, recent[0].Status)
+		require.NotNil(t, recent[0].Message)
+		assert.Equal(t, wantMessage, *recent[0].Message)
+	}
+
 	mit1 := common.TestBuildMachineInstanceType(t, dbSession, m, instanceType1)
 	assert.NotNil(t, mit1)
 
@@ -2485,6 +2496,7 @@ func TestMachineHandler_Update(t *testing.T) {
 					require.NoError(t, gerr)
 					assert.Equal(t, cdbm.InstanceStatusRepairing, inst.Status)
 					assert.Equal(t, "false", inst.Labels[model.InstanceLabelOnlineRepairAllowAutoDeletion])
+					assertOnlineRepairLatestStatusDetail(t, cdbm.InstanceStatusRepairing, "Instance is being repaired on Site")
 				},
 			},
 		},
@@ -2510,6 +2522,7 @@ func TestMachineHandler_Update(t *testing.T) {
 					require.NoError(t, gerr)
 					assert.Equal(t, cdbm.InstanceStatusRepairing, inst.Status)
 					assert.Equal(t, "true", inst.Labels[model.InstanceLabelOnlineRepairAllowAutoDeletion])
+					assertOnlineRepairLatestStatusDetail(t, cdbm.InstanceStatusRepairing, "Instance is being repaired on Site")
 				},
 			},
 		},
@@ -2536,6 +2549,7 @@ func TestMachineHandler_Update(t *testing.T) {
 					assert.Equal(t, cdbm.InstanceStatusReady, inst.Status)
 					_, has := inst.Labels[model.InstanceLabelOnlineRepairAllowAutoDeletion]
 					assert.False(t, has)
+					assertOnlineRepairLatestStatusDetail(t, cdbm.InstanceStatusReady, "Instance is no longer being repaired on Site, Ready for use")
 				},
 			},
 		},
@@ -2560,6 +2574,7 @@ func TestMachineHandler_Update(t *testing.T) {
 					inst, gerr := isd.GetByID(context.Background(), nil, iOnlineRepairReady.ID, nil)
 					require.NoError(t, gerr)
 					assert.Equal(t, cdbm.InstanceStatusRepairing, inst.Status)
+					assertOnlineRepairLatestStatusDetail(t, cdbm.InstanceStatusRepairing, "Instance is being repaired on Site")
 				},
 			},
 		},

--- a/api/pkg/api/handler/machine_test.go
+++ b/api/pkg/api/handler/machine_test.go
@@ -1829,10 +1829,10 @@ func TestMachineHandler_Update(t *testing.T) {
 		require.NoError(t, uerr)
 	}
 
-	assertOnlineRepairLatestStatusDetail := func(t *testing.T, wantStatus, wantMessage string) {
+	assertOnlineRepairLatestStatusDetail := func(t *testing.T, instanceID uuid.UUID, wantStatus, wantMessage string) {
 		t.Helper()
 		sdDAO := cdbm.NewStatusDetailDAO(dbSession)
-		recent, rerr := sdDAO.GetRecentByEntityIDs(context.Background(), nil, []string{iOnlineRepairReady.ID.String()}, 1)
+		recent, rerr := sdDAO.GetRecentByEntityIDs(context.Background(), nil, []string{instanceID.String()}, 1)
 		require.NoError(t, rerr)
 		require.Len(t, recent, 1)
 		assert.Equal(t, wantStatus, recent[0].Status)
@@ -2496,7 +2496,7 @@ func TestMachineHandler_Update(t *testing.T) {
 					require.NoError(t, gerr)
 					assert.Equal(t, cdbm.InstanceStatusRepairing, inst.Status)
 					assert.Equal(t, "false", inst.Labels[model.InstanceLabelOnlineRepairAllowAutoDeletion])
-					assertOnlineRepairLatestStatusDetail(t, cdbm.InstanceStatusRepairing, "Instance is currently being repaired")
+					assertOnlineRepairLatestStatusDetail(t, iOnlineRepairReady.ID, cdbm.InstanceStatusRepairing, "Instance is currently being repaired")
 				},
 			},
 		},
@@ -2522,7 +2522,7 @@ func TestMachineHandler_Update(t *testing.T) {
 					require.NoError(t, gerr)
 					assert.Equal(t, cdbm.InstanceStatusRepairing, inst.Status)
 					assert.Equal(t, "true", inst.Labels[model.InstanceLabelOnlineRepairAllowAutoDeletion])
-					assertOnlineRepairLatestStatusDetail(t, cdbm.InstanceStatusRepairing, "Instance is currently being repaired")
+					assertOnlineRepairLatestStatusDetail(t, iOnlineRepairReady.ID, cdbm.InstanceStatusRepairing, "Instance is currently being repaired")
 				},
 			},
 		},
@@ -2549,7 +2549,7 @@ func TestMachineHandler_Update(t *testing.T) {
 					assert.Equal(t, cdbm.InstanceStatusReady, inst.Status)
 					_, has := inst.Labels[model.InstanceLabelOnlineRepairAllowAutoDeletion]
 					assert.False(t, has)
-					assertOnlineRepairLatestStatusDetail(t, cdbm.InstanceStatusReady, "Instance repair has been completed, ready for use")
+					assertOnlineRepairLatestStatusDetail(t, iOnlineRepairReady.ID, cdbm.InstanceStatusReady, "Instance repair has been completed, ready for use")
 				},
 			},
 		},
@@ -2582,7 +2582,7 @@ func TestMachineHandler_Update(t *testing.T) {
 					assert.Equal(t, cdbm.InstanceStatusReady, inst.Status)
 					_, has := inst.Labels[model.InstanceLabelOnlineRepairAllowAutoDeletion]
 					assert.False(t, has)
-					assertOnlineRepairLatestStatusDetail(t, cdbm.InstanceStatusReady, "Instance repair has been completed, ready for use")
+					assertOnlineRepairLatestStatusDetail(t, iOnlineRepairReady.ID, cdbm.InstanceStatusReady, "Instance repair has been completed, ready for use")
 				},
 			},
 		},
@@ -2624,7 +2624,7 @@ func TestMachineHandler_Update(t *testing.T) {
 					assert.Equal(t, cdbm.InstanceStatusReady, inst.Status)
 					_, has := inst.Labels[model.InstanceLabelOnlineRepairAllowAutoDeletion]
 					assert.False(t, has)
-					assertOnlineRepairLatestStatusDetail(t, cdbm.InstanceStatusReady, "Instance repair has been completed, ready for use")
+					assertOnlineRepairLatestStatusDetail(t, iOnlineRepairReady.ID, cdbm.InstanceStatusReady, "Instance repair has been completed, ready for use")
 					_, cerr := machineDAO.Clear(context.Background(), nil, cdbm.MachineClearInput{
 						MachineID: mOnlineRepairReady.ID,
 						Health:    true,
@@ -2654,7 +2654,7 @@ func TestMachineHandler_Update(t *testing.T) {
 					inst, gerr := isd.GetByID(context.Background(), nil, iOnlineRepairReady.ID, nil)
 					require.NoError(t, gerr)
 					assert.Equal(t, cdbm.InstanceStatusRepairing, inst.Status)
-					assertOnlineRepairLatestStatusDetail(t, cdbm.InstanceStatusRepairing, "Instance is currently being repaired")
+					assertOnlineRepairLatestStatusDetail(t, iOnlineRepairReady.ID, cdbm.InstanceStatusRepairing, "Instance is currently being repaired")
 				},
 			},
 		},

--- a/api/pkg/api/handler/machine_test.go
+++ b/api/pkg/api/handler/machine_test.go
@@ -2496,7 +2496,7 @@ func TestMachineHandler_Update(t *testing.T) {
 					require.NoError(t, gerr)
 					assert.Equal(t, cdbm.InstanceStatusRepairing, inst.Status)
 					assert.Equal(t, "false", inst.Labels[model.InstanceLabelOnlineRepairAllowAutoDeletion])
-					assertOnlineRepairLatestStatusDetail(t, cdbm.InstanceStatusRepairing, "Instance is being repaired on Site")
+					assertOnlineRepairLatestStatusDetail(t, cdbm.InstanceStatusRepairing, "Instance is currently being repaired")
 				},
 			},
 		},
@@ -2522,7 +2522,7 @@ func TestMachineHandler_Update(t *testing.T) {
 					require.NoError(t, gerr)
 					assert.Equal(t, cdbm.InstanceStatusRepairing, inst.Status)
 					assert.Equal(t, "true", inst.Labels[model.InstanceLabelOnlineRepairAllowAutoDeletion])
-					assertOnlineRepairLatestStatusDetail(t, cdbm.InstanceStatusRepairing, "Instance is being repaired on Site")
+					assertOnlineRepairLatestStatusDetail(t, cdbm.InstanceStatusRepairing, "Instance is currently being repaired")
 				},
 			},
 		},
@@ -2549,7 +2549,7 @@ func TestMachineHandler_Update(t *testing.T) {
 					assert.Equal(t, cdbm.InstanceStatusReady, inst.Status)
 					_, has := inst.Labels[model.InstanceLabelOnlineRepairAllowAutoDeletion]
 					assert.False(t, has)
-					assertOnlineRepairLatestStatusDetail(t, cdbm.InstanceStatusReady, "Instance is no longer being repaired on Site, Ready for use")
+					assertOnlineRepairLatestStatusDetail(t, cdbm.InstanceStatusReady, "Instance repair has been completed, ready for use")
 				},
 			},
 		},
@@ -2582,7 +2582,7 @@ func TestMachineHandler_Update(t *testing.T) {
 					assert.Equal(t, cdbm.InstanceStatusReady, inst.Status)
 					_, has := inst.Labels[model.InstanceLabelOnlineRepairAllowAutoDeletion]
 					assert.False(t, has)
-					assertOnlineRepairLatestStatusDetail(t, cdbm.InstanceStatusReady, "Instance is no longer being repaired on Site, Ready for use")
+					assertOnlineRepairLatestStatusDetail(t, cdbm.InstanceStatusReady, "Instance repair has been completed, ready for use")
 				},
 			},
 		},
@@ -2624,7 +2624,7 @@ func TestMachineHandler_Update(t *testing.T) {
 					assert.Equal(t, cdbm.InstanceStatusReady, inst.Status)
 					_, has := inst.Labels[model.InstanceLabelOnlineRepairAllowAutoDeletion]
 					assert.False(t, has)
-					assertOnlineRepairLatestStatusDetail(t, cdbm.InstanceStatusReady, "Instance is no longer being repaired on Site, Ready for use")
+					assertOnlineRepairLatestStatusDetail(t, cdbm.InstanceStatusReady, "Instance repair has been completed, ready for use")
 					_, cerr := machineDAO.Clear(context.Background(), nil, cdbm.MachineClearInput{
 						MachineID: mOnlineRepairReady.ID,
 						Health:    true,
@@ -2654,7 +2654,7 @@ func TestMachineHandler_Update(t *testing.T) {
 					inst, gerr := isd.GetByID(context.Background(), nil, iOnlineRepairReady.ID, nil)
 					require.NoError(t, gerr)
 					assert.Equal(t, cdbm.InstanceStatusRepairing, inst.Status)
-					assertOnlineRepairLatestStatusDetail(t, cdbm.InstanceStatusRepairing, "Instance is being repaired on Site")
+					assertOnlineRepairLatestStatusDetail(t, cdbm.InstanceStatusRepairing, "Instance is currently being repaired")
 				},
 			},
 		},

--- a/api/pkg/api/handler/machine_test.go
+++ b/api/pkg/api/handler/machine_test.go
@@ -2456,7 +2456,7 @@ func TestMachineHandler_Update(t *testing.T) {
 			},
 		},
 		{
-			name: "test Machine update API online repair failure, Instance must be Repairing to exit",
+			name: "test Machine update API online repair failure, exit without Repairing status, marker label, or machine OnLineRepair health alert",
 			fields: fields{
 				dbSession: dbSession,
 				tc:        tc,
@@ -2550,6 +2550,86 @@ func TestMachineHandler_Update(t *testing.T) {
 					_, has := inst.Labels[model.InstanceLabelOnlineRepairAllowAutoDeletion]
 					assert.False(t, has)
 					assertOnlineRepairLatestStatusDetail(t, cdbm.InstanceStatusReady, "Instance is no longer being repaired on Site, Ready for use")
+				},
+			},
+		},
+		{
+			name: "test Machine update API online repair success, exit when instance Ready but online repair marker label remains",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        tc,
+				scp:       scp,
+				cfg:       cfg,
+			},
+			args: args{
+				reqData:    buildOnlineRepairExitRequest(),
+				reqMachine: mOnlineRepairReady,
+				reqOrg:     ipOrg1,
+				reqUser:    ipu,
+				respCode:   http.StatusOK,
+				beforeHandle: func(t *testing.T) {
+					t.Helper()
+					_, uerr := isd.Update(context.Background(), nil, cdbm.InstanceUpdateInput{
+						InstanceID: iOnlineRepairReady.ID,
+						Status:     cdb.GetStrPtr(cdbm.InstanceStatusReady),
+						Labels:     map[string]string{model.InstanceLabelOnlineRepairAllowAutoDeletion: "false"},
+					})
+					require.NoError(t, uerr)
+				},
+				verifyOnlineRepair: func(t *testing.T) {
+					inst, gerr := isd.GetByID(context.Background(), nil, iOnlineRepairReady.ID, nil)
+					require.NoError(t, gerr)
+					assert.Equal(t, cdbm.InstanceStatusReady, inst.Status)
+					_, has := inst.Labels[model.InstanceLabelOnlineRepairAllowAutoDeletion]
+					assert.False(t, has)
+					assertOnlineRepairLatestStatusDetail(t, cdbm.InstanceStatusReady, "Instance is no longer being repaired on Site, Ready for use")
+				},
+			},
+		},
+		{
+			name: "test Machine update API online repair success, exit when Ready without marker but Machine health lists OnLineRepair alert",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        tc,
+				scp:       scp,
+				cfg:       cfg,
+			},
+			args: args{
+				reqData:    buildOnlineRepairExitRequest(),
+				reqMachine: mOnlineRepairReady,
+				reqOrg:     ipOrg1,
+				reqUser:    ipu,
+				respCode:   http.StatusOK,
+				beforeHandle: func(t *testing.T) {
+					t.Helper()
+					machineRepairResetReady(t)
+					health := map[string]interface{}{
+						"alerts": []map[string]interface{}{
+							{
+								"id":      model.MachineHealthAlertIDOnlineRepair,
+								"message": `{}`,
+							},
+						},
+					}
+					_, uerr := machineDAO.Update(ctx, nil, cdbm.MachineUpdateInput{
+						MachineID: mOnlineRepairReady.ID,
+						Health:    health,
+					})
+					require.NoError(t, uerr)
+				},
+				verifyOnlineRepair: func(t *testing.T) {
+					t.Helper()
+					inst, gerr := isd.GetByID(context.Background(), nil, iOnlineRepairReady.ID, nil)
+					require.NoError(t, gerr)
+					assert.Equal(t, cdbm.InstanceStatusReady, inst.Status)
+					_, has := inst.Labels[model.InstanceLabelOnlineRepairAllowAutoDeletion]
+					assert.False(t, has)
+					assertOnlineRepairLatestStatusDetail(t, cdbm.InstanceStatusReady, "Instance is no longer being repaired on Site, Ready for use")
+					_, cerr := machineDAO.Clear(context.Background(), nil, cdbm.MachineClearInput{
+						MachineID: mOnlineRepairReady.ID,
+						Health:    true,
+					})
+					require.NoError(t, cerr)
 				},
 			},
 		},

--- a/api/pkg/api/handler/util/common/common.go
+++ b/api/pkg/api/handler/util/common/common.go
@@ -306,6 +306,24 @@ func AcquireInstanceTypeQuotaLock(ctx context.Context, tx *cdb.Tx, tenantID uuid
 	return tx.TryAcquireAdvisoryLock(ctx, cdb.GetAdvisoryLockIDFromString(lockID), nil)
 }
 
+// MachineReportsOnlineRepairHealthAlert is true when inventory-synced machine health JSON lists the
+// OnLineRepair probe (tenant online repair active on Site regardless of stale instance status / labels).
+func MachineReportsOnlineRepairHealthAlert(dbMachine *cdbm.Machine) bool {
+	if dbMachine == nil {
+		return false
+	}
+	h, err := dbMachine.GetHealth()
+	if err != nil || h == nil {
+		return false
+	}
+	for i := range h.Alerts {
+		if h.Alerts[i].Id == cam.MachineHealthAlertIDOnlineRepair {
+			return true
+		}
+	}
+	return false
+}
+
 // GetUnallocatedMachineForInstanceType provides unallocatd machine based on instancetype
 func GetUnallocatedMachineForInstanceType(ctx context.Context, tx *cdb.Tx, dbSession *cdb.Session, instanceType *cdbm.InstanceType) (*cdbm.Machine, error) {
 	if instanceType == nil {

--- a/api/pkg/api/handler/util/common/common.go
+++ b/api/pkg/api/handler/util/common/common.go
@@ -306,24 +306,6 @@ func AcquireInstanceTypeQuotaLock(ctx context.Context, tx *cdb.Tx, tenantID uuid
 	return tx.TryAcquireAdvisoryLock(ctx, cdb.GetAdvisoryLockIDFromString(lockID), nil)
 }
 
-// MachineReportsOnlineRepairHealthAlert is true when inventory-synced machine health JSON lists the
-// OnLineRepair probe (tenant online repair active on Site regardless of stale instance status / labels).
-func MachineReportsOnlineRepairHealthAlert(dbMachine *cdbm.Machine) bool {
-	if dbMachine == nil {
-		return false
-	}
-	h, err := dbMachine.GetHealth()
-	if err != nil || h == nil {
-		return false
-	}
-	for i := range h.Alerts {
-		if h.Alerts[i].Id == cam.MachineHealthAlertIDOnlineRepair {
-			return true
-		}
-	}
-	return false
-}
-
 // GetUnallocatedMachineForInstanceType provides unallocatd machine based on instancetype
 func GetUnallocatedMachineForInstanceType(ctx context.Context, tx *cdb.Tx, dbSession *cdb.Session, instanceType *cdbm.InstanceType) (*cdbm.Machine, error) {
 	if instanceType == nil {

--- a/api/pkg/api/model/machine.go
+++ b/api/pkg/api/model/machine.go
@@ -44,8 +44,9 @@ const (
 	MachineMaxLabelCount = 10
 	// InstanceLabelOnlineRepairAllowAutoDeletion records repairPolicy.allowAutoInstanceDeletionOnFailure from the last enter-online-repair request ("true" / "false").
 	InstanceLabelOnlineRepairAllowAutoDeletion = "onlineRepair.allowAutoInstanceDeletionOnFailure"
-	// MachineOnlineRepairHealthOverrideSourceTenant is the source of the online repair health override.
-	MachineOnlineRepairHealthOverrideSourceTenant = "tenant-reported-issue"
+	// MachineOnlineRepairHealthOverrideSource is the merges-path source NICo Core uses for in-pool
+	// online repair (repair_merge_active); must align with RequestOnlineRepair / admin CLI.
+	MachineOnlineRepairHealthOverrideSource = "request-online-repair"
 	// MachineHealthAlertIDOnlineRepair is the ID of the online repair health alert.
 	MachineHealthAlertIDOnlineRepair = "OnLineRepair"
 	// TenantReportedIssueAlertID is the ID of the tenant-reported issue health alert.
@@ -314,14 +315,14 @@ func (mur APIMachineUpdateRequest) ToInsertHealthReportOverrideProto(machineID s
 		},
 	}
 	hr := &cwssaws.HealthReport{
-		Source: MachineOnlineRepairHealthOverrideSourceTenant,
+		Source: MachineOnlineRepairHealthOverrideSource,
 		Alerts: []*cwssaws.HealthProbeAlert{alert},
 	}
 	return &cwssaws.InsertHealthReportOverrideRequest{
 		MachineId: &cwssaws.MachineId{Id: machineID},
 		Override: &cwssaws.HealthReportOverride{
 			Report: hr,
-			Mode:   cwssaws.OverrideMode_Replace,
+			Mode:   cwssaws.OverrideMode_Merge,
 		},
 	}, nil
 }
@@ -329,7 +330,7 @@ func (mur APIMachineUpdateRequest) ToInsertHealthReportOverrideProto(machineID s
 func (mur APIMachineUpdateRequest) ToRemoveHealthReportOverrideProto(machineID string) (*cwssaws.RemoveHealthReportOverrideRequest, error) {
 	return &cwssaws.RemoveHealthReportOverrideRequest{
 		MachineId: &cwssaws.MachineId{Id: machineID},
-		Source:    MachineOnlineRepairHealthOverrideSourceTenant,
+		Source:    MachineOnlineRepairHealthOverrideSource,
 	}, nil
 }
 

--- a/api/pkg/api/model/machine.go
+++ b/api/pkg/api/model/machine.go
@@ -44,9 +44,9 @@ const (
 	MachineMaxLabelCount = 10
 	// InstanceLabelOnlineRepairAllowAutoDeletion records repairPolicy.allowAutoInstanceDeletionOnFailure from the last enter-online-repair request ("true" / "false").
 	InstanceLabelOnlineRepairAllowAutoDeletion = "onlineRepair.allowAutoInstanceDeletionOnFailure"
-	// MachineOnlineRepairHealthOverrideSource is the merges-path source NICo Core uses for in-pool
+	// MachineHealthOverrideSourceOnlineRepair is the merges-path source NICo Core uses for in-pool
 	// online repair (repair_merge_active); must align with RequestOnlineRepair / admin CLI.
-	MachineOnlineRepairHealthOverrideSource = "request-online-repair"
+	MachineHealthOverrideSourceOnlineRepair = "request-online-repair"
 	// MachineHealthAlertIDOnlineRepair is the ID of the online repair health alert.
 	MachineHealthAlertIDOnlineRepair = "OnLineRepair"
 	// TenantReportedIssueAlertID is the ID of the tenant-reported issue health alert.
@@ -315,7 +315,7 @@ func (mur APIMachineUpdateRequest) ToInsertHealthReportOverrideProto(machineID s
 		},
 	}
 	hr := &cwssaws.HealthReport{
-		Source: MachineOnlineRepairHealthOverrideSource,
+		Source: MachineHealthOverrideSourceOnlineRepair,
 		Alerts: []*cwssaws.HealthProbeAlert{alert},
 	}
 	return &cwssaws.InsertHealthReportOverrideRequest{
@@ -330,7 +330,7 @@ func (mur APIMachineUpdateRequest) ToInsertHealthReportOverrideProto(machineID s
 func (mur APIMachineUpdateRequest) ToRemoveHealthReportOverrideProto(machineID string) (*cwssaws.RemoveHealthReportOverrideRequest, error) {
 	return &cwssaws.RemoveHealthReportOverrideRequest{
 		MachineId: &cwssaws.MachineId{Id: machineID},
-		Source:    MachineOnlineRepairHealthOverrideSource,
+		Source:    MachineHealthOverrideSourceOnlineRepair,
 	}, nil
 }
 

--- a/api/pkg/api/model/machine_test.go
+++ b/api/pkg/api/model/machine_test.go
@@ -866,9 +866,9 @@ func TestAPIMachineUpdateRequest_ToInsertHealthReportOverrideProto(t *testing.T)
 			require.NotNil(t, got.MachineId)
 			assert.Equal(t, tt.machineID, got.MachineId.Id)
 			require.NotNil(t, got.Override)
-			assert.Equal(t, cwssaws.OverrideMode_Replace, got.Override.Mode)
+			assert.Equal(t, cwssaws.OverrideMode_Merge, got.Override.Mode)
 			require.NotNil(t, got.Override.Report)
-			assert.Equal(t, MachineOnlineRepairHealthOverrideSourceTenant, got.Override.Report.Source)
+			assert.Equal(t, MachineOnlineRepairHealthOverrideSource, got.Override.Report.Source)
 
 			require.Len(t, got.Override.Report.Alerts, 1)
 			alert := got.Override.Report.Alerts[0]
@@ -906,14 +906,14 @@ func TestAPIMachineUpdateRequest_ToRemoveHealthReportOverrideProto(t *testing.T)
 		wantSource string
 	}{
 		{
-			name:       "builds remove request with machine id and tenant-reported-issue source",
+			name:       "builds remove request with machine id and request-online-repair source",
 			machineID:  "aabbccdd-eeff-0011-2233-445566778899",
-			wantSource: MachineOnlineRepairHealthOverrideSourceTenant,
+			wantSource: MachineOnlineRepairHealthOverrideSource,
 		},
 		{
 			name:       "builds remove request for another machine id",
 			machineID:  "bbccddee-ff00-1122-3344-556677889900",
-			wantSource: MachineOnlineRepairHealthOverrideSourceTenant,
+			wantSource: MachineOnlineRepairHealthOverrideSource,
 		},
 	}
 	for _, tt := range tests {

--- a/api/pkg/api/model/machine_test.go
+++ b/api/pkg/api/model/machine_test.go
@@ -868,7 +868,7 @@ func TestAPIMachineUpdateRequest_ToInsertHealthReportOverrideProto(t *testing.T)
 			require.NotNil(t, got.Override)
 			assert.Equal(t, cwssaws.OverrideMode_Merge, got.Override.Mode)
 			require.NotNil(t, got.Override.Report)
-			assert.Equal(t, MachineOnlineRepairHealthOverrideSource, got.Override.Report.Source)
+			assert.Equal(t, MachineHealthOverrideSourceOnlineRepair, got.Override.Report.Source)
 
 			require.Len(t, got.Override.Report.Alerts, 1)
 			alert := got.Override.Report.Alerts[0]
@@ -908,12 +908,12 @@ func TestAPIMachineUpdateRequest_ToRemoveHealthReportOverrideProto(t *testing.T)
 		{
 			name:       "builds remove request with machine id and request-online-repair source",
 			machineID:  "aabbccdd-eeff-0011-2233-445566778899",
-			wantSource: MachineOnlineRepairHealthOverrideSource,
+			wantSource: MachineHealthOverrideSourceOnlineRepair,
 		},
 		{
 			name:       "builds remove request for another machine id",
 			machineID:  "bbccddee-ff00-1122-3344-556677889900",
-			wantSource: MachineOnlineRepairHealthOverrideSource,
+			wantSource: MachineHealthOverrideSourceOnlineRepair,
 		},
 	}
 	for _, tt := range tests {

--- a/db/pkg/db/model/machine.go
+++ b/db/pkg/db/model/machine.go
@@ -284,6 +284,19 @@ type HealthProbeAlert struct {
 	Classifications []string `json:"classifications"`
 }
 
+// HasAlertID reports whether Alerts contains an entry with Id equal to alertID.
+func (h *MachineHealth) HasAlertID(alertID string) bool {
+	if h == nil {
+		return false
+	}
+	for _, alert := range h.Alerts {
+		if alert.Id == alertID {
+			return true
+		}
+	}
+	return false
+}
+
 // GetIndentedJSON returns formatted json of Machine
 func (m *Machine) GetIndentedJSON() ([]byte, error) {
 	return json.MarshalIndent(m, "", "  ")

--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -17869,8 +17869,8 @@ components:
         enabled:
           type: boolean
           description: |-
-            When true, initiates the online repair process: applies the tenant-reported OnlineRepair health override on the Machine and sets the associated Instance status to Repairing.
-            When false, exits online repair: clears the health override and returns the Instance to Ready. Cannot be combined with instance type, maintenance, or label updates in the same request.
+            When true, initiates the online repair process: sends a core compatible merge-mode health override (source `request-online-repair`, matching Core RequestOnlineRepair) and sets the associated Instance status to Repairing.
+            When false, exits online repair: clears that health override and returns the Instance to Ready. Cannot be combined with instance type, maintenance, or label updates in the same request.
         policy:
           $ref: '#/components/schemas/MachineOnlineRepairPolicy'
         acknowledgments:

--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -17869,8 +17869,8 @@ components:
         enabled:
           type: boolean
           description: |-
-            When true, initiates the online repair process: sends a core compatible merge-mode health override (source `request-online-repair`, matching Core RequestOnlineRepair) and sets the associated Instance status to Repairing.
-            When false, exits online repair: clears that health override and returns the Instance to Ready. Cannot be combined with instance type, maintenance, or label updates in the same request.
+            When true, initiates the online repair process by sending a merge-mode health override with source: `request-online-repair` and sets the associated Instance status to Repairing.
+            When false, exits online repair by clearing the merge-mode health override and returns the Instance to Ready status. Cannot be combined with instance type, maintenance, or label updates in the same request.
         policy:
           $ref: '#/components/schemas/MachineOnlineRepairPolicy'
         acknowledgments:

--- a/sdk/standard/client.go
+++ b/sdk/standard/client.go
@@ -601,7 +601,10 @@ func addFile(w *multipart.Writer, fieldName, path string) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	err = file.Close()
+	if err != nil {
+		return err
+	}
 
 	part, err := w.CreateFormFile(fieldName, filepath.Base(path))
 	if err != nil {

--- a/sdk/standard/model_expected_machine.go
+++ b/sdk/standard/model_expected_machine.go
@@ -74,8 +74,7 @@ type ExpectedMachine struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32 `json:"hostId,omitempty"`
-	// User-defined key-value pairs for organizing and categorizing Expected Machines
+	HostId NullableInt32     `json:"hostId,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
 	// ISO 8601 datetime when the Expected Machine was created
 	Created *time.Time `json:"created,omitempty"`

--- a/sdk/standard/model_expected_machine_create_request.go
+++ b/sdk/standard/model_expected_machine_create_request.go
@@ -71,8 +71,7 @@ type ExpectedMachineCreateRequest struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32 `json:"hostId,omitempty"`
-	// User-defined key-value pairs for organizing and categorizing Expected Machines
+	HostId NullableInt32     `json:"hostId,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_expected_machine_update_request.go
+++ b/sdk/standard/model_expected_machine_update_request.go
@@ -69,8 +69,7 @@ type ExpectedMachineUpdateRequest struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32 `json:"hostId,omitempty"`
-	// User-defined key-value pairs for organizing and categorizing Expected Machines
+	HostId NullableInt32     `json:"hostId,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_expected_power_shelf.go
+++ b/sdk/standard/model_expected_power_shelf.go
@@ -64,8 +64,7 @@ type ExpectedPowerShelf struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32 `json:"hostId,omitempty"`
-	// User-defined key-value pairs for organizing and categorizing Expected Power Shelves
+	HostId NullableInt32     `json:"hostId,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
 	// ISO 8601 datetime when the Expected Power Shelf was created
 	Created *time.Time `json:"created,omitempty"`

--- a/sdk/standard/model_expected_power_shelf_create_request.go
+++ b/sdk/standard/model_expected_power_shelf_create_request.go
@@ -67,8 +67,7 @@ type ExpectedPowerShelfCreateRequest struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32 `json:"hostId,omitempty"`
-	// User-defined key-value pairs for organizing and categorizing Expected Power Shelves
+	HostId NullableInt32     `json:"hostId,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_expected_power_shelf_update_request.go
+++ b/sdk/standard/model_expected_power_shelf_update_request.go
@@ -65,8 +65,7 @@ type ExpectedPowerShelfUpdateRequest struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32 `json:"hostId,omitempty"`
-	// User-defined key-value pairs for organizing and categorizing Expected Power Shelves
+	HostId NullableInt32     `json:"hostId,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_expected_rack.go
+++ b/sdk/standard/model_expected_rack.go
@@ -48,9 +48,8 @@ type ExpectedRack struct {
 	// Human-readable name of the Expected Rack
 	Name *string `json:"name,omitempty"`
 	// Human-readable description of the Expected Rack
-	Description *string `json:"description,omitempty"`
-	// User-defined key-value pairs for organizing and categorizing Expected Racks. Well-known keys (`chassis.*`, `location.*`) are used to convey chassis identity and physical location.
-	Labels map[string]string `json:"labels,omitempty"`
+	Description *string           `json:"description,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
 	// ISO 8601 datetime when the Expected Rack was created
 	Created *time.Time `json:"created,omitempty"`
 	// ISO 8601 datetime when the Expected Rack was last updated

--- a/sdk/standard/model_expected_rack_create_request.go
+++ b/sdk/standard/model_expected_rack_create_request.go
@@ -47,9 +47,8 @@ type ExpectedRackCreateRequest struct {
 	// Human-readable name of the Expected Rack
 	Name NullableString `json:"name,omitempty"`
 	// Human-readable description of the Expected Rack
-	Description NullableString `json:"description,omitempty"`
-	// User-defined key-value pairs for organizing and categorizing Expected Racks. Well-known keys (`chassis.*`, `location.*`) are used to convey chassis identity and physical location.
-	Labels map[string]string `json:"labels,omitempty"`
+	Description NullableString    `json:"description,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
 }
 
 type _ExpectedRackCreateRequest ExpectedRackCreateRequest

--- a/sdk/standard/model_expected_rack_update_request.go
+++ b/sdk/standard/model_expected_rack_update_request.go
@@ -45,9 +45,8 @@ type ExpectedRackUpdateRequest struct {
 	// Human-readable name of the Expected Rack
 	Name NullableString `json:"name,omitempty"`
 	// Human-readable description of the Expected Rack
-	Description NullableString `json:"description,omitempty"`
-	// User-defined key-value pairs for organizing and categorizing Expected Racks. Well-known keys (`chassis.*`, `location.*`) are used to convey chassis identity and physical location.
-	Labels map[string]string `json:"labels,omitempty"`
+	Description NullableString    `json:"description,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
 }
 
 // NewExpectedRackUpdateRequest instantiates a new ExpectedRackUpdateRequest object

--- a/sdk/standard/model_expected_switch.go
+++ b/sdk/standard/model_expected_switch.go
@@ -64,8 +64,7 @@ type ExpectedSwitch struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32 `json:"hostId,omitempty"`
-	// User-defined key-value pairs for organizing and categorizing Expected Switches
+	HostId NullableInt32     `json:"hostId,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
 	// ISO 8601 datetime when the Expected Switch was created
 	Created *time.Time `json:"created,omitempty"`

--- a/sdk/standard/model_expected_switch_create_request.go
+++ b/sdk/standard/model_expected_switch_create_request.go
@@ -71,8 +71,7 @@ type ExpectedSwitchCreateRequest struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32 `json:"hostId,omitempty"`
-	// User-defined key-value pairs for organizing and categorizing Expected Switches
+	HostId NullableInt32     `json:"hostId,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_expected_switch_update_request.go
+++ b/sdk/standard/model_expected_switch_update_request.go
@@ -69,8 +69,7 @@ type ExpectedSwitchUpdateRequest struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32 `json:"hostId,omitempty"`
-	// User-defined key-value pairs for organizing and categorizing Expected Switches
+	HostId NullableInt32     `json:"hostId,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_infini_band_partition.go
+++ b/sdk/standard/model_infini_band_partition.go
@@ -37,24 +37,23 @@ var _ MappedNullable = &InfiniBandPartition{}
 
 // InfiniBandPartition InfiniBand Partitions are network segments utilizing InfiniBand topology
 type InfiniBandPartition struct {
-	Id                      *string         `json:"id,omitempty"`
-	Name                    *string         `json:"name,omitempty"`
-	Description             NullableString  `json:"description,omitempty"`
-	SiteId                  *string         `json:"siteId,omitempty"`
-	TenantId                *string         `json:"tenantId,omitempty"`
-	ControllerIBPartitionId NullableString  `json:"controllerIBPartitionId,omitempty"`
-	PartitionKey            NullableString  `json:"partitionKey,omitempty"`
-	PartitionName           NullableString  `json:"partitionName,omitempty"`
-	ServiceLevel            NullableInt32   `json:"serviceLevel,omitempty"`
-	RateLimit               NullableFloat32 `json:"rateLimit,omitempty"`
-	Mtu                     NullableInt32   `json:"mtu,omitempty"`
-	EnableSharp             *bool           `json:"enableSharp,omitempty"`
-	// String key value pairs describing InfiniBand Partition labels. Up to 10 key value pairs can be specified
-	Labels        map[string]string          `json:"labels,omitempty"`
-	Status        *InfiniBandPartitionStatus `json:"status,omitempty"`
-	StatusHistory []StatusDetail             `json:"statusHistory,omitempty"`
-	Created       *time.Time                 `json:"created,omitempty"`
-	Updated       *time.Time                 `json:"updated,omitempty"`
+	Id                      *string                    `json:"id,omitempty"`
+	Name                    *string                    `json:"name,omitempty"`
+	Description             NullableString             `json:"description,omitempty"`
+	SiteId                  *string                    `json:"siteId,omitempty"`
+	TenantId                *string                    `json:"tenantId,omitempty"`
+	ControllerIBPartitionId NullableString             `json:"controllerIBPartitionId,omitempty"`
+	PartitionKey            NullableString             `json:"partitionKey,omitempty"`
+	PartitionName           NullableString             `json:"partitionName,omitempty"`
+	ServiceLevel            NullableInt32              `json:"serviceLevel,omitempty"`
+	RateLimit               NullableFloat32            `json:"rateLimit,omitempty"`
+	Mtu                     NullableInt32              `json:"mtu,omitempty"`
+	EnableSharp             *bool                      `json:"enableSharp,omitempty"`
+	Labels                  map[string]string          `json:"labels,omitempty"`
+	Status                  *InfiniBandPartitionStatus `json:"status,omitempty"`
+	StatusHistory           []StatusDetail             `json:"statusHistory,omitempty"`
+	Created                 *time.Time                 `json:"created,omitempty"`
+	Updated                 *time.Time                 `json:"updated,omitempty"`
 }
 
 // NewInfiniBandPartition instantiates a new InfiniBandPartition object

--- a/sdk/standard/model_infini_band_partition_create_request.go
+++ b/sdk/standard/model_infini_band_partition_create_request.go
@@ -43,8 +43,7 @@ type InfiniBandPartitionCreateRequest struct {
 	// Optional description of the Partition
 	Description NullableString `json:"description,omitempty"`
 	// ID of the Site the Partition should belong to
-	SiteId string `json:"siteId"`
-	// String key value pairs describing Partition labels. Up to 10 key value pairs can be specified
+	SiteId string            `json:"siteId"`
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_infini_band_partition_update_request.go
+++ b/sdk/standard/model_infini_band_partition_update_request.go
@@ -38,10 +38,9 @@ var _ MappedNullable = &InfiniBandPartitionUpdateRequest{}
 
 // InfiniBandPartitionUpdateRequest Request data to update an InfiniBand Partition
 type InfiniBandPartitionUpdateRequest struct {
-	Name        string         `json:"name"`
-	Description NullableString `json:"description,omitempty"`
-	// String key value pairs describing Partition labels. Up to 10 key value pairs can be specified
-	Labels map[string]string `json:"labels,omitempty"`
+	Name        string            `json:"name"`
+	Description NullableString    `json:"description,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
 }
 
 type _InfiniBandPartitionUpdateRequest InfiniBandPartitionUpdateRequest

--- a/sdk/standard/model_instance_update_request.go
+++ b/sdk/standard/model_instance_update_request.go
@@ -58,9 +58,8 @@ type InstanceUpdateRequest struct {
 	// Whether the custom iPXE data should be used for every boot.
 	AlwaysBootWithCustomIpxe NullableBool `json:"alwaysBootWithCustomIpxe,omitempty"`
 	// Indicates whether the Phone Home service should be enabled or disabled for Instance
-	PhoneHomeEnabled NullableBool `json:"phoneHomeEnabled,omitempty"`
-	// Update labels of the Instance. The labels will be entirely replaced by those sent in the request. Any labels not included in the request will be removed. To retain existing labels, first fetch them and include them along with this request.
-	Labels map[string]string `json:"labels,omitempty"`
+	PhoneHomeEnabled NullableBool      `json:"phoneHomeEnabled,omitempty"`
+	Labels           map[string]string `json:"labels,omitempty"`
 	// IDs of additional VPCs the Instance should attach to through non-primary interfaces. This field may only be specified when every entry in `interfaces` uses `vpcPrefixId`. IDs must be unique, must be valid UUIDs, and must not include the primary `vpcId`.
 	SecondaryVpcIds []string `json:"secondaryVpcIds,omitempty"`
 	// Update Interfaces of the Instance

--- a/sdk/standard/model_machine_online_repair.go
+++ b/sdk/standard/model_machine_online_repair.go
@@ -38,7 +38,7 @@ var _ MappedNullable = &MachineOnlineRepair{}
 
 // MachineOnlineRepair Enable or disable online repair of a Machine. Online repair facilitates repairing a Machine without the Tenant having to release the Machine by deleting the Instance. When `enabled` is true, `policy` and `acknowledgments` are required inside this object, and `healthIssue` is required at the top level of the MachineUpdateRequest. When `enabled` is false, none of those fields may be set.
 type MachineOnlineRepair struct {
-	// When true, initiates the online repair process: sends a core compatible merge-mode health override (source `request-online-repair`, matching Core RequestOnlineRepair) and sets the associated Instance status to Repairing. When false, exits online repair: clears that health override and returns the Instance to Ready. Cannot be combined with instance type, maintenance, or label updates in the same request.
+	// When true, initiates the online repair process by sending a merge-mode health override with source: `request-online-repair` and sets the associated Instance status to Repairing. When false, exits online repair by clearing the merge-mode health override and returns the Instance to Ready status. Cannot be combined with instance type, maintenance, or label updates in the same request.
 	Enabled         bool                                `json:"enabled"`
 	Policy          *MachineOnlineRepairPolicy          `json:"policy,omitempty"`
 	Acknowledgments *MachineOnlineRepairAcknowledgments `json:"acknowledgments,omitempty"`

--- a/sdk/standard/model_machine_online_repair.go
+++ b/sdk/standard/model_machine_online_repair.go
@@ -38,7 +38,7 @@ var _ MappedNullable = &MachineOnlineRepair{}
 
 // MachineOnlineRepair Enable or disable online repair of a Machine. Online repair facilitates repairing a Machine without the Tenant having to release the Machine by deleting the Instance. When `enabled` is true, `policy` and `acknowledgments` are required inside this object, and `healthIssue` is required at the top level of the MachineUpdateRequest. When `enabled` is false, none of those fields may be set.
 type MachineOnlineRepair struct {
-	// When true, initiates the online repair process: applies the tenant-reported OnlineRepair health override on the Machine and sets the associated Instance status to Repairing. When false, exits online repair: clears the health override and returns the Instance to Ready. Cannot be combined with instance type, maintenance, or label updates in the same request.
+	// When true, initiates the online repair process: sends a core compatible merge-mode health override (source `request-online-repair`, matching Core RequestOnlineRepair) and sets the associated Instance status to Repairing. When false, exits online repair: clears that health override and returns the Instance to Ready. Cannot be combined with instance type, maintenance, or label updates in the same request.
 	Enabled         bool                                `json:"enabled"`
 	Policy          *MachineOnlineRepairPolicy          `json:"policy,omitempty"`
 	Acknowledgments *MachineOnlineRepairAcknowledgments `json:"acknowledgments,omitempty"`

--- a/sdk/standard/model_machine_update_request.go
+++ b/sdk/standard/model_machine_update_request.go
@@ -43,10 +43,9 @@ type MachineUpdateRequest struct {
 	// Set to `true` to enable maintenance mode and to `false` to disable maintenance mode. Can be set by Provider or Privileged Tenant.
 	SetMaintenanceMode NullableBool `json:"setMaintenanceMode,omitempty"`
 	// Optional message describing the reason for moving Machine into maintenance mode. Can be updated by Provider or Privileged Tenant.
-	MaintenanceMessage NullableString `json:"maintenanceMessage,omitempty"`
-	// Machine labels will be overwritten, include existing labels to preserve them. Can be updated by Provider or Privileged Tenant.
-	Labels       map[string]string    `json:"labels,omitempty"`
-	OnlineRepair *MachineOnlineRepair `json:"onlineRepair,omitempty"`
+	MaintenanceMessage NullableString       `json:"maintenanceMessage,omitempty"`
+	Labels             map[string]string    `json:"labels,omitempty"`
+	OnlineRepair       *MachineOnlineRepair `json:"onlineRepair,omitempty"`
 	// Required when `onlineRepair.enabled` is true. Must not be set when exiting online repair (`onlineRepair.enabled` false).
 	HealthIssue *MachineHealthIssue `json:"healthIssue,omitempty"`
 }

--- a/sdk/standard/model_vpc.go
+++ b/sdk/standard/model_vpc.go
@@ -64,9 +64,8 @@ type VPC struct {
 	// Propagation details for the attached Network Security Group
 	NetworkSecurityGroupPropagationDetails *NetworkSecurityGroupPropagationDetails `json:"networkSecurityGroupPropagationDetails,omitempty"`
 	// ID of the default NVLink Logical Partition that GPUs for all Instances in the VPC will attach to
-	NvLinkLogicalPartitionId NullableString `json:"nvLinkLogicalPartitionId,omitempty"`
-	// String key value pairs describing VPC labels
-	Labels map[string]string `json:"labels,omitempty"`
+	NvLinkLogicalPartitionId NullableString    `json:"nvLinkLogicalPartitionId,omitempty"`
+	Labels                   map[string]string `json:"labels,omitempty"`
 	// Status of the VPC
 	Status *VpcStatus `json:"status,omitempty"`
 	// History of status changes for the VPC

--- a/sdk/standard/model_vpc_create_request.go
+++ b/sdk/standard/model_vpc_create_request.go
@@ -55,9 +55,8 @@ type VpcCreateRequest struct {
 	// Explicitly requested VNI for the VPC
 	Vni NullableInt32 `json:"vni,omitempty"`
 	// ID of the default NVLink Logical Partition that GPUs for all Instances in the VPC will attach to
-	NvLinkLogicalPartitionId NullableString `json:"nvLinkLogicalPartitionId,omitempty"`
-	// String key value pairs describing VPC labels. Up to 10 key value pairs can be specified
-	Labels map[string]string `json:"labels,omitempty"`
+	NvLinkLogicalPartitionId NullableString    `json:"nvLinkLogicalPartitionId,omitempty"`
+	Labels                   map[string]string `json:"labels,omitempty"`
 }
 
 type _VpcCreateRequest VpcCreateRequest

--- a/sdk/standard/model_vpc_update_request.go
+++ b/sdk/standard/model_vpc_update_request.go
@@ -43,9 +43,8 @@ type VpcUpdateRequest struct {
 	// ID of the Network Security Group to attach to the VPC
 	NetworkSecurityGroupId NullableString `json:"networkSecurityGroupId,omitempty"`
 	// ID of the default NVLink Logical Partition that GPUs for all Instances in the VPC will attach to. Can only be updated if VPC currently has no active Instances
-	NvLinkLogicalPartitionId NullableString `json:"nvLinkLogicalPartitionId,omitempty"`
-	// Update labels of the VPC. Up to 10 key value pairs can be specified. The labels will be entirely replaced by those sent in the request. Any labels not included in the request will be removed. To retain existing labels, first fetch them and include them along with this request.
-	Labels map[string]string `json:"labels,omitempty"`
+	NvLinkLogicalPartitionId NullableString    `json:"nvLinkLogicalPartitionId,omitempty"`
+	Labels                   map[string]string `json:"labels,omitempty"`
 }
 
 // NewVpcUpdateRequest instantiates a new VpcUpdateRequest object

--- a/site-workflow/pkg/activity/machine_test.go
+++ b/site-workflow/pkg/activity/machine_test.go
@@ -150,12 +150,12 @@ func TestManageMachine_CreateMachineHealthReportOverrideOnSite(t *testing.T) {
 		MachineId: &cwssaws.MachineId{Id: "machine-1"},
 		Override: &cwssaws.HealthReportOverride{
 			Report: &cwssaws.HealthReport{
-				Source: "tenant-reported-issue",
+				Source: "request-online-repair",
 				Alerts: []*cwssaws.HealthProbeAlert{
 					{Id: "OnLineRepair", Message: `{"details":"d","issue_category":"OTHER","summary":"s"}`},
 				},
 			},
-			Mode: cwssaws.OverrideMode_Replace,
+			Mode: cwssaws.OverrideMode_Merge,
 		},
 	}
 	assert.NoError(t, mm.CreateMachineHealthReportOverrideOnSite(context.Background(), req))
@@ -173,7 +173,7 @@ func TestManageMachine_DeleteMachineHealthReportOverrideOnSite(t *testing.T) {
 	mm := NewManageMachine(coreGrpcAtomicClient)
 	req := &cwssaws.RemoveHealthReportOverrideRequest{
 		MachineId: &cwssaws.MachineId{Id: "machine-1"},
-		Source:    "tenant-reported-issue",
+		Source:    "request-online-repair",
 	}
 	assert.NoError(t, mm.DeleteMachineHealthReportOverrideOnSite(context.Background(), req))
 

--- a/site-workflow/pkg/workflow/machine_test.go
+++ b/site-workflow/pkg/workflow/machine_test.go
@@ -190,12 +190,12 @@ func (s *MachineWorkflowTestSuite) Test_CreateMachineHealthReportOverride_Succes
 		MachineId: &cwssaws.MachineId{Id: uuid.New().String()},
 		Override: &cwssaws.HealthReportOverride{
 			Report: &cwssaws.HealthReport{
-				Source: "tenant-reported-issue",
+				Source: "request-online-repair",
 				Alerts: []*cwssaws.HealthProbeAlert{
 					{Id: "OnLineRepair", Message: `{"details":"d","issue_category":"OTHER","summary":"s"}`},
 				},
 			},
-			Mode: cwssaws.OverrideMode_Replace,
+			Mode: cwssaws.OverrideMode_Merge,
 		},
 	}
 	s.env.RegisterActivity(machineManager.CreateMachineHealthReportOverrideOnSite)
@@ -209,7 +209,7 @@ func (s *MachineWorkflowTestSuite) Test_DeleteMachineHealthReportOverride_Succes
 	var machineManager mActivity.ManageMachine
 	req := &cwssaws.RemoveHealthReportOverrideRequest{
 		MachineId: &cwssaws.MachineId{Id: uuid.New().String()},
-		Source:    "tenant-reported-issue",
+		Source:    "request-online-repair",
 	}
 	s.env.RegisterActivity(machineManager.DeleteMachineHealthReportOverrideOnSite)
 	s.env.OnActivity(machineManager.DeleteMachineHealthReportOverrideOnSite, mock.Anything, mock.Anything).Return(nil)


### PR DESCRIPTION
## Description
- Adding Instance status info when Machine is in repair or out.
- Updated Instance status check, Allow Instance delete label check, Health override alert present before removing health override
- Updated mode and source info according CORE changes

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Fix** - Bug fixes (fix:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **API** - API models or endpoints updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [x] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
