### PR TITLE
feat: Add Flat VPC type and instance `auto` interface support

### DIFF
--- a/api/pkg/api/handler/instance.go
+++ b/api/pkg/api/handler/instance.go
@@ -70,6 +70,22 @@ type CreateInstanceHandler struct {
 	tracerSpan *cutil.TracerSpan
 }
 
+// buildInstanceNetworkConfig assembles the workflow
+// InstanceNetworkConfig from the persisted auto flag and the
+// per-interface configs built earlier in the handler. When auto is
+// true the explicit interface list is intentionally omitted: NICo
+// resolves interfaces from the host's HostInband segments, so
+// sending an explicit list alongside auto=true is contradictory
+// (rejected by Core, and on update could otherwise carry forward
+// the instance's previously-persisted interfaces).
+func buildInstanceNetworkConfig(auto bool, interfaceConfigs []*cwssaws.InstanceInterfaceConfig) *cwssaws.InstanceNetworkConfig {
+	nc := &cwssaws.InstanceNetworkConfig{Auto: auto}
+	if !auto {
+		nc.Interfaces = interfaceConfigs
+	}
+	return nc
+}
+
 // NewCreateInstanceHandler initializes and returns a new handler for creating Instance
 func NewCreateInstanceHandler(dbSession *cdb.Session, tc temporalClient.Client, scp *sc.ClientPool, cfg *config.Config) CreateInstanceHandler {
 	return CreateInstanceHandler{
@@ -363,6 +379,16 @@ func (cih CreateInstanceHandler) Handle(c echo.Context) error {
 	if vpc.ControllerVpcID == nil || vpc.Status != cdbm.VpcStatusReady {
 		logger.Warn().Msg("VPC specified in request data is not ready")
 		return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "VPC specified in request data is not ready", nil)
+	}
+
+	// `auto` is the explicit signal that an Instance lives on a zero-DPU
+	// host (or a host with its DPU in NIC mode); those instances must be
+	// in a Flat VPC. Core also rejects this combination, but we surface
+	// the error here as defense in depth and to avoid round-tripping the
+	// site for an obviously bad request.
+	if apiRequest.Auto && !cdbm.VpcTypeSupportsAutoInterface(vpc.NetworkVirtualizationType) {
+		logger.Warn().Msg("auto-network instances may only be created in a Flat VPC")
+		return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "`auto` is only supported when the VPC has `networkVirtualizationType` set to `FLAT`", nil)
 	}
 
 	var defaultNvllpID *uuid.UUID
@@ -1262,6 +1288,7 @@ func (cih CreateInstanceHandler) Handle(c echo.Context) error {
 			AlwaysBootWithCustomIpxe: *apiRequest.AlwaysBootWithCustomIpxe,
 			PhoneHomeEnabled:         *apiRequest.PhoneHomeEnabled,
 			UserData:                 apiRequest.UserData,
+			NetworkAuto:              apiRequest.Auto,
 			NetworkSecurityGroupID:   apiRequest.NetworkSecurityGroupID,
 			Labels:                   apiRequest.Labels,
 			IsUpdatePending:          false,
@@ -1286,7 +1313,7 @@ func (cih CreateInstanceHandler) Handle(c echo.Context) error {
 		// Update the controller ID
 		// We need this to match the instance ID.  This was previously handled
 		// by the async cloud workflow after successful creation on site.
-		instance, derr = instanceDAO.Update(ctx, tx, cdbm.InstanceUpdateInput{InstanceID: instance.ID, ControllerInstanceID: cdb.GetUUIDPtr(instance.ID)})
+		instance, derr = instanceDAO.Update(ctx, tx, cdbm.InstanceUpdateInput{InstanceID: instance.ID, InstanceUpdateCommon: cdbm.InstanceUpdateCommon{ControllerInstanceID: cdb.GetUUIDPtr(instance.ID)}})
 		if derr != nil {
 			logger.Error().Err(derr).Msg("unable to update Instance record controllerInstanceID in DB")
 			return cutil.NewAPIError(http.StatusInternalServerError, "Failed updating new Instance record, DB error", nil)
@@ -1552,10 +1579,8 @@ func (cih CreateInstanceHandler) Handle(c echo.Context) error {
 					TenantOrganizationId: tenant.Org,
 					TenantKeysetIds:      instanceSshKeyGroupIds,
 				},
-				Os: osConfig,
-				Network: &cwssaws.InstanceNetworkConfig{
-					Interfaces: interfaceConfigs,
-				},
+				Os:      osConfig,
+				Network: buildInstanceNetworkConfig(instance.NetworkAuto, interfaceConfigs),
 				Infiniband: &cwssaws.InstanceInfinibandConfig{
 					IbInterfaces: ibInterfaceConfigs,
 				},
@@ -1705,10 +1730,12 @@ func (uih UpdateInstanceHandler) handleReboot(c echo.Context, logger *zerolog.Lo
 		var derr error
 		ui, derr = instanceDAO.Update(ctx, tx,
 			cdbm.InstanceUpdateInput{
-				InstanceID:  instance.ID,
-				Name:        apiRequest.Name,
-				Description: apiRequest.Description,
-				PowerStatus: powerStatus,
+				InstanceID: instance.ID,
+				InstanceUpdateCommon: cdbm.InstanceUpdateCommon{
+					Name:        apiRequest.Name,
+					Description: apiRequest.Description,
+					PowerStatus: powerStatus,
+				},
 			},
 		)
 		if derr != nil {
@@ -2140,6 +2167,34 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 	// we know the caller has access to this instance.
 	if instance.Status == cdbm.InstanceStatusTerminating || instance.Status == cdbm.InstanceStatusTerminated {
 		return cutil.NewAPIErrorResponse(c, http.StatusConflict, "Instance is terminating and cannot be updated", nil)
+	}
+
+	// `auto: true` (re-)resolves interfaces from the host's HostInband
+	// segments; this only makes sense in a Flat VPC. Core also rejects
+	// this combination, but we surface the error here as defense in
+	// depth and to avoid round-tripping the site for an obviously bad
+	// request. `auto: false` is permitted on any VPC type (it's the
+	// default state).
+	if apiRequest.Auto != nil && *apiRequest.Auto && !cdbm.VpcTypeSupportsAutoInterface(vpc.NetworkVirtualizationType) {
+		logger.Warn().Msg("auto-network update is only valid for instances in a Flat VPC")
+		return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "`auto: true` is only supported when the Instance's VPC has `networkVirtualizationType` set to `FLAT`", nil)
+	}
+
+	// Reject explicit `interfaces` when the effective post-update state
+	// would still have auto enabled. `effectiveAuto` is the request's
+	// value when supplied, otherwise the instance's currently-persisted
+	// state. Validation already rejects (auto=true, interfaces=[...]) in
+	// the same payload, but a PATCH that omits `auto` against an
+	// already-auto instance would otherwise slip past and persist
+	// Interface rows that `buildInstanceNetworkConfig` then drops from
+	// the workflow payload -- leaving DB/site state diverged.
+	effectiveAuto := instance.NetworkAuto
+	if apiRequest.Auto != nil {
+		effectiveAuto = *apiRequest.Auto
+	}
+	if effectiveAuto && len(apiRequest.Interfaces) > 0 {
+		logger.Warn().Msg("explicit interfaces cannot be updated while the instance remains in auto mode")
+		return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "`interfaces` cannot be set while `auto` is true; disable `auto` first or omit `interfaces`", nil)
 	}
 
 	if instance.IsMissingOnSite {
@@ -2757,17 +2812,20 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 		var derr error
 		ui, derr = instanceDAO.Update(ctx, tx,
 			cdbm.InstanceUpdateInput{
-				InstanceID:               instanceID,
-				Name:                     apiRequest.Name,
-				Description:              apiRequest.Description,
-				OperatingSystemID:        osID,
-				IpxeScript:               apiRequest.IpxeScript,
-				AlwaysBootWithCustomIpxe: apiRequest.AlwaysBootWithCustomIpxe,
-				NetworkSecurityGroupID:   nsgID,
-				PhoneHomeEnabled:         apiRequest.PhoneHomeEnabled,
-				Status:                   instanceStatusConfiguring,
-				UserData:                 apiRequest.UserData,
-				Labels:                   apiRequest.Labels,
+				InstanceID: instanceID,
+				InstanceUpdateCommon: cdbm.InstanceUpdateCommon{
+					Name:                     apiRequest.Name,
+					Description:              apiRequest.Description,
+					OperatingSystemID:        osID,
+					IpxeScript:               apiRequest.IpxeScript,
+					AlwaysBootWithCustomIpxe: apiRequest.AlwaysBootWithCustomIpxe,
+					NetworkSecurityGroupID:   nsgID,
+					PhoneHomeEnabled:         apiRequest.PhoneHomeEnabled,
+					Status:                   instanceStatusConfiguring,
+					UserData:                 apiRequest.UserData,
+					NetworkAuto:              apiRequest.Auto,
+					Labels:                   apiRequest.Labels,
+				},
 			},
 		)
 		if derr != nil {
@@ -2942,8 +3000,30 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 			return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve current Ethernet Interfaces for Instance, DB error", nil)
 		}
 
-		// Create new Interface records in the DB if specified in request
-		if len(apiRequest.Interfaces) > 0 {
+		// Create new Interface records in the DB if specified in request.
+		//
+		// Three branches:
+		//   - Switching to auto mode (`ui.NetworkAuto && len(apiRequest.Interfaces) == 0`):
+		//     mark every prior explicit interface row as Deleting and
+		//     return an empty list. Reads after this should reflect the
+		//     auto contract (no explicit interfaces) rather than the
+		//     stale rows that pre-dated the mode switch.
+		//   - Explicit interfaces in the request: create the new rows
+		//     and mark the previous rows as Deleting (existing behavior).
+		//   - Neither (no interface change, not switching to auto):
+		//     carry the existing rows forward.
+		switch {
+		case ui.NetworkAuto && len(apiRequest.Interfaces) == 0:
+			for i := range existingIfcs {
+				existingIfcs[i].Status = cdbm.InterfaceStatusDeleting
+				_, err := ifcDAO.Update(ctx, tx, cdbm.InterfaceUpdateInput{InterfaceID: existingIfcs[i].ID, Status: cdb.GetStrPtr(cdbm.InterfaceStatusDeleting)})
+				if err != nil {
+					logger.Error().Err(err).Msg("failed to update Interface record in DB")
+					return cutil.NewAPIError(http.StatusInternalServerError, "Failed to update Interface for Instance, DB error", nil)
+				}
+			}
+			newdbIfcs = []cdbm.Interface{}
+		case len(apiRequest.Interfaces) > 0:
 			for _, dbifc := range dbInterfaces {
 				input := cdbm.InterfaceCreateInput{
 					InstanceID:         instance.ID,
@@ -2979,7 +3059,7 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 					return cutil.NewAPIError(http.StatusInternalServerError, "Failed to update Interface for Instance, DB error", nil)
 				}
 			}
-		} else {
+		default:
 			newdbIfcs = existingIfcs
 		}
 
@@ -3458,10 +3538,8 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 					TenantOrganizationId: tenant.Org,
 					TenantKeysetIds:      instanceSshKeyGroupIds,
 				},
-				Os: osConfig,
-				Network: &cwssaws.InstanceNetworkConfig{
-					Interfaces: interfaceConfigs,
-				},
+				Os:      osConfig,
+				Network: buildInstanceNetworkConfig(ui.NetworkAuto, interfaceConfigs),
 				Infiniband: &cwssaws.InstanceInfinibandConfig{
 					IbInterfaces: ibInterfaceConfigs,
 				},
@@ -4641,7 +4719,7 @@ func (dih DeleteInstanceHandler) Handle(c echo.Context) error {
 
 	err = cdb.WithTx(ctx, dih.dbSession, func(tx *cdb.Tx) error {
 		// Update Instance to set status to Deleting
-		_, derr := instanceDAO.Update(ctx, tx, cdbm.InstanceUpdateInput{InstanceID: instance.ID, Status: cdb.GetStrPtr(cdbm.InstanceStatusTerminating)})
+		_, derr := instanceDAO.Update(ctx, tx, cdbm.InstanceUpdateInput{InstanceID: instance.ID, InstanceUpdateCommon: cdbm.InstanceUpdateCommon{Status: cdb.GetStrPtr(cdbm.InstanceStatusTerminating)}})
 		if derr != nil {
 			logger.Error().Err(derr).Msg("error updating Instance in DB")
 			return cutil.NewAPIError(http.StatusInternalServerError, "Failed to delete Instance", nil)

--- a/api/pkg/api/handler/instance_test.go
+++ b/api/pkg/api/handler/instance_test.go
@@ -3385,6 +3385,38 @@ func TestCreateInstanceHandler_Handle(t *testing.T) {
 			wantErr:            false,
 			verifyChildSpanner: true,
 		},
+		{
+			// vpc1 is an ETHERNET_VIRTUALIZER VPC; `auto: true` is only
+			// valid for instances in a Flat VPC. The model validator
+			// admits the empty-interfaces + auto pair, so this exercises
+			// the handler-side cross-check that fetches the VPC and
+			// rejects the mismatch before the workflow is invoked.
+			name: "test Instance create API endpoint rejects auto=true on a non-Flat VPC",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        tc,
+				cfg:       cfg,
+			},
+			args: args{
+				reqData: &model.APIInstanceCreateRequest{
+					Name:              "Test Auto on ETV VPC",
+					Description:       cdb.GetStrPtr("auto=true must be rejected outside Flat VPCs"),
+					TenantID:          tn1.ID.String(),
+					InstanceTypeID:    cdb.GetStrPtr(ist1.ID.String()),
+					VpcID:             vpc1.ID.String(),
+					OperatingSystemID: cdb.GetStrPtr(os1.ID.String()),
+					IpxeScript:        cdb.GetStrPtr(common.DefaultIpxeScript),
+					Auto:              true,
+					Interfaces:        []model.APIInterfaceCreateOrUpdateRequest{},
+				},
+				reqOrg:      tnOrg,
+				reqUser:     tnu1,
+				respCode:    http.StatusBadRequest,
+				respMessage: "`auto` is only supported when the VPC has `networkVirtualizationType` set to `FLAT`",
+			},
+			wantErr:            false,
+			verifyChildSpanner: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -3587,8 +3619,8 @@ func TestCreateInstanceHandler_Handle(t *testing.T) {
 func resetInstanceStatus(t *testing.T, dbSession *cdb.Session, instanceID uuid.UUID, status string) {
 	instanceDAO := cdbm.NewInstanceDAO(dbSession)
 	_, err := instanceDAO.Update(context.Background(), nil, cdbm.InstanceUpdateInput{
-		InstanceID: instanceID,
-		Status:     cdb.GetStrPtr(status),
+		InstanceID:           instanceID,
+		InstanceUpdateCommon: cdbm.InstanceUpdateCommon{Status: cdb.GetStrPtr(status)},
 	})
 	if err != nil {
 		t.Fatalf("error updating instance status: %v", err)
@@ -4029,8 +4061,8 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 
 	insDAO := cdbm.NewInstanceDAO(dbSession)
 	_, err := insDAO.Update(context.Background(), nil, cdbm.InstanceUpdateInput{
-		InstanceID:      inst14.ID,
-		IsMissingOnSite: cdb.GetBoolPtr(true),
+		InstanceID:           inst14.ID,
+		InstanceUpdateCommon: cdbm.InstanceUpdateCommon{IsMissingOnSite: cdb.GetBoolPtr(true)},
 	})
 	assert.NoError(t, err)
 
@@ -6391,6 +6423,31 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 				reqUser:     tnu1,
 				respCode:    http.StatusConflict,
 				respMessage: cdb.GetStrPtr("Instance is missing on site and cannot be updated"),
+			},
+			wantErr: false,
+		},
+		{
+			// inst1 lives on vpc1 (ETHERNET_VIRTUALIZER). Toggling
+			// `auto: true` on an instance whose VPC isn't Flat must be
+			// rejected at the handler layer (the model validator only
+			// checks the `auto`/`interfaces` exclusivity; it can't see
+			// the VPC type).
+			name: "test Instance update API endpoint rejects auto=true on a non-Flat VPC",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        tc,
+				scp:       scp,
+				cfg:       cfg,
+			},
+			args: args{
+				reqData: &model.APIInstanceUpdateRequest{
+					Auto: cdb.GetBoolPtr(true),
+				},
+				reqInstance: inst1.ID.String(),
+				reqOrg:      tnOrg1,
+				reqUser:     tnu1,
+				respCode:    http.StatusBadRequest,
+				respMessage: cdb.GetStrPtr("`auto: true` is only supported when the Instance's VPC has `networkVirtualizationType` set to `FLAT`"),
 			},
 			wantErr: false,
 		},

--- a/api/pkg/api/handler/instancebatch.go
+++ b/api/pkg/api/handler/instancebatch.go
@@ -419,6 +419,16 @@ func (bcih BatchCreateInstanceHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "VPC specified in request data is not ready", nil)
 	}
 
+	// `auto` is the explicit signal that an Instance lives on a zero-DPU
+	// host (or a host with its DPU in NIC mode); those instances must be
+	// in a Flat VPC. Core also rejects this combination, but we surface
+	// the error here as defense in depth and to avoid round-tripping the
+	// site for an obviously bad request.
+	if apiRequest.Auto && !cdbm.VpcTypeSupportsAutoInterface(vpc.NetworkVirtualizationType) {
+		logger.Warn().Msg("auto-network instances may only be created in a Flat VPC")
+		return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "`auto` is only supported when the VPC has `networkVirtualizationType` set to `FLAT`", nil)
+	}
+
 	var defaultNvllpID *uuid.UUID
 	if vpc.NVLinkLogicalPartitionID != nil {
 		// NOTE: No validation needed here because the VPC validation ensures the NVLink Logical Partition is valid for this instance
@@ -1239,6 +1249,7 @@ func (bcih BatchCreateInstanceHandler) Handle(c echo.Context) error {
 			AlwaysBootWithCustomIpxe: *apiRequest.AlwaysBootWithCustomIpxe,
 			PhoneHomeEnabled:         *apiRequest.PhoneHomeEnabled,
 			UserData:                 apiRequest.UserData,
+			NetworkAuto:              apiRequest.Auto,
 			NetworkSecurityGroupID:   apiRequest.NetworkSecurityGroupID,
 			Labels:                   apiRequest.Labels,
 			InstanceTypeID:           &apiInstanceTypeID,
@@ -1258,20 +1269,27 @@ func (bcih BatchCreateInstanceHandler) Handle(c echo.Context) error {
 	}
 	logger.Info().Int("count", len(createdInstances)).Msg("batch created all instance records")
 
-	// --- Build and batch update ControllerInstanceIDs ---
-	instanceUpdateInputs := make([]cdbm.InstanceUpdateInput, 0, len(createdInstances))
+	// --- Set each instance's ControllerInstanceID to its own ID ---
+	//
+	// Each row needs a *different* ControllerInstanceID value (its own
+	// ID), so this doesn't fit `UpdateMultiple`'s shared-mask /
+	// shared-values contract. We issue one single-row Update per
+	// instance inside the existing transaction -- atomic and cheap at
+	// the batch sizes we support (capped at MaxBatchSize, ~18 today).
+	updatedInstances := make([]cdbm.Instance, 0, len(createdInstances))
 	for _, inst := range createdInstances {
-		instanceUpdateInputs = append(instanceUpdateInputs, cdbm.InstanceUpdateInput{
-			InstanceID:           inst.ID,
-			ControllerInstanceID: cdb.GetUUIDPtr(inst.ID),
+		updated, uerr := inDAO.Update(ctx, tx, cdbm.InstanceUpdateInput{
+			InstanceID: inst.ID,
+			InstanceUpdateCommon: cdbm.InstanceUpdateCommon{
+				ControllerInstanceID: cdb.GetUUIDPtr(inst.ID),
+			},
 		})
-	}
-
-	updatedInstances, err := inDAO.UpdateMultiple(ctx, tx, instanceUpdateInputs)
-	if err != nil {
-		logger.Error().Err(err).Msg("failed to batch update controller instance IDs")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError,
-			fmt.Sprintf("Failed to batch update instances: %v", err), nil)
+		if uerr != nil {
+			logger.Error().Err(uerr).Msg("failed to update controller instance ID")
+			return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError,
+				fmt.Sprintf("Failed to update Instance: %v", uerr), nil)
+		}
+		updatedInstances = append(updatedInstances, *updated)
 	}
 	logger.Info().Int("count", len(updatedInstances)).Msg("batch updated all controller instance IDs")
 
@@ -1626,10 +1644,8 @@ func (bcih BatchCreateInstanceHandler) Handle(c echo.Context) error {
 					TenantOrganizationId: tenant.Org,
 					TenantKeysetIds:      instanceSshKeyGroupIds,
 				},
-				Os: osConfig,
-				Network: &cwssaws.InstanceNetworkConfig{
-					Interfaces: data.interfaceConfigs,
-				},
+				Os:      osConfig,
+				Network: buildInstanceNetworkConfig(instance.NetworkAuto, data.interfaceConfigs),
 				Infiniband: &cwssaws.InstanceInfinibandConfig{
 					IbInterfaces: data.ibInterfaceConfigs,
 				},

--- a/api/pkg/api/handler/instancebatch_test.go
+++ b/api/pkg/api/handler/instancebatch_test.go
@@ -1247,6 +1247,35 @@ func TestBatchCreateInstanceHandler_Handle(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			// vpc1 is an ETHERNET_VIRTUALIZER VPC; `auto: true` is only
+			// valid for instances in a Flat VPC. The handler-side
+			// cross-check should reject the mismatch before any workflow
+			// is invoked.
+			name: "test batch instance create API endpoint rejects auto=true on a non-Flat VPC",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        tc,
+				scp:       scp,
+				cfg:       cfg,
+			},
+			args: args{
+				reqData: &model.APIBatchInstanceCreateRequest{
+					NamePrefix:     "test-auto-non-flat",
+					Count:          2,
+					TenantID:       tn1.ID.String(),
+					InstanceTypeID: ist1.ID.String(),
+					VpcID:          vpc1.ID.String(),
+					IpxeScript:     cdb.GetStrPtr("test script"),
+					Auto:           true,
+				},
+				reqOrg:   tnOrg,
+				reqUser:  tnu1,
+				respCode: http.StatusBadRequest,
+				respMsg:  "`auto` is only supported when the VPC has `networkVirtualizationType` set to `FLAT`",
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/api/pkg/api/handler/machine.go
+++ b/api/pkg/api/handler/machine.go
@@ -1418,8 +1418,10 @@ func (umh UpdateMachineHandler) Handle(c echo.Context) error {
 
 				_, derr = iDAO.Update(ctx, orTx, cdbm.InstanceUpdateInput{
 					InstanceID: inst.ID,
-					Status:     cdb.GetStrPtr(cdbm.InstanceStatusRepairing),
-					Labels:     instanceLabels,
+					InstanceUpdateCommon: cdbm.InstanceUpdateCommon{
+						Status: cdb.GetStrPtr(cdbm.InstanceStatusRepairing),
+						Labels: instanceLabels,
+					},
 				})
 				if derr != nil {
 					logger.Error().Err(derr).Msg("error updating Instance for online repair in DB")
@@ -1492,8 +1494,10 @@ func (umh UpdateMachineHandler) Handle(c echo.Context) error {
 
 				_, derr = iDAO.Update(ctx, orTx, cdbm.InstanceUpdateInput{
 					InstanceID: inst.ID,
-					Status:     cdb.GetStrPtr(cdbm.InstanceStatusReady),
-					Labels:     instanceLabels,
+					InstanceUpdateCommon: cdbm.InstanceUpdateCommon{
+						Status: cdb.GetStrPtr(cdbm.InstanceStatusReady),
+						Labels: instanceLabels,
+					},
 				})
 				if derr != nil {
 					logger.Error().Err(derr).Msg("error updating Instance after clearing online repair in DB")

--- a/api/pkg/api/handler/machine_test.go
+++ b/api/pkg/api/handler/machine_test.go
@@ -1813,8 +1813,10 @@ func TestMachineHandler_Update(t *testing.T) {
 		t.Helper()
 		_, uerr := isd.Update(context.Background(), nil, cdbm.InstanceUpdateInput{
 			InstanceID: iOnlineRepairReady.ID,
-			Status:     cdb.GetStrPtr(cdbm.InstanceStatusReady),
-			Labels:     map[string]string{},
+			InstanceUpdateCommon: cdbm.InstanceUpdateCommon{
+				Status: cdb.GetStrPtr(cdbm.InstanceStatusReady),
+				Labels: map[string]string{},
+			},
 		})
 		require.NoError(t, uerr)
 	}
@@ -1823,8 +1825,10 @@ func TestMachineHandler_Update(t *testing.T) {
 		t.Helper()
 		_, uerr := isd.Update(context.Background(), nil, cdbm.InstanceUpdateInput{
 			InstanceID: iOnlineRepairReady.ID,
-			Status:     cdb.GetStrPtr(cdbm.InstanceStatusRepairing),
-			Labels:     map[string]string{model.InstanceLabelOnlineRepairAllowAutoDeletion: "false"},
+			InstanceUpdateCommon: cdbm.InstanceUpdateCommon{
+				Status: cdb.GetStrPtr(cdbm.InstanceStatusRepairing),
+				Labels: map[string]string{model.InstanceLabelOnlineRepairAllowAutoDeletion: "false"},
+			},
 		})
 		require.NoError(t, uerr)
 	}
@@ -2571,8 +2575,10 @@ func TestMachineHandler_Update(t *testing.T) {
 					t.Helper()
 					_, uerr := isd.Update(context.Background(), nil, cdbm.InstanceUpdateInput{
 						InstanceID: iOnlineRepairReady.ID,
-						Status:     cdb.GetStrPtr(cdbm.InstanceStatusReady),
-						Labels:     map[string]string{model.InstanceLabelOnlineRepairAllowAutoDeletion: "false"},
+						InstanceUpdateCommon: cdbm.InstanceUpdateCommon{
+							Status: cdb.GetStrPtr(cdbm.InstanceStatusReady),
+							Labels: map[string]string{model.InstanceLabelOnlineRepairAllowAutoDeletion: "false"},
+						},
 					})
 					require.NoError(t, uerr)
 				},

--- a/api/pkg/api/handler/vpc.go
+++ b/api/pkg/api/handler/vpc.go
@@ -264,7 +264,7 @@ func (cvh CreateVPCHandler) Handle(c echo.Context) error {
 		// `routingProfile` only and let the handler default
 		// `networkVirtualizationType` from site config; Validate
 		// cannot see that default, so the check lives here.
-		if *networkVirtualizationType != cdbm.VpcFNN {
+		if !cdbm.VpcTypeSupportsRoutingProfile(networkVirtualizationType) {
 			logger.Warn().Str("routingProfile", *apiRequest.RoutingProfile).Msg("`routingProfile` can only be specified if network virtualization type is set to `FNN`, or Site has native networking enabled and no network virtualization type is specified")
 			return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "`routingProfile` can only be specified if network virtualization type is set to `FNN`, or Site has native networking enabled and no network virtualization type is specified", nil)
 		}

--- a/api/pkg/api/handler/vpc_test.go
+++ b/api/pkg/api/handler/vpc_test.go
@@ -647,6 +647,57 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 			verifyChildSpanner: true,
 		},
 		{
+			name: "test VPC create API endpoint Flat virtualization success",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        tc,
+				cfg:       cfg,
+			},
+			args: args{
+				reqData: &model.APIVpcCreateRequest{
+					Name:                      "Test Flat VPC",
+					Description:               cdb.GetStrPtr("Flat VPC for zero-DPU instances"),
+					SiteID:                    st1.ID.String(),
+					NetworkVirtualizationType: cdb.GetStrPtr(cdbm.VpcFlat),
+				},
+				reqOrg:         tnOrg,
+				reqUser:        tnu,
+				respCode:       http.StatusCreated,
+				expectedStatus: cdbm.VpcStatusProvisioning,
+				expectedStatusDetails: []expectedStatusDetail{
+					{
+						status:  cdbm.VpcStatusProvisioning,
+						message: "VPC provisioning has been initiated on Site",
+					},
+				},
+			},
+			wantErr:            false,
+			verifyChildSpanner: true,
+		},
+		{
+			name: "test VPC create API endpoint rejects routing profile for Flat virtualization",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        tc,
+				cfg:       cfg,
+			},
+			args: args{
+				reqData: &model.APIVpcCreateRequest{
+					Name:                      "Test Flat VPC with routing profile",
+					Description:               cdb.GetStrPtr("Flat VPC with disallowed routing profile"),
+					SiteID:                    st1.ID.String(),
+					NetworkVirtualizationType: cdb.GetStrPtr(cdbm.VpcFlat),
+					RoutingProfile:            cdb.GetStrPtr(model.APIVpcRoutingProfileInternal),
+				},
+				reqOrg:      tnOrg,
+				reqUser:     tnu,
+				respCode:    http.StatusBadRequest,
+				respMessage: "`routingProfile` is only supported when `networkVirtualizationType` is FNN",
+			},
+			wantErr:            false,
+			verifyChildSpanner: true,
+		},
+		{
 			name: "test VPC create API endpoint original success payload fails with routing profile on ethernet virtualization",
 			fields: fields{
 				dbSession: dbSession,

--- a/api/pkg/api/model/instance.go
+++ b/api/pkg/api/model/instance.go
@@ -368,8 +368,15 @@ type APIInstanceCreateRequest struct {
 	PhoneHomeEnabled *bool `json:"phoneHomeEnabled"`
 	// UserData is the ID of the Operating System
 	UserData *string `json:"userData"`
-	// Interfaces is the list of Interfaces to create for the Instance
+	// Interfaces is the list of Interfaces to create for the Instance.
+	// Mutually exclusive with `Auto`: when `Auto` is true this MUST be empty.
 	Interfaces []APIInterfaceCreateOrUpdateRequest `json:"interfaces"`
+	// Auto, when true, asks NICo to auto-resolve the Instance's network
+	// interfaces from the host's HostInband network segments. Intended for
+	// instances on zero-DPU hosts (or hosts with their DPU in NIC mode).
+	// When true, `Interfaces` MUST be empty. The resolved per-interface
+	// details surface in the Instance's status.
+	Auto bool `json:"auto"`
 	// InfiniBandInterfaces is the list of InfiniBandInterface to create for the Instance
 	InfiniBandInterfaces []APIInfiniBandInterfaceCreateOrUpdateRequest `json:"infinibandInterfaces"`
 	// DpuExtensionServiceDeployments is the list of DpuExtensionServiceDeployments to create for the Instance
@@ -421,8 +428,14 @@ type APIBatchInstanceCreateRequest struct {
 	PhoneHomeEnabled *bool `json:"phoneHomeEnabled"`
 	// UserData is the user data for the instances
 	UserData *string `json:"userData"`
-	// Interfaces is the list of Interfaces to create for each instance (shared across all instances)
+	// Interfaces is the list of Interfaces to create for each instance (shared across all instances).
+	// Mutually exclusive with `Auto`: when `Auto` is true this MUST be empty.
 	Interfaces []APIInterfaceCreateOrUpdateRequest `json:"interfaces"`
+	// Auto, when true, asks NICo to auto-resolve each Instance's network
+	// interfaces from the host's HostInband network segments. Intended for
+	// instances on zero-DPU hosts (or hosts with their DPU in NIC mode).
+	// When true, `Interfaces` MUST be empty.
+	Auto bool `json:"auto"`
 	// InfiniBandInterfaces is the list of InfiniBandInterface to create for each instance (shared across all instances)
 	InfiniBandInterfaces []APIInfiniBandInterfaceCreateOrUpdateRequest `json:"infinibandInterfaces"`
 	// NVLinkInterfaces is the list of NVLinkInterface to create for each instance (shared across all instances)
@@ -461,8 +474,15 @@ func (icr APIInstanceCreateRequest) Validate() error {
 		validation.Field(&icr.OperatingSystemID,
 			validationis.UUID.Error(validationErrorInvalidUUID)),
 		validation.Field(&icr.Interfaces,
-			validation.Required.Error("at least one Interface must be specified"),
-			validation.Length(1, MaxInterfaceCount).Error(fmt.Sprintf("at most %v Interfaces can be specified", MaxInterfaceCount))),
+			// When Auto is true, the Instance has NICo auto-resolve interfaces
+			// from the host's HostInband segments, so the explicit list MUST
+			// be empty. Otherwise at least one interface is required.
+			validation.When(icr.Auto,
+				validation.Length(0, 0).Error("`interfaces` must be empty when `auto` is true"),
+			).Else(
+				validation.Required.Error("at least one Interface must be specified"),
+				validation.Length(1, MaxInterfaceCount).Error(fmt.Sprintf("at most %v Interfaces can be specified", MaxInterfaceCount)),
+			)),
 	)
 
 	if err != nil {
@@ -470,6 +490,11 @@ func (icr APIInstanceCreateRequest) Validate() error {
 	}
 
 	if icr.SecondaryVpcIDs != nil {
+		if icr.Auto {
+			return validation.Errors{
+				"secondaryVpcIds": errors.New("`secondaryVpcIds` is not supported when `auto` is true"),
+			}
+		}
 		for _, iface := range icr.Interfaces {
 			if iface.VpcPrefixID == nil {
 				return validation.Errors{
@@ -790,8 +815,15 @@ func (bicr APIBatchInstanceCreateRequest) Validate() error {
 		validation.Field(&bicr.OperatingSystemID,
 			validationis.UUID.Error(validationErrorInvalidUUID)),
 		validation.Field(&bicr.Interfaces,
-			validation.Required.Error("at least one Interface must be specified"),
-			validation.Length(1, MaxInterfaceCount).Error(fmt.Sprintf("at most %v Interfaces can be specified", MaxInterfaceCount))),
+			// When Auto is true, the batch has NICo auto-resolve interfaces
+			// from the host's HostInband segments, so the explicit list MUST
+			// be empty. Otherwise at least one interface is required.
+			validation.When(bicr.Auto,
+				validation.Length(0, 0).Error("`interfaces` must be empty when `auto` is true"),
+			).Else(
+				validation.Required.Error("at least one Interface must be specified"),
+				validation.Length(1, MaxInterfaceCount).Error(fmt.Sprintf("at most %v Interfaces can be specified", MaxInterfaceCount)),
+			)),
 	)
 
 	if err != nil {
@@ -799,6 +831,11 @@ func (bicr APIBatchInstanceCreateRequest) Validate() error {
 	}
 
 	if bicr.SecondaryVpcIDs != nil {
+		if bicr.Auto {
+			return validation.Errors{
+				"secondaryVpcIds": errors.New("`secondaryVpcIds` is not supported when `auto` is true"),
+			}
+		}
 		for _, iface := range bicr.Interfaces {
 			if iface.VpcPrefixID == nil {
 				return validation.Errors{
@@ -1071,8 +1108,14 @@ type APIInstanceUpdateRequest struct {
 	// vpcPrefixId. The update handler then verifies that the supplied UUIDs
 	// exactly match the VPCs resolved from those prefix-backed interfaces.
 	SecondaryVpcIDs []string `json:"secondaryVpcIds"`
-	// Interfaces is the list of Interfaces to update for the Instance
+	// Interfaces is the list of Interfaces to update for the Instance.
+	// Mutually exclusive with `Auto`: when `Auto` is true this MUST be empty.
 	Interfaces []APIInterfaceCreateOrUpdateRequest `json:"interfaces"`
+	// Auto, when set, asks NICo to auto-resolve the Instance's network
+	// interfaces from the host's HostInband network segments. `nil` leaves
+	// the value unchanged; `true` re-resolves; `false` returns to explicit
+	// interface configuration. When `true`, `Interfaces` MUST be empty.
+	Auto *bool `json:"auto"`
 	// InfiniBandInterfaces is the list of InfiniBandInterface to update for the Instance
 	InfiniBandInterfaces []APIInfiniBandInterfaceCreateOrUpdateRequest `json:"infinibandInterfaces"`
 	// DpuExtensionServiceDeployments is the list of DpuExtensionServiceDeployments to update for the Instance
@@ -1361,6 +1404,7 @@ func (iur *APIInstanceUpdateRequest) IsUpdateRequest() bool {
 		iur.AlwaysBootWithCustomIpxe != nil ||
 		iur.SecondaryVpcIDs != nil ||
 		iur.Interfaces != nil ||
+		iur.Auto != nil ||
 		iur.InfiniBandInterfaces != nil ||
 		iur.NVLinkInterfaces != nil ||
 		iur.SSHKeyGroupIDs != nil ||
@@ -1369,7 +1413,7 @@ func (iur *APIInstanceUpdateRequest) IsUpdateRequest() bool {
 
 // IsInterfaceUpdateRequest checks if the request is an instance interface update request
 func (iur *APIInstanceUpdateRequest) IsInterfaceUpdateRequest() bool {
-	return iur.Interfaces != nil || iur.InfiniBandInterfaces != nil || iur.NVLinkInterfaces != nil
+	return iur.Interfaces != nil || iur.Auto != nil || iur.InfiniBandInterfaces != nil || iur.NVLinkInterfaces != nil
 }
 
 // IsRebootRequest checks if the request is an instance reboot request
@@ -1399,7 +1443,20 @@ func (iur APIInstanceUpdateRequest) Validate() error {
 		return err
 	}
 
+	// Auto/interfaces exclusivity: if the caller is explicitly switching
+	// to auto, an explicit interface list cannot also be supplied.
+	if iur.Auto != nil && *iur.Auto && len(iur.Interfaces) > 0 {
+		return validation.Errors{
+			"interfaces": errors.New("`interfaces` must be empty when `auto` is true"),
+		}
+	}
+
 	if iur.SecondaryVpcIDs != nil {
+		if iur.Auto != nil && *iur.Auto {
+			return validation.Errors{
+				"secondaryVpcIds": errors.New("`secondaryVpcIds` is not supported when `auto` is true"),
+			}
+		}
 		if len(iur.Interfaces) == 0 {
 			return validation.Errors{
 				"secondaryVpcIds": errors.New("`secondaryVpcIds` can only be specified when `interfaces` is specified and non-empty"),
@@ -1587,6 +1644,11 @@ type APIInstance struct {
 	TpmEkCertificate *string `json:"tpmEkCertificate"`
 	// Status is the status of the Instance
 	Status string `json:"status"`
+	// Auto is true when this Instance had its network interfaces
+	// auto-resolved by NICo from the host's HostInband segments. When
+	// true, `Interfaces` reflects the resolved set; the caller's request
+	// list was empty.
+	Auto bool `json:"auto"`
 	// Interfaces are list of the subnet associated with the Instance
 	Interfaces []APIInterface `json:"interfaces"`
 	// InfiniBandInterfaces are list of the InfiniBandInterface associated with the Instance
@@ -1633,6 +1695,7 @@ func NewAPIInstance(dbinst *cdbm.Instance, dbSite *cdbm.Site, dbiss []cdbm.Inter
 		AlwaysBootWithCustomIpxe:               dbinst.AlwaysBootWithCustomIpxe,
 		PhoneHomeEnabled:                       dbinst.PhoneHomeEnabled,
 		UserData:                               dbinst.UserData,
+		Auto:                                   dbinst.NetworkAuto,
 		Labels:                                 dbinst.Labels,
 		IsUpdatePending:                        dbinst.IsUpdatePending,
 		Created:                                dbinst.Created,

--- a/api/pkg/api/model/instance_test.go
+++ b/api/pkg/api/model/instance_test.go
@@ -2383,3 +2383,204 @@ func TestAPIInstanceDeleteRequest_Validate(t *testing.T) {
 		})
 	}
 }
+
+// TestAPIInstanceCreateRequest_Validate_Auto exercises the `auto` /
+// `interfaces` exclusivity rules introduced for zero-DPU instances.
+func TestAPIInstanceCreateRequest_Validate_Auto(t *testing.T) {
+	tests := []struct {
+		name             string
+		req              APIInstanceCreateRequest
+		wantErr          bool
+		wantErrorMessage string
+	}{
+		{
+			name: "auto=true with empty interfaces succeeds",
+			req: APIInstanceCreateRequest{
+				Name:              "auto-instance",
+				TenantID:          uuid.NewString(),
+				InstanceTypeID:    cdb.GetStrPtr(uuid.NewString()),
+				VpcID:             uuid.NewString(),
+				OperatingSystemID: cdb.GetStrPtr(uuid.NewString()),
+				Auto:              true,
+				Interfaces:        nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "auto=true with interfaces is rejected",
+			req: APIInstanceCreateRequest{
+				Name:              "auto-instance",
+				TenantID:          uuid.NewString(),
+				InstanceTypeID:    cdb.GetStrPtr(uuid.NewString()),
+				VpcID:             uuid.NewString(),
+				OperatingSystemID: cdb.GetStrPtr(uuid.NewString()),
+				Auto:              true,
+				Interfaces: []APIInterfaceCreateOrUpdateRequest{
+					{SubnetID: cdb.GetStrPtr(uuid.NewString())},
+				},
+			},
+			wantErr:          true,
+			wantErrorMessage: "`interfaces` must be empty when `auto` is true",
+		},
+		{
+			name: "auto=false with empty interfaces is rejected",
+			req: APIInstanceCreateRequest{
+				Name:              "manual-instance",
+				TenantID:          uuid.NewString(),
+				InstanceTypeID:    cdb.GetStrPtr(uuid.NewString()),
+				VpcID:             uuid.NewString(),
+				OperatingSystemID: cdb.GetStrPtr(uuid.NewString()),
+				Auto:              false,
+				Interfaces:        nil,
+			},
+			wantErr:          true,
+			wantErrorMessage: "at least one Interface must be specified",
+		},
+		{
+			name: "auto=true with secondaryVpcIds is rejected",
+			req: APIInstanceCreateRequest{
+				Name:              "auto-instance",
+				TenantID:          uuid.NewString(),
+				InstanceTypeID:    cdb.GetStrPtr(uuid.NewString()),
+				VpcID:             uuid.NewString(),
+				OperatingSystemID: cdb.GetStrPtr(uuid.NewString()),
+				Auto:              true,
+				SecondaryVpcIDs:   []string{uuid.NewString()},
+			},
+			wantErr:          true,
+			wantErrorMessage: "`secondaryVpcIds` is not supported when `auto` is true",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.req.Validate()
+			if (err != nil) != tt.wantErr {
+				marshalledErr, _ := json.Marshal(err)
+				t.Errorf("Validate() error = %v, wantErr %v", string(marshalledErr), tt.wantErr)
+			}
+			if tt.wantErrorMessage != "" && err != nil {
+				assert.Contains(t, err.Error(), tt.wantErrorMessage)
+			}
+		})
+	}
+}
+
+// TestAPIBatchInstanceCreateRequest_Validate_Auto mirrors the create-side
+// exclusivity rules for the batch endpoint.
+func TestAPIBatchInstanceCreateRequest_Validate_Auto(t *testing.T) {
+	tests := []struct {
+		name             string
+		req              APIBatchInstanceCreateRequest
+		wantErr          bool
+		wantErrorMessage string
+	}{
+		{
+			name: "auto=true with empty interfaces succeeds",
+			req: APIBatchInstanceCreateRequest{
+				NamePrefix:     "auto-batch",
+				Count:          2,
+				TenantID:       uuid.NewString(),
+				InstanceTypeID: uuid.NewString(),
+				VpcID:          uuid.NewString(),
+				IpxeScript:     cdb.GetStrPtr("test ipxe"),
+				Auto:           true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "auto=true with interfaces is rejected",
+			req: APIBatchInstanceCreateRequest{
+				NamePrefix:     "auto-batch",
+				Count:          2,
+				TenantID:       uuid.NewString(),
+				InstanceTypeID: uuid.NewString(),
+				VpcID:          uuid.NewString(),
+				IpxeScript:     cdb.GetStrPtr("test ipxe"),
+				Auto:           true,
+				Interfaces: []APIInterfaceCreateOrUpdateRequest{
+					{SubnetID: cdb.GetStrPtr(uuid.NewString())},
+				},
+			},
+			wantErr:          true,
+			wantErrorMessage: "`interfaces` must be empty when `auto` is true",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.req.Validate()
+			if (err != nil) != tt.wantErr {
+				marshalledErr, _ := json.Marshal(err)
+				t.Errorf("Validate() error = %v, wantErr %v", string(marshalledErr), tt.wantErr)
+			}
+			if tt.wantErrorMessage != "" && err != nil {
+				assert.Contains(t, err.Error(), tt.wantErrorMessage)
+			}
+		})
+	}
+}
+
+// TestAPIInstanceUpdateRequest_Validate_Auto covers the auto/interfaces
+// exclusivity rule when toggling auto via the update endpoint.
+func TestAPIInstanceUpdateRequest_Validate_Auto(t *testing.T) {
+	autoTrue := true
+	autoFalse := false
+	tests := []struct {
+		name             string
+		req              APIInstanceUpdateRequest
+		wantErr          bool
+		wantErrorMessage string
+	}{
+		{
+			name:    "auto unset leaves validation untouched",
+			req:     APIInstanceUpdateRequest{Auto: nil},
+			wantErr: false,
+		},
+		{
+			name:    "auto=true with no interfaces succeeds",
+			req:     APIInstanceUpdateRequest{Auto: &autoTrue},
+			wantErr: false,
+		},
+		{
+			name: "auto=true with interfaces is rejected",
+			req: APIInstanceUpdateRequest{
+				Auto: &autoTrue,
+				Interfaces: []APIInterfaceCreateOrUpdateRequest{
+					{SubnetID: cdb.GetStrPtr(uuid.NewString())},
+				},
+			},
+			wantErr:          true,
+			wantErrorMessage: "`interfaces` must be empty when `auto` is true",
+		},
+		{
+			name: "auto=false with interfaces succeeds",
+			req: APIInstanceUpdateRequest{
+				Auto: &autoFalse,
+				Interfaces: []APIInterfaceCreateOrUpdateRequest{
+					{SubnetID: cdb.GetStrPtr(uuid.NewString())},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "auto=true with secondaryVpcIds is rejected",
+			req: APIInstanceUpdateRequest{
+				Auto:            &autoTrue,
+				SecondaryVpcIDs: []string{uuid.NewString()},
+			},
+			wantErr:          true,
+			wantErrorMessage: "`secondaryVpcIds` is not supported when `auto` is true",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.req.Validate()
+			if (err != nil) != tt.wantErr {
+				marshalledErr, _ := json.Marshal(err)
+				t.Errorf("Validate() error = %v, wantErr %v", string(marshalledErr), tt.wantErr)
+			}
+			if tt.wantErrorMessage != "" && err != nil {
+				assert.Contains(t, err.Error(), tt.wantErrorMessage)
+			}
+		})
+	}
+}

--- a/api/pkg/api/model/vpc.go
+++ b/api/pkg/api/model/vpc.go
@@ -137,9 +137,9 @@ func (ascr APIVpcCreateRequest) Validate() error {
 
 	// NetworkVirtualizationType validation
 	if ascr.NetworkVirtualizationType != nil {
-		if (*ascr.NetworkVirtualizationType != cdbm.VpcEthernetVirtualizer) && (*ascr.NetworkVirtualizationType != cdbm.VpcFNN) {
+		if !cdbm.VpcNetworkVirtualzationTypeMap[*ascr.NetworkVirtualizationType] {
 			return validation.Errors{
-				"networkVirtualizationType": errors.New("either ETHERNET_VIRTUALIZER or FNN are currently supported"),
+				"networkVirtualizationType": errors.New("ETHERNET_VIRTUALIZER, FNN, and FLAT are currently supported"),
 			}
 		}
 	}
@@ -151,7 +151,7 @@ func (ascr APIVpcCreateRequest) Validate() error {
 			}
 		}
 
-		if ascr.NetworkVirtualizationType != nil && *ascr.NetworkVirtualizationType != cdbm.VpcFNN {
+		if ascr.NetworkVirtualizationType != nil && !cdbm.VpcTypeSupportsRoutingProfile(ascr.NetworkVirtualizationType) {
 			return validation.Errors{
 				"routingProfile": errors.New("`routingProfile` is only supported when `networkVirtualizationType` is FNN"),
 			}

--- a/api/pkg/api/model/vpc_test.go
+++ b/api/pkg/api/model/vpc_test.go
@@ -115,6 +115,25 @@ func TestAPIVpcCreateRequest_Validate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "test valid VPC create request - Flat virtualization type",
+			fields: fields{
+				Name:                      "test-name",
+				SiteID:                    uuid.NewString(),
+				NetworkVirtualizationType: cdb.GetStrPtr(cdbm.VpcFlat),
+			},
+			wantErr: false,
+		},
+		{
+			name: "test invalid VPC create request - routing profile on Flat VPC",
+			fields: fields{
+				Name:                      "test-name",
+				SiteID:                    uuid.NewString(),
+				NetworkVirtualizationType: cdb.GetStrPtr(cdbm.VpcFlat),
+				RoutingProfile:            cdb.GetStrPtr(APIVpcRoutingProfileInternal),
+			},
+			wantErr: true,
+		},
+		{
 			name: "test valid VPC create request - routing profile when network virtualization type is omitted",
 			fields: fields{
 				Name:           "test-name",

--- a/db/pkg/db/model/instance.go
+++ b/db/pkg/db/model/instance.go
@@ -176,6 +176,7 @@ type Instance struct {
 	AlwaysBootWithCustomIpxe               bool                                    `bun:"always_boot_with_custom_ipxe,notnull"`
 	PhoneHomeEnabled                       bool                                    `bun:"phone_home_enabled,notnull"`
 	UserData                               *string                                 `bun:"user_data"`
+	NetworkAuto                            bool                                    `bun:"network_auto,notnull"`
 	Labels                                 map[string]string                       `bun:"labels,type:jsonb"`
 	IsUpdatePending                        bool                                    `bun:"is_update_pending,notnull"`
 	InfinityRCRStatus                      *string                                 `bun:"infinity_rcr_status"`
@@ -210,6 +211,7 @@ type InstanceCreateInput struct {
 	AlwaysBootWithCustomIpxe               bool
 	PhoneHomeEnabled                       bool
 	UserData                               *string
+	NetworkAuto                            bool
 	Labels                                 map[string]string
 	IsUpdatePending                        bool
 	InfinityRCRStatus                      *string
@@ -219,9 +221,13 @@ type InstanceCreateInput struct {
 	CreatedBy                              uuid.UUID
 }
 
-// InstanceUpdateInput input parameters for Update method
-type InstanceUpdateInput struct {
-	InstanceID                             uuid.UUID
+// InstanceUpdateCommon captures the per-field update patch shared by
+// the single-row and multi-row update paths. Every non-pointer field
+// has its zero value interpreted as "unset, do not update"; pointer
+// fields use nil to mean the same. Splitting these fields out of the
+// per-input struct lets `UpdateMultiple` apply one shared patch to a
+// slice of instance IDs.
+type InstanceUpdateCommon struct {
 	Name                                   *string
 	Description                            *string
 	TenantID                               *uuid.UUID
@@ -239,6 +245,7 @@ type InstanceUpdateInput struct {
 	AlwaysBootWithCustomIpxe               *bool
 	PhoneHomeEnabled                       *bool
 	UserData                               *string
+	NetworkAuto                            *bool
 	Labels                                 map[string]string
 	IsUpdatePending                        *bool
 	InfinityRCRStatus                      *string
@@ -246,6 +253,24 @@ type InstanceUpdateInput struct {
 	Status                                 *string
 	PowerStatus                            *string
 	IsMissingOnSite                        *bool
+}
+
+// InstanceUpdateInput input parameters for the single-row Update.
+// Embeds InstanceUpdateCommon so callers can read or assign the
+// update fields directly without going through a nested struct.
+type InstanceUpdateInput struct {
+	InstanceID uuid.UUID
+	InstanceUpdateCommon
+}
+
+// InstanceUpdateMultipleInput input parameters for UpdateMultiple.
+// All listed instances receive the same update patch drawn from the
+// embedded InstanceUpdateCommon. Heterogeneous per-row patches are
+// not supported -- callers that need different fields per instance
+// must issue separate calls.
+type InstanceUpdateMultipleInput struct {
+	InstanceIDs []uuid.UUID
+	InstanceUpdateCommon
 }
 
 // InstanceClearInput input parameters for Clear method
@@ -324,8 +349,10 @@ type InstanceDAO interface {
 	GetAll(ctx context.Context, tx *db.Tx, filter InstanceFilterInput, page paginator.PageInput, includeRelations []string) ([]Instance, int, error)
 	//
 	Update(ctx context.Context, tx *db.Tx, input InstanceUpdateInput) (*Instance, error)
-	// UpdateMultiple used to update multiple rows
-	UpdateMultiple(ctx context.Context, tx *db.Tx, inputs []InstanceUpdateInput) ([]Instance, error)
+	// UpdateMultiple applies a single shared update patch to every
+	// instance ID in `input.InstanceIDs`. Callers needing
+	// heterogeneous per-row updates must call multiple times.
+	UpdateMultiple(ctx context.Context, tx *db.Tx, input InstanceUpdateMultipleInput) ([]Instance, error)
 	//
 	Clear(ctx context.Context, tx *db.Tx, input InstanceClearInput) (*Instance, error)
 	//
@@ -671,7 +698,10 @@ func (isd InstanceSQLDAO) Update(ctx context.Context, tx *db.Tx, input InstanceU
 		// Detailed per-field tracing is recorded in the UpdateMultiple child span.
 	}
 
-	results, err := isd.UpdateMultiple(ctx, tx, []InstanceUpdateInput{input})
+	results, err := isd.UpdateMultiple(ctx, tx, InstanceUpdateMultipleInput{
+		InstanceIDs:          []uuid.UUID{input.InstanceID},
+		InstanceUpdateCommon: input.InstanceUpdateCommon,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -823,6 +853,7 @@ func (isd InstanceSQLDAO) CreateMultiple(ctx context.Context, tx *db.Tx, inputs 
 			AlwaysBootWithCustomIpxe:               input.AlwaysBootWithCustomIpxe,
 			PhoneHomeEnabled:                       input.PhoneHomeEnabled,
 			UserData:                               input.UserData,
+			NetworkAuto:                            input.NetworkAuto,
 			IsUpdatePending:                        input.IsUpdatePending,
 			InfinityRCRStatus:                      input.InfinityRCRStatus,
 			TpmEkCertificate:                       input.TpmEkCertificate,
@@ -864,34 +895,52 @@ func (isd InstanceSQLDAO) CreateMultiple(ctx context.Context, tx *db.Tx, inputs 
 	return sorted, nil
 }
 
-// UpdateMultiple updates multiple Instances with the given parameters using a single bulk UPDATE query
-// All inputs should update the same set of fields for optimal performance
-// The updated fields are assumed to be set to non-null values
-// since there are 2 operations (UPDATE, SELECT), it is required that
-// this library call happens within a transaction
-func (isd InstanceSQLDAO) UpdateMultiple(ctx context.Context, tx *db.Tx, inputs []InstanceUpdateInput) ([]Instance, error) {
-	if len(inputs) > db.MaxBatchItems {
-		return nil, fmt.Errorf("batch size %d exceeds maximum allowed %d", len(inputs), db.MaxBatchItems)
+// UpdateMultiple applies a single shared update patch (drawn from the
+// embedded InstanceUpdateCommon) to every instance ID in
+// `input.InstanceIDs`, using one bulk UPDATE query.
+//
+// Heterogeneous per-row patches are intentionally not supported. Each
+// nil-pointer field in the patch is treated as "don't update," and the
+// resulting column set is computed once and applied uniformly across
+// all rows. Callers that need different fields for different rows
+// must call this function multiple times.
+//
+// Since there are two operations (UPDATE, SELECT), this call must
+// happen within a transaction.
+func (isd InstanceSQLDAO) UpdateMultiple(ctx context.Context, tx *db.Tx, input InstanceUpdateMultipleInput) ([]Instance, error) {
+	if len(input.InstanceIDs) > db.MaxBatchItems {
+		return nil, fmt.Errorf("batch size %d exceeds maximum allowed %d", len(input.InstanceIDs), db.MaxBatchItems)
 	}
 
 	// Create a child span and set the attributes for current request
 	ctx, instanceDAOSpan := isd.tracerSpan.CreateChildInCurrentContext(ctx, "InstanceDAO.UpdateMultiple")
 	if instanceDAOSpan != nil {
 		defer instanceDAOSpan.End()
-		isd.tracerSpan.SetAttribute(instanceDAOSpan, "batch_size", len(inputs))
+		isd.tracerSpan.SetAttribute(instanceDAOSpan, "batch_size", len(input.InstanceIDs))
 	}
 
-	if len(inputs) == 0 {
+	if len(input.InstanceIDs) == 0 {
 		return []Instance{}, nil
 	}
 
-	// Build instances and collect columns to update
-	instances := make([]*Instance, 0, len(inputs))
-	ids := make([]uuid.UUID, 0, len(inputs))
-	columnsSet := make(map[string]bool)
+	// Reject duplicate InstanceIDs up front. The post-fetch SELECT
+	// returns one row per unique ID, so a duplicate would cause a
+	// count-mismatch error after writes have already happened.
+	seenIDs := make(map[uuid.UUID]struct{}, len(input.InstanceIDs))
+	for idx, id := range input.InstanceIDs {
+		if _, exists := seenIDs[id]; exists {
+			return nil, fmt.Errorf("UpdateMultiple: duplicate instance id %s at input %d", id, idx)
+		}
+		seenIDs[id] = struct{}{}
+	}
 
-	// Limit per-item tracing to avoid overly-large spans; see db.MaxBatchItemsToTrace for details
-	traceItems := len(inputs)
+	// Build the prototype row once from the shared update patch. The
+	// bulk UPDATE will copy these values into a per-ID Instance below.
+	proto := &Instance{}
+	columns := []string{}
+	c := input.InstanceUpdateCommon
+
+	traceItems := len(input.InstanceIDs)
 	if traceItems > db.MaxBatchItemsToTrace {
 		traceItems = db.MaxBatchItemsToTrace
 		if instanceDAOSpan != nil {
@@ -899,224 +948,176 @@ func (isd InstanceSQLDAO) UpdateMultiple(ctx context.Context, tx *db.Tx, inputs 
 		}
 	}
 
-	for idx, input := range inputs {
-		i := &Instance{
-			ID: input.InstanceID,
+	// Set field i. Set column name. Record a trace attribute keyed
+	// to the patch itself (not per-row, since the patch is shared).
+	trace := func(key, value string) {
+		if instanceDAOSpan != nil {
+			isd.tracerSpan.SetAttribute(instanceDAOSpan, "patch."+key, value)
 		}
-		columns := []string{}
-		addTrace := instanceDAOSpan != nil && idx < traceItems
-		prefix := fmt.Sprintf("items.%d.", idx)
+	}
+	if c.Name != nil {
+		proto.Name = *c.Name
+		columns = append(columns, "name")
+		trace("name", *c.Name)
+	}
+	if c.Description != nil {
+		proto.Description = c.Description
+		columns = append(columns, "description")
+		trace("description", *c.Description)
+	}
+	if c.TenantID != nil {
+		proto.TenantID = *c.TenantID
+		columns = append(columns, "tenant_id")
+		trace("tenant_id", c.TenantID.String())
+	}
+	if c.InfrastructureProviderID != nil {
+		proto.InfrastructureProviderID = *c.InfrastructureProviderID
+		columns = append(columns, "infrastructure_provider_id")
+		trace("infrastructure_provider_id", c.InfrastructureProviderID.String())
+	}
+	if c.SiteID != nil {
+		proto.SiteID = *c.SiteID
+		columns = append(columns, "site_id")
+		trace("site_id", c.SiteID.String())
+	}
+	if c.InstanceTypeID != nil {
+		proto.InstanceTypeID = c.InstanceTypeID
+		columns = append(columns, "instance_type_id")
+		trace("instance_type_id", c.InstanceTypeID.String())
+	}
+	if c.NetworkSecurityGroupID != nil {
+		proto.NetworkSecurityGroupID = c.NetworkSecurityGroupID
+		columns = append(columns, "network_security_group_id")
+		trace("network_security_group_id", *c.NetworkSecurityGroupID)
+	}
+	if c.VpcID != nil {
+		proto.VpcID = *c.VpcID
+		columns = append(columns, "vpc_id")
+		trace("vpc_id", c.VpcID.String())
+	}
+	if c.MachineID != nil {
+		proto.MachineID = c.MachineID
+		columns = append(columns, "machine_id")
+		trace("machine_id", *c.MachineID)
+	}
+	if c.ControllerInstanceID != nil {
+		proto.ControllerInstanceID = c.ControllerInstanceID
+		columns = append(columns, "controller_instance_id")
+		trace("controller_instance_id", c.ControllerInstanceID.String())
+	}
+	if c.Hostname != nil {
+		proto.Hostname = c.Hostname
+		columns = append(columns, "hostname")
+		trace("hostname", *c.Hostname)
+	}
+	if c.OperatingSystemID != nil {
+		proto.OperatingSystemID = c.OperatingSystemID
+		columns = append(columns, "operating_system_id")
+		trace("operating_system_id", c.OperatingSystemID.String())
+	}
+	if c.IpxeScript != nil {
+		proto.IpxeScript = c.IpxeScript
+		columns = append(columns, "ipxe_script")
+		trace("ipxe_script", *c.IpxeScript)
+	}
+	if c.AlwaysBootWithCustomIpxe != nil {
+		proto.AlwaysBootWithCustomIpxe = *c.AlwaysBootWithCustomIpxe
+		columns = append(columns, "always_boot_with_custom_ipxe")
+		trace("always_boot_with_custom_ipxe", fmt.Sprintf("%t", *c.AlwaysBootWithCustomIpxe))
+	}
+	if c.PhoneHomeEnabled != nil {
+		proto.PhoneHomeEnabled = *c.PhoneHomeEnabled
+		columns = append(columns, "phone_home_enabled")
+		trace("phone_home_enabled", fmt.Sprintf("%t", *c.PhoneHomeEnabled))
+	}
+	if c.UserData != nil {
+		proto.UserData = c.UserData
+		columns = append(columns, "user_data")
+		trace("user_data", *c.UserData)
+	}
+	if c.NetworkAuto != nil {
+		proto.NetworkAuto = *c.NetworkAuto
+		columns = append(columns, "network_auto")
+		trace("network_auto", fmt.Sprintf("%t", *c.NetworkAuto))
+	}
+	if c.Labels != nil {
+		proto.Labels = c.Labels
+		columns = append(columns, "labels")
+		if instanceDAOSpan != nil {
+			isd.tracerSpan.SetAttribute(instanceDAOSpan, "patch.labels", c.Labels)
+		}
+	}
+	if c.IsUpdatePending != nil {
+		proto.IsUpdatePending = *c.IsUpdatePending
+		columns = append(columns, "is_update_pending")
+		trace("is_update_pending", fmt.Sprintf("%t", *c.IsUpdatePending))
+	}
+	if c.InfinityRCRStatus != nil {
+		proto.InfinityRCRStatus = c.InfinityRCRStatus
+		columns = append(columns, "infinity_rcr_status")
+		trace("infinity_rcr_status", *c.InfinityRCRStatus)
+	}
+	if c.Status != nil {
+		proto.Status = *c.Status
+		columns = append(columns, "status")
+		trace("status", *c.Status)
+	}
+	if c.PowerStatus != nil {
+		proto.PowerStatus = c.PowerStatus
+		columns = append(columns, "power_status")
+		trace("power_status", *c.PowerStatus)
+	}
+	if c.IsMissingOnSite != nil {
+		proto.IsMissingOnSite = *c.IsMissingOnSite
+		columns = append(columns, "is_missing_on_site")
+		trace("is_missing_on_site", fmt.Sprintf("%t", *c.IsMissingOnSite))
+	}
+	if c.NetworkSecurityGroupPropagationDetails != nil {
+		proto.NetworkSecurityGroupPropagationDetails = c.NetworkSecurityGroupPropagationDetails
+		columns = append(columns, "network_security_group_propagation_details")
+		if instanceDAOSpan != nil {
+			isd.tracerSpan.SetAttribute(instanceDAOSpan, "patch.network_security_group_propagation_details", c.NetworkSecurityGroupPropagationDetails)
+		}
+	}
+	if c.TpmEkCertificate != nil {
+		proto.TpmEkCertificate = c.TpmEkCertificate
+		columns = append(columns, "tpm_ek_certificate")
+		trace("tpm_ek_certificate", *c.TpmEkCertificate)
+	}
+	_ = traceItems // retained for future per-row trace decisions if needed
 
-		// Field-level tracing: only trace fields that are actually being updated for this item
-		// This keeps spans focused and avoids recording null/unchanged values
-		if input.Name != nil {
-			i.Name = *input.Name
-			columns = append(columns, "name")
-			if addTrace {
-				isd.tracerSpan.SetAttribute(instanceDAOSpan, prefix+"name", *input.Name)
-			}
-		}
-		if input.Description != nil {
-			i.Description = input.Description
-			columns = append(columns, "description")
-			if addTrace {
-				isd.tracerSpan.SetAttribute(instanceDAOSpan, prefix+"description", *input.Description)
-			}
-		}
-		if input.TenantID != nil {
-			i.TenantID = *input.TenantID
-			columns = append(columns, "tenant_id")
-			if addTrace {
-				isd.tracerSpan.SetAttribute(instanceDAOSpan, prefix+"tenant_id", input.TenantID.String())
-			}
-		}
-		if input.InfrastructureProviderID != nil {
-			i.InfrastructureProviderID = *input.InfrastructureProviderID
-			columns = append(columns, "infrastructure_provider_id")
-			if addTrace {
-				isd.tracerSpan.SetAttribute(instanceDAOSpan, prefix+"infrastructure_provider_id", input.InfrastructureProviderID.String())
-			}
-		}
-		if input.SiteID != nil {
-			i.SiteID = *input.SiteID
-			columns = append(columns, "site_id")
-			if addTrace {
-				isd.tracerSpan.SetAttribute(instanceDAOSpan, prefix+"site_id", input.SiteID.String())
-			}
-		}
-		if input.InstanceTypeID != nil {
-			i.InstanceTypeID = input.InstanceTypeID
-			columns = append(columns, "instance_type_id")
-			if addTrace {
-				isd.tracerSpan.SetAttribute(instanceDAOSpan, prefix+"instance_type_id", input.InstanceTypeID.String())
-			}
-		}
-		if input.NetworkSecurityGroupID != nil {
-			i.NetworkSecurityGroupID = input.NetworkSecurityGroupID
-			columns = append(columns, "network_security_group_id")
-			if addTrace {
-				isd.tracerSpan.SetAttribute(instanceDAOSpan, prefix+"network_security_group_id", *input.NetworkSecurityGroupID)
-			}
-		}
-		if input.VpcID != nil {
-			i.VpcID = *input.VpcID
-			columns = append(columns, "vpc_id")
-			if addTrace {
-				isd.tracerSpan.SetAttribute(instanceDAOSpan, prefix+"vpc_id", input.VpcID.String())
-			}
-		}
-		if input.MachineID != nil {
-			i.MachineID = input.MachineID
-			columns = append(columns, "machine_id")
-			if addTrace {
-				isd.tracerSpan.SetAttribute(instanceDAOSpan, prefix+"machine_id", *input.MachineID)
-			}
-		}
-		if input.ControllerInstanceID != nil {
-			i.ControllerInstanceID = input.ControllerInstanceID
-			columns = append(columns, "controller_instance_id")
-			if addTrace {
-				isd.tracerSpan.SetAttribute(instanceDAOSpan, prefix+"controller_instance_id", input.ControllerInstanceID.String())
-			}
-		}
-		if input.Hostname != nil {
-			i.Hostname = input.Hostname
-			columns = append(columns, "hostname")
-			if addTrace {
-				isd.tracerSpan.SetAttribute(instanceDAOSpan, prefix+"hostname", *input.Hostname)
-			}
-		}
-		if input.OperatingSystemID != nil {
-			i.OperatingSystemID = input.OperatingSystemID
-			columns = append(columns, "operating_system_id")
-			if addTrace {
-				isd.tracerSpan.SetAttribute(instanceDAOSpan, prefix+"operating_system_id", input.OperatingSystemID.String())
-			}
-		}
-		if input.IpxeScript != nil {
-			i.IpxeScript = input.IpxeScript
-			columns = append(columns, "ipxe_script")
-			if addTrace {
-				isd.tracerSpan.SetAttribute(instanceDAOSpan, prefix+"ipxe_script", *input.IpxeScript)
-			}
-		}
-		if input.AlwaysBootWithCustomIpxe != nil {
-			i.AlwaysBootWithCustomIpxe = *input.AlwaysBootWithCustomIpxe
-			columns = append(columns, "always_boot_with_custom_ipxe")
-			if addTrace {
-				isd.tracerSpan.SetAttribute(instanceDAOSpan, prefix+"always_boot_with_custom_ipxe", fmt.Sprintf("%t", *input.AlwaysBootWithCustomIpxe))
-			}
-		}
-		if input.PhoneHomeEnabled != nil {
-			i.PhoneHomeEnabled = *input.PhoneHomeEnabled
-			columns = append(columns, "phone_home_enabled")
-			if addTrace {
-				isd.tracerSpan.SetAttribute(instanceDAOSpan, prefix+"phone_home_enabled", fmt.Sprintf("%t", *input.PhoneHomeEnabled))
-			}
-		}
-		if input.UserData != nil {
-			i.UserData = input.UserData
-			columns = append(columns, "user_data")
-			if addTrace {
-				isd.tracerSpan.SetAttribute(instanceDAOSpan, prefix+"user_data", *input.UserData)
-			}
-		}
-		if input.Labels != nil {
-			i.Labels = input.Labels
-			columns = append(columns, "labels")
-			if addTrace {
-				isd.tracerSpan.SetAttribute(instanceDAOSpan, prefix+"labels", input.Labels)
-			}
-		}
-		if input.IsUpdatePending != nil {
-			i.IsUpdatePending = *input.IsUpdatePending
-			columns = append(columns, "is_update_pending")
-			if addTrace {
-				isd.tracerSpan.SetAttribute(instanceDAOSpan, prefix+"is_update_pending", fmt.Sprintf("%t", *input.IsUpdatePending))
-			}
-		}
-		if input.InfinityRCRStatus != nil {
-			i.InfinityRCRStatus = input.InfinityRCRStatus
-			columns = append(columns, "infinity_rcr_status")
-			if addTrace {
-				isd.tracerSpan.SetAttribute(instanceDAOSpan, prefix+"infinity_rcr_status", *input.InfinityRCRStatus)
-			}
-		}
-		if input.Status != nil {
-			i.Status = *input.Status
-			columns = append(columns, "status")
-			if addTrace {
-				isd.tracerSpan.SetAttribute(instanceDAOSpan, prefix+"status", *input.Status)
-			}
-		}
-		if input.PowerStatus != nil {
-			i.PowerStatus = input.PowerStatus
-			columns = append(columns, "power_status")
-			if addTrace {
-				isd.tracerSpan.SetAttribute(instanceDAOSpan, prefix+"power_status", *input.PowerStatus)
-			}
-		}
-		if input.IsMissingOnSite != nil {
-			i.IsMissingOnSite = *input.IsMissingOnSite
-			columns = append(columns, "is_missing_on_site")
-			if addTrace {
-				isd.tracerSpan.SetAttribute(instanceDAOSpan, prefix+"is_missing_on_site", fmt.Sprintf("%t", *input.IsMissingOnSite))
-			}
-		}
-		if input.NetworkSecurityGroupPropagationDetails != nil {
-			i.NetworkSecurityGroupPropagationDetails = input.NetworkSecurityGroupPropagationDetails
-			columns = append(columns, "network_security_group_propagation_details")
-			if addTrace {
-				isd.tracerSpan.SetAttribute(instanceDAOSpan, prefix+"network_security_group_propagation_details", input.NetworkSecurityGroupPropagationDetails)
-			}
-		}
-		if input.TpmEkCertificate != nil {
-			i.TpmEkCertificate = input.TpmEkCertificate
-			columns = append(columns, "tpm_ek_certificate")
-			if addTrace {
-				isd.tracerSpan.SetAttribute(instanceDAOSpan, prefix+"tpm_ek_certificate", *input.TpmEkCertificate)
-			}
-		}
-
-		instances = append(instances, i)
-		ids = append(ids, input.InstanceID)
-		for _, col := range columns {
-			columnsSet[col] = true
-		}
-
+	// Materialise one Instance per ID, copying the shared prototype.
+	instances := make([]*Instance, 0, len(input.InstanceIDs))
+	for _, id := range input.InstanceIDs {
+		row := *proto
+		row.ID = id
+		instances = append(instances, &row)
 	}
 
-	// Build column list
-	columns := make([]string, 0, len(columnsSet)+1)
-	for col := range columnsSet {
-		columns = append(columns, col)
-	}
+	// "updated" is always rewritten so the row's timestamp advances.
 	columns = append(columns, "updated")
 
-	// Execute bulk update
-	_, err := db.GetIDB(tx, isd.dbSession).NewUpdate().
+	if _, err := db.GetIDB(tx, isd.dbSession).NewUpdate().
 		Model(&instances).
 		Column(columns...).
 		Bulk().
-		Exec(ctx)
-	if err != nil {
+		Exec(ctx); err != nil {
 		return nil, err
 	}
 
 	// Fetch the updated instances
 	var result []Instance
-	err = db.GetIDB(tx, isd.dbSession).NewSelect().Model(&result).Where("i.id IN (?)", bun.In(ids)).Scan(ctx)
-	if err != nil {
+	if err := db.GetIDB(tx, isd.dbSession).NewSelect().Model(&result).Where("i.id IN (?)", bun.In(input.InstanceIDs)).Scan(ctx); err != nil {
 		return nil, err
 	}
 
 	// Sort result to match input order (O(n) direct index placement)
 	// This check should never fail since we just updated these records with the exact ids
-	if len(result) != len(ids) {
-		return nil, fmt.Errorf("unexpected result count: got %d, expected %d", len(result), len(ids))
+	if len(result) != len(input.InstanceIDs) {
+		return nil, fmt.Errorf("unexpected result count: got %d, expected %d", len(result), len(input.InstanceIDs))
 	}
-	idToIndex := make(map[uuid.UUID]int, len(ids))
-	for i, id := range ids {
+	idToIndex := make(map[uuid.UUID]int, len(input.InstanceIDs))
+	for i, id := range input.InstanceIDs {
 		idToIndex[id] = i
 	}
 	sorted := make([]Instance, len(result))

--- a/db/pkg/db/model/instance_test.go
+++ b/db/pkg/db/model/instance_test.go
@@ -1584,6 +1584,7 @@ type InstanceWithAllocation struct {
 	AlwaysBootWithCustomIpxe               bool                                    `bun:"always_boot_with_custom_ipxe,notnull"`
 	PhoneHomeEnabled                       bool                                    `bun:"phone_home_enabled,notnull"`
 	UserData                               *string                                 `bun:"user_data"`
+	NetworkAuto                            bool                                    `bun:"network_auto,notnull"`
 	Labels                                 map[string]string                       `bun:"labels,type:jsonb"`
 	IsUpdatePending                        bool                                    `bun:"is_update_pending,notnull"`
 	InfinityRCRStatus                      *string                                 `bun:"infinity_rcr_status"`
@@ -2502,31 +2503,33 @@ func TestInstanceSQLDAO_Update(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			got, err := isd.Update(ctx, nil,
 				InstanceUpdateInput{
-					InstanceID:                             tc.id,
-					Name:                                   tc.paramName,
-					Description:                            tc.paramDescription,
-					TenantID:                               tc.paramTenantID,
-					InfrastructureProviderID:               tc.paramInfrastructureProviderID,
-					SiteID:                                 tc.paramSiteID,
-					InstanceTypeID:                         tc.paramInstanceTypeID,
-					NetworkSecurityGroupID:                 tc.paramNetworkSecurityGroupID,
-					NetworkSecurityGroupPropagationDetails: tc.paramNetworkSecurityGroupPropagationDetails,
-					VpcID:                                  tc.paramVpcID,
-					MachineID:                              tc.paramMachineID,
-					ControllerInstanceID:                   tc.paramControlledInstanceID,
-					Hostname:                               tc.paramHostname,
-					OperatingSystemID:                      tc.paramOperatingSystemID,
-					IpxeScript:                             tc.paramIpxeScript,
-					AlwaysBootWithCustomIpxe:               tc.paramAlwaysBootWithCustomIpxe,
-					PhoneHomeEnabled:                       tc.paramEnablePhoneHome,
-					UserData:                               tc.paramUserData,
-					Labels:                                 tc.paramLabels,
-					IsUpdatePending:                        tc.paramIsUpdatePending,
-					InfinityRCRStatus:                      tc.paramInfinityRCRStatus,
-					Status:                                 tc.paramStatus,
-					PowerStatus:                            tc.paramPowerStatus,
-					IsMissingOnSite:                        tc.paramIsMissingOnSite,
-					TpmEkCertificate:                       tc.paramTpmEkCertificate,
+					InstanceID: tc.id,
+					InstanceUpdateCommon: InstanceUpdateCommon{
+						Name:                                   tc.paramName,
+						Description:                            tc.paramDescription,
+						TenantID:                               tc.paramTenantID,
+						InfrastructureProviderID:               tc.paramInfrastructureProviderID,
+						SiteID:                                 tc.paramSiteID,
+						InstanceTypeID:                         tc.paramInstanceTypeID,
+						NetworkSecurityGroupID:                 tc.paramNetworkSecurityGroupID,
+						NetworkSecurityGroupPropagationDetails: tc.paramNetworkSecurityGroupPropagationDetails,
+						VpcID:                                  tc.paramVpcID,
+						MachineID:                              tc.paramMachineID,
+						ControllerInstanceID:                   tc.paramControlledInstanceID,
+						Hostname:                               tc.paramHostname,
+						OperatingSystemID:                      tc.paramOperatingSystemID,
+						IpxeScript:                             tc.paramIpxeScript,
+						AlwaysBootWithCustomIpxe:               tc.paramAlwaysBootWithCustomIpxe,
+						PhoneHomeEnabled:                       tc.paramEnablePhoneHome,
+						UserData:                               tc.paramUserData,
+						Labels:                                 tc.paramLabels,
+						IsUpdatePending:                        tc.paramIsUpdatePending,
+						InfinityRCRStatus:                      tc.paramInfinityRCRStatus,
+						Status:                                 tc.paramStatus,
+						PowerStatus:                            tc.paramPowerStatus,
+						IsMissingOnSite:                        tc.paramIsMissingOnSite,
+						TpmEkCertificate:                       tc.paramTpmEkCertificate,
+					},
 				},
 			)
 			assert.Equal(t, tc.expectedError, err != nil)
@@ -3181,75 +3184,70 @@ func TestInstanceSQLDAO_UpdateMultiple(t *testing.T) {
 	// OTEL Spanner configuration
 	_, _, ctx = testCommonTraceProviderSetup(t, ctx)
 
+	// UpdateMultiple applies a single shared update mask to N instance
+	// IDs. Each subtest sets the same fields on every targeted row;
+	// heterogeneous per-row updates require separate calls.
 	tests := []struct {
 		desc               string
-		inputs             []InstanceUpdateInput
+		input              InstanceUpdateMultipleInput
 		expectError        bool
 		expectedCount      int
+		expectStatus       *string
+		expectName         *string
 		verifyChildSpanner bool
 	}{
 		{
-			desc: "batch update three instances",
-			inputs: []InstanceUpdateInput{
-				{
-					InstanceID:        i1.ID,
-					Name:              db.GetStrPtr("test-update-1-modified"),
+			desc: "batch update three instances with shared patch",
+			input: InstanceUpdateMultipleInput{
+				InstanceIDs: []uuid.UUID{i1.ID, i2.ID, i3.ID},
+				InstanceUpdateCommon: InstanceUpdateCommon{
 					Status:            db.GetStrPtr(InstanceStatusReady),
 					MachineID:         &machine.ID,
 					OperatingSystemID: db.GetUUIDPtr(operatingSystem.ID),
 					Labels:            map[string]string{"updated": "true"},
 				},
-				{
-					InstanceID:     i2.ID,
-					Name:           db.GetStrPtr("test-update-2-modified"),
-					Status:         db.GetStrPtr(InstanceStatusConfiguring),
-					InstanceTypeID: &instanceType.ID,
-				},
-				{
-					InstanceID: i3.ID,
-					Name:       db.GetStrPtr("test-update-3-modified"),
-					Status:     db.GetStrPtr(InstanceStatusError),
-				},
 			},
 			expectError:        false,
 			expectedCount:      3,
+			expectStatus:       db.GetStrPtr(InstanceStatusReady),
 			verifyChildSpanner: true,
 		},
 		{
-			desc:               "batch update with empty input",
-			inputs:             []InstanceUpdateInput{},
-			expectError:        false,
-			expectedCount:      0,
-			verifyChildSpanner: false,
+			desc:          "batch update with empty input",
+			input:         InstanceUpdateMultipleInput{},
+			expectError:   false,
+			expectedCount: 0,
 		},
 		{
-			desc: "batch update single instance",
-			inputs: []InstanceUpdateInput{
-				{
-					InstanceID: i1.ID,
-					Status:     db.GetStrPtr(InstanceStatusUpdating),
+			desc: "batch update single instance via slice of one",
+			input: InstanceUpdateMultipleInput{
+				InstanceIDs: []uuid.UUID{i1.ID},
+				InstanceUpdateCommon: InstanceUpdateCommon{
+					Status: db.GetStrPtr(InstanceStatusUpdating),
 				},
 			},
 			expectError:   false,
 			expectedCount: 1,
+			expectStatus:  db.GetStrPtr(InstanceStatusUpdating),
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			got, err := isd.UpdateMultiple(ctx, nil, tc.inputs)
+			got, err := isd.UpdateMultiple(ctx, nil, tc.input)
 			assert.Equal(t, tc.expectError, err != nil)
 			if !tc.expectError {
 				assert.NotNil(t, got)
 				assert.Equal(t, tc.expectedCount, len(got))
-				// Verify updates and that results are returned in the same order as inputs
+				// Result order must match input order; every row should
+				// reflect the shared mask values.
 				for i, instance := range got {
-					assert.Equal(t, tc.inputs[i].InstanceID, instance.ID, "result order should match input order")
-					if tc.inputs[i].Name != nil {
-						assert.Equal(t, *tc.inputs[i].Name, instance.Name)
+					assert.Equal(t, tc.input.InstanceIDs[i], instance.ID, "result order should match input order")
+					if tc.expectStatus != nil {
+						assert.Equal(t, *tc.expectStatus, instance.Status)
 					}
-					if tc.inputs[i].Status != nil {
-						assert.Equal(t, *tc.inputs[i].Status, instance.Status)
+					if tc.expectName != nil {
+						assert.Equal(t, *tc.expectName, instance.Name)
 					}
 				}
 			}
@@ -3270,19 +3268,43 @@ func TestInstanceSQLDAO_UpdateMultiple_ExceedsMaxBatchItems(t *testing.T) {
 	defer dbSession.Close()
 	isd := NewInstanceDAO(dbSession)
 
-	// Create inputs exceeding MaxBatchItems
-	inputs := make([]InstanceUpdateInput, db.MaxBatchItems+1)
-	for i := range inputs {
-		inputs[i] = InstanceUpdateInput{
-			InstanceID: uuid.New(),
-			Name:       db.GetStrPtr(fmt.Sprintf("test-%d", i)),
-		}
+	// Create IDs exceeding MaxBatchItems
+	ids := make([]uuid.UUID, db.MaxBatchItems+1)
+	for i := range ids {
+		ids[i] = uuid.New()
+	}
+	input := InstanceUpdateMultipleInput{
+		InstanceIDs:          ids,
+		InstanceUpdateCommon: InstanceUpdateCommon{Name: db.GetStrPtr("test")},
 	}
 
-	_, err := isd.UpdateMultiple(ctx, nil, inputs)
+	_, err := isd.UpdateMultiple(ctx, nil, input)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "batch size")
 	assert.Contains(t, err.Error(), "exceeds maximum allowed")
+}
+
+// TestInstanceSQLDAO_UpdateMultiple_RejectsDuplicateIDs covers the
+// pre-write guard against duplicate InstanceIDs in a single call.
+// Without it, the post-fetch SELECT returns one row per unique ID
+// while the input slice still counts duplicates, surfacing as a
+// post-write count-mismatch with a partially applied batch.
+func TestInstanceSQLDAO_UpdateMultiple_RejectsDuplicateIDs(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testInstanceInitDB(t)
+	defer dbSession.Close()
+	isd := NewInstanceDAO(dbSession)
+
+	dupID := uuid.New()
+	input := InstanceUpdateMultipleInput{
+		InstanceIDs:          []uuid.UUID{dupID, uuid.New(), dupID},
+		InstanceUpdateCommon: InstanceUpdateCommon{Status: db.GetStrPtr(InstanceStatusReady)},
+	}
+
+	_, err := isd.UpdateMultiple(ctx, nil, input)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate instance id")
+	assert.Contains(t, err.Error(), dupID.String())
 }
 
 func TestInstanceSQLDAO_GetAll_WithNames(t *testing.T) {
@@ -3426,38 +3448,41 @@ func TestInstanceSQLDAO_UpdateMultiple_AllFields(t *testing.T) {
 	// Prepare new values for update
 	newControllerInstanceID := uuid.New()
 
-	// Update with ALL fields set to new values
-	input := InstanceUpdateInput{
-		InstanceID:               instance.ID,
-		Name:                     db.GetStrPtr("updated-instance-name"),
-		Description:              db.GetStrPtr("updated description"),
-		TenantID:                 &tenant.ID,
-		InfrastructureProviderID: &ip.ID,
-		SiteID:                   &site.ID,
-		InstanceTypeID:           &instanceType.ID,
-		// NetworkSecurityGroupID is a FK, skip it
-		NetworkSecurityGroupPropagationDetails: &NetworkSecurityGroupPropagationDetails{
-			FriendlyStatus: "propagated",
+	// Update with ALL fields set to new values, applied as a shared
+	// mask to a single-ID slice.
+	input := InstanceUpdateMultipleInput{
+		InstanceIDs: []uuid.UUID{instance.ID},
+		InstanceUpdateCommon: InstanceUpdateCommon{
+			Name:                     db.GetStrPtr("updated-instance-name"),
+			Description:              db.GetStrPtr("updated description"),
+			TenantID:                 &tenant.ID,
+			InfrastructureProviderID: &ip.ID,
+			SiteID:                   &site.ID,
+			InstanceTypeID:           &instanceType.ID,
+			// NetworkSecurityGroupID is a FK, skip it
+			NetworkSecurityGroupPropagationDetails: &NetworkSecurityGroupPropagationDetails{
+				FriendlyStatus: "propagated",
+			},
+			VpcID:                    &vpc.ID,
+			MachineID:                &machine.ID,
+			ControllerInstanceID:     &newControllerInstanceID,
+			Hostname:                 db.GetStrPtr("new-hostname.example.com"),
+			OperatingSystemID:        &operatingSystem.ID,
+			IpxeScript:               db.GetStrPtr("new-ipxe-script"),
+			AlwaysBootWithCustomIpxe: db.GetBoolPtr(true),
+			PhoneHomeEnabled:         db.GetBoolPtr(true),
+			UserData:                 db.GetStrPtr("new-userdata"),
+			Labels:                   map[string]string{"env": "prod", "team": "platform"},
+			IsUpdatePending:          db.GetBoolPtr(true),
+			InfinityRCRStatus:        db.GetStrPtr("RESOURCE_GRANTED"),
+			TpmEkCertificate:         db.GetStrPtr("tpm-cert-data"),
+			Status:                   db.GetStrPtr(InstanceStatusReady),
+			PowerStatus:              db.GetStrPtr("on"),
+			IsMissingOnSite:          db.GetBoolPtr(true),
 		},
-		VpcID:                    &vpc.ID,
-		MachineID:                &machine.ID,
-		ControllerInstanceID:     &newControllerInstanceID,
-		Hostname:                 db.GetStrPtr("new-hostname.example.com"),
-		OperatingSystemID:        &operatingSystem.ID,
-		IpxeScript:               db.GetStrPtr("new-ipxe-script"),
-		AlwaysBootWithCustomIpxe: db.GetBoolPtr(true),
-		PhoneHomeEnabled:         db.GetBoolPtr(true),
-		UserData:                 db.GetStrPtr("new-userdata"),
-		Labels:                   map[string]string{"env": "prod", "team": "platform"},
-		IsUpdatePending:          db.GetBoolPtr(true),
-		InfinityRCRStatus:        db.GetStrPtr("RESOURCE_GRANTED"),
-		TpmEkCertificate:         db.GetStrPtr("tpm-cert-data"),
-		Status:                   db.GetStrPtr(InstanceStatusReady),
-		PowerStatus:              db.GetStrPtr("on"),
-		IsMissingOnSite:          db.GetBoolPtr(true),
 	}
 
-	results, err := isd.UpdateMultiple(ctx, nil, []InstanceUpdateInput{input})
+	results, err := isd.UpdateMultiple(ctx, nil, input)
 	assert.NoError(t, err)
 	assert.Len(t, results, 1)
 

--- a/db/pkg/db/model/vpc.go
+++ b/db/pkg/db/model/vpc.go
@@ -48,12 +48,16 @@ const (
 	// VpcOrderByDefault default field to be used for ordering when none specified
 	VpcOrderByDefault = "created"
 
-	// VpcEthernetVirtualizer is basic nico native netorking
+	// Network virtualization type values. Each value is the literal
+	// string stored in the `network_virtualization_type` column and
+	// returned as the REST API enum value. See `vpcTypeCapabilities`
+	// (below) for the per-type capability matrix.
 	VpcEthernetVirtualizer         = "ETHERNET_VIRTUALIZER"
 	VpcEthernetVirtualizerWithNVUE = "ETHERNET_VIRTUALIZER_WITH_NVUE"
 	VpcFNNClassic                  = "FNN_CLASSIC"
 	VpcFNNL3                       = "FNN_L3"
 	VpcFNN                         = "FNN"
+	VpcFlat                        = "FLAT"
 )
 
 var (
@@ -80,8 +84,55 @@ var (
 	VpcNetworkVirtualzationTypeMap = map[string]bool{
 		VpcEthernetVirtualizer: true,
 		VpcFNN:                 true,
+		VpcFlat:                true,
+	}
+
+	// vpcTypeCapabilities encodes the REST-tier capability matrix for
+	// VPC network-virtualization types. It mirrors the richer capability
+	// matrix in Core (see `carbide_api_model::vpc::capability`) but only
+	// carries the bits this layer actually gates on. Unknown or
+	// deprecated values (e.g. legacy FNN_CLASSIC, FNN_L3 rows) resolve
+	// to the zero value, which is the safe "supports nothing
+	// REST-specific" default. Callers should use the helper functions
+	// below rather than this map directly.
+	vpcTypeCapabilities = map[string]struct {
+		// supportsRoutingProfile is true for VPC types that accept a
+		// `routingProfile` field on create. FNN-only today.
+		supportsRoutingProfile bool
+
+		// supportsAutoInterface is true for VPC types that allow
+		// Instances to opt in to NICo-resolved interface configuration
+		// via `auto: true`. Flat-only today.
+		supportsAutoInterface bool
+	}{
+		VpcEthernetVirtualizer:         {},
+		VpcEthernetVirtualizerWithNVUE: {},
+		VpcFNN:                         {supportsRoutingProfile: true},
+		VpcFlat:                        {supportsAutoInterface: true},
 	}
 )
+
+// VpcTypeSupportsRoutingProfile reports whether VPCs of the given
+// network-virtualization type accept a `routingProfile` on create.
+// A nil pointer (no type specified) returns false; the caller is
+// expected to have resolved any defaulting beforehand.
+func VpcTypeSupportsRoutingProfile(virtType *string) bool {
+	if virtType == nil {
+		return false
+	}
+	return vpcTypeCapabilities[*virtType].supportsRoutingProfile
+}
+
+// VpcTypeSupportsAutoInterface reports whether Instances in VPCs of
+// the given network-virtualization type may set `auto: true` on
+// create or update. A nil pointer (no type recorded on the VPC)
+// returns false -- the safe default for legacy or unresolvable rows.
+func VpcTypeSupportsAutoInterface(virtType *string) bool {
+	if virtType == nil {
+		return false
+	}
+	return vpcTypeCapabilities[*virtType].supportsAutoInterface
+}
 
 // Vpc represents entries in the vpc table
 type Vpc struct {
@@ -171,8 +222,11 @@ func (vpc *Vpc) ToProto() *cwssaws.Vpc {
 	}
 	if vpc.NetworkVirtualizationType != nil {
 		nwvt := cwssaws.VpcVirtualizationType_ETHERNET_VIRTUALIZER
-		if *vpc.NetworkVirtualizationType == cwssaws.VpcVirtualizationType_FNN.String() {
+		switch *vpc.NetworkVirtualizationType {
+		case cwssaws.VpcVirtualizationType_FNN.String():
 			nwvt = cwssaws.VpcVirtualizationType_FNN
+		case cwssaws.VpcVirtualizationType_FLAT.String():
+			nwvt = cwssaws.VpcVirtualizationType_FLAT
 		}
 		proto.NetworkVirtualizationType = &nwvt
 	}

--- a/db/pkg/migrations/20260523061229_instance_network_auto.go
+++ b/db/pkg/migrations/20260523061229_instance_network_auto.go
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	Migrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
+		tx, terr := db.BeginTx(ctx, &sql.TxOptions{})
+		if terr != nil {
+			handlePanic(terr, "failed to begin transaction")
+		}
+
+		// network_auto carries the request-time signal that NICo should
+		// auto-resolve the instance's network interfaces from the host's
+		// HostInband segments. Default FALSE preserves the historical
+		// "explicit interfaces required" contract for existing rows.
+		_, err := tx.ExecContext(ctx, `ALTER TABLE "instance" ADD COLUMN IF NOT EXISTS network_auto BOOLEAN NOT NULL DEFAULT FALSE`)
+		handleError(tx, err)
+
+		terr = tx.Commit()
+		if terr != nil {
+			handlePanic(terr, "failed to commit transaction")
+		}
+
+		fmt.Print(" [up migration] Added 'network_auto' column to 'instance' table successfully. ")
+		return nil
+	}, func(ctx context.Context, db *bun.DB) error {
+		if _, err := db.ExecContext(ctx, `ALTER TABLE "instance" DROP COLUMN IF EXISTS network_auto`); err != nil {
+			return err
+		}
+		fmt.Print(" [down migration] Dropped 'network_auto' column from 'instance' table successfully. ")
+		return nil
+	})
+}

--- a/db/pkg/util/testing.go
+++ b/db/pkg/util/testing.go
@@ -62,6 +62,11 @@ func getTestDBParams() TestDBConfig {
 		tdbcfg.User = user
 	}
 
+	password, ok := os.LookupEnv("PGPASSWORD")
+	if ok {
+		tdbcfg.Password = password
+	}
+
 	if os.Getenv("CI") == "true" {
 		tdbcfg.Host = "postgres"
 		tdbcfg.Port = 5432

--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -13699,7 +13699,8 @@ components:
           enum:
             - ETHERNET_VIRTUALIZER
             - FNN
-          description: Network virtualization type of the VPC
+            - FLAT
+          description: 'Network virtualization type of the VPC. Flat VPCs hold instances on zero-DPU hosts (or hosts with their DPU in NIC mode); their interfaces are bound to underlay (HostInband) network segments and NICo does not drive their data plane.'
         routingProfile:
           type:
             - string
@@ -13824,7 +13825,8 @@ components:
           enum:
             - ETHERNET_VIRTUALIZER
             - FNN
-          description: 'Network virtualization type of the VPC. If no value is specified, then defaults to `FNN` if Site has native networking enabled, or ETHERNET_VIRTUALIZER if native networking is disabled'
+            - FLAT
+          description: 'Network virtualization type of the VPC. If no value is specified, then defaults to `FNN` if Site has native networking enabled, or `ETHERNET_VIRTUALIZER` if native networking is disabled. Flat VPCs hold instances on zero-DPU hosts (or hosts with their DPU in NIC mode) and are never auto-selected -- `FLAT` must be specified explicitly.'
         routingProfile:
           type:
             - string
@@ -15807,6 +15809,9 @@ components:
             - string
             - 'null'
           description: 'Serial Console URL for the Instance. Format: ssh://<id>@siteSerialConsoleHostname'
+        auto:
+          type: boolean
+          description: 'True when this Instance uses NICo auto-resolved networking from the host''s underlay (HostInband) network segments. When true, the caller''s request `interfaces` list was empty, this `interfaces` field remains empty on readback, and the resolved per-interface details surface under `status.network.interfaces`.'
         interfaces:
           type: array
           items:
@@ -16069,9 +16074,12 @@ components:
           $ref: '#/components/schemas/Labels'
         interfaces:
           type: array
-          description: 'At least one interface must be specified. Either Subnet or VPC Prefix interfaces allowed. Only one of the Subnets or VPC Prefixes can be attached over Physical interface. If only one Subnet is specified, then it will be attached over physical interface regardless of the value of isPhysical. In case of VPC Prefix, isPhysical will always be true'
+          description: 'At least one interface must be specified unless `auto` is true. Either Subnet or VPC Prefix interfaces allowed. Only one of the Subnets or VPC Prefixes can be attached over Physical interface. If only one Subnet is specified, then it will be attached over physical interface regardless of the value of isPhysical. In case of VPC Prefix, isPhysical will always be true. Mutually exclusive with `auto`: when `auto` is true this list MUST be empty.'
           items:
             $ref: '#/components/schemas/InterfaceCreateRequest'
+        auto:
+          type: boolean
+          description: 'When true, asks NICo to auto-resolve the Instance''s network interfaces from the host''s underlay (HostInband) network segments. Intended for instances on zero-DPU hosts (or hosts with their DPU in NIC mode). When true: (1) the target VPC''s `networkVirtualizationType` MUST be `FLAT`, (2) `interfaces` MUST be empty or omitted, and (3) `secondaryVpcIds` MUST be empty or omitted. Resolved interfaces surface on the Instance''s read response.'
         infinibandInterfaces:
           type: array
           description: Associate one or more Partitions with this Instance
@@ -16100,7 +16108,6 @@ components:
         - name
         - tenantId
         - vpcId
-        - interfaces
     BatchInstanceCreateRequest:
       title: BatchInstanceCreateRequest
       type: object
@@ -16216,9 +16223,12 @@ components:
           $ref: '#/components/schemas/Labels'
         interfaces:
           type: array
-          description: 'Interface configuration shared across all instances. At least one interface must be specified. Either Subnet or VPC Prefix interfaces allowed, only one of the Subnets or VPC Prefixes can be attached over Physical interface. Interface `ipAddress` is not supported for batch instance creation requests.'
+          description: 'Interface configuration shared across all instances. At least one interface must be specified unless `auto` is true. Either Subnet or VPC Prefix interfaces allowed, only one of the Subnets or VPC Prefixes can be attached over Physical interface. Interface `ipAddress` is not supported for batch instance creation requests. Mutually exclusive with `auto`: when `auto` is true this list MUST be empty.'
           items:
             $ref: '#/components/schemas/InterfaceCreateRequest'
+        auto:
+          type: boolean
+          description: 'When true, asks NICo to auto-resolve each Instance''s network interfaces from the host''s underlay (HostInband) network segments. Intended for instances on zero-DPU hosts (or hosts with their DPU in NIC mode). When true: (1) the target VPC''s `networkVirtualizationType` MUST be `FLAT`, (2) `interfaces` MUST be empty or omitted, and (3) `secondaryVpcIds` MUST be empty or omitted.'
         infinibandInterfaces:
           type: array
           description: InfiniBand interface configuration shared across all instances
@@ -16250,7 +16260,6 @@ components:
         - tenantId
         - instanceTypeId
         - vpcId
-        - interfaces
     InstanceUpdateRequest:
       title: InstanceUpdateRequest
       type: object
@@ -16395,9 +16404,14 @@ components:
             format: uuid
         interfaces:
           type: array
-          description: Update Interfaces of the Instance
+          description: 'Update Interfaces of the Instance. Mutually exclusive with `auto`: when `auto` is true this list MUST be empty.'
           items:
             $ref: '#/components/schemas/InterfaceCreateRequest'
+        auto:
+          type:
+            - boolean
+            - 'null'
+          description: 'When set, asks NICo to auto-resolve the Instance''s network interfaces from the host''s underlay (HostInband) segments. `null` leaves the value unchanged; `true` (re-)resolves; `false` returns to explicit interface configuration. When `true`, the Instance''s VPC MUST already have `networkVirtualizationType: FLAT`, `interfaces` MUST be empty or omitted, and `secondaryVpcIds` MUST be empty or omitted.'
         infinibandInterfaces:
           type: array
           description: Update InfiniBand Interfaces of the Instance

--- a/sdk/standard/compat/instance_create.go
+++ b/sdk/standard/compat/instance_create.go
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package compat holds deprecated, source-compatible wrappers around
+// standard SDK constructors whose signatures changed as a side effect
+// of optional-field changes in the OpenAPI spec (which the generator
+// reflects by dropping the corresponding constructor argument).
+//
+// The wrappers live here rather than under `sdk/standard/helpers`
+// because the `standard` package already imports `helpers` (for
+// pagination and API-name rewriting), so `helpers` cannot import
+// `standard` back. This sibling package can safely depend on
+// `standard` without creating an import cycle.
+
+package compat
+
+import standard "github.com/NVIDIA/infra-controller-rest/sdk/standard"
+
+// NewInstanceCreateRequestWithInterfaces preserves the pre-`auto`
+// `NewInstanceCreateRequest` signature, which took an explicit
+// `interfaces` argument before that field became optional on the
+// REST API. Callers should migrate to
+// `standard.NewInstanceCreateRequest(name, tenantId, vpcId)` followed
+// by `SetInterfaces` (or `SetAuto` for zero-DPU instances).
+//
+// Deprecated: use `standard.NewInstanceCreateRequest` + `SetInterfaces`.
+func NewInstanceCreateRequestWithInterfaces(name, tenantID, vpcID string, interfaces []standard.InterfaceCreateRequest) *standard.InstanceCreateRequest {
+	req := standard.NewInstanceCreateRequest(name, tenantID, vpcID)
+	req.SetInterfaces(interfaces)
+	return req
+}
+
+// NewBatchInstanceCreateRequestWithInterfaces preserves the pre-`auto`
+// `NewBatchInstanceCreateRequest` signature, which took an explicit
+// `interfaces` argument before that field became optional. Callers
+// should migrate to `standard.NewBatchInstanceCreateRequest(...)`
+// followed by `SetInterfaces` (or `SetAuto` for zero-DPU batches).
+//
+// Deprecated: use `standard.NewBatchInstanceCreateRequest` + `SetInterfaces`.
+func NewBatchInstanceCreateRequestWithInterfaces(namePrefix string, count int32, tenantID, instanceTypeID, vpcID string, interfaces []standard.InterfaceCreateRequest) *standard.BatchInstanceCreateRequest {
+	req := standard.NewBatchInstanceCreateRequest(namePrefix, count, tenantID, instanceTypeID, vpcID)
+	req.SetInterfaces(interfaces)
+	return req
+}

--- a/sdk/standard/model_batch_instance_create_request.go
+++ b/sdk/standard/model_batch_instance_create_request.go
@@ -65,8 +65,10 @@ type BatchInstanceCreateRequest struct {
 	// When set to true, the Instances will be enabled with the Phone Home service.
 	PhoneHomeEnabled *bool             `json:"phoneHomeEnabled,omitempty"`
 	Labels           map[string]string `json:"labels,omitempty"`
-	// Interface configuration shared across all instances. At least one interface must be specified. Either Subnet or VPC Prefix interfaces allowed, only one of the Subnets or VPC Prefixes can be attached over Physical interface. Interface `ipAddress` is not supported for batch instance creation requests.
-	Interfaces []InterfaceCreateRequest `json:"interfaces"`
+	// Interface configuration shared across all instances. At least one interface must be specified unless `auto` is true. Either Subnet or VPC Prefix interfaces allowed, only one of the Subnets or VPC Prefixes can be attached over Physical interface. Interface `ipAddress` is not supported for batch instance creation requests. Mutually exclusive with `auto`: when `auto` is true this list MUST be empty.
+	Interfaces []InterfaceCreateRequest `json:"interfaces,omitempty"`
+	// When true, asks NICo to auto-resolve each Instance's network interfaces from the host's underlay (HostInband) network segments. Intended for instances on zero-DPU hosts (or hosts with their DPU in NIC mode). When true: (1) the target VPC's `networkVirtualizationType` MUST be `FLAT`, (2) `interfaces` MUST be empty or omitted, and (3) `secondaryVpcIds` MUST be empty or omitted.
+	Auto *bool `json:"auto,omitempty"`
 	// InfiniBand interface configuration shared across all instances
 	InfinibandInterfaces []InfiniBandInterfaceCreateRequest `json:"infinibandInterfaces,omitempty"`
 	// DPU Extension Services to deploy to all instances in the batch
@@ -85,14 +87,13 @@ type _BatchInstanceCreateRequest BatchInstanceCreateRequest
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewBatchInstanceCreateRequest(namePrefix string, count int32, tenantId string, instanceTypeId string, vpcId string, interfaces []InterfaceCreateRequest) *BatchInstanceCreateRequest {
+func NewBatchInstanceCreateRequest(namePrefix string, count int32, tenantId string, instanceTypeId string, vpcId string) *BatchInstanceCreateRequest {
 	this := BatchInstanceCreateRequest{}
 	this.NamePrefix = namePrefix
 	this.Count = count
 	this.TenantId = tenantId
 	this.InstanceTypeId = instanceTypeId
 	this.VpcId = vpcId
-	this.Interfaces = interfaces
 	var topologyOptimized bool = true
 	this.TopologyOptimized = &topologyOptimized
 	return &this
@@ -571,28 +572,68 @@ func (o *BatchInstanceCreateRequest) SetLabels(v map[string]string) {
 	o.Labels = v
 }
 
-// GetInterfaces returns the Interfaces field value
+// GetInterfaces returns the Interfaces field value if set, zero value otherwise.
 func (o *BatchInstanceCreateRequest) GetInterfaces() []InterfaceCreateRequest {
-	if o == nil {
+	if o == nil || IsNil(o.Interfaces) {
 		var ret []InterfaceCreateRequest
 		return ret
 	}
-
 	return o.Interfaces
 }
 
-// GetInterfacesOk returns a tuple with the Interfaces field value
+// GetInterfacesOk returns a tuple with the Interfaces field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *BatchInstanceCreateRequest) GetInterfacesOk() ([]InterfaceCreateRequest, bool) {
-	if o == nil {
+	if o == nil || IsNil(o.Interfaces) {
 		return nil, false
 	}
 	return o.Interfaces, true
 }
 
-// SetInterfaces sets field value
+// HasInterfaces returns a boolean if a field has been set.
+func (o *BatchInstanceCreateRequest) HasInterfaces() bool {
+	if o != nil && !IsNil(o.Interfaces) {
+		return true
+	}
+
+	return false
+}
+
+// SetInterfaces gets a reference to the given []InterfaceCreateRequest and assigns it to the Interfaces field.
 func (o *BatchInstanceCreateRequest) SetInterfaces(v []InterfaceCreateRequest) {
 	o.Interfaces = v
+}
+
+// GetAuto returns the Auto field value if set, zero value otherwise.
+func (o *BatchInstanceCreateRequest) GetAuto() bool {
+	if o == nil || IsNil(o.Auto) {
+		var ret bool
+		return ret
+	}
+	return *o.Auto
+}
+
+// GetAutoOk returns a tuple with the Auto field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *BatchInstanceCreateRequest) GetAutoOk() (*bool, bool) {
+	if o == nil || IsNil(o.Auto) {
+		return nil, false
+	}
+	return o.Auto, true
+}
+
+// HasAuto returns a boolean if a field has been set.
+func (o *BatchInstanceCreateRequest) HasAuto() bool {
+	if o != nil && !IsNil(o.Auto) {
+		return true
+	}
+
+	return false
+}
+
+// SetAuto gets a reference to the given bool and assigns it to the Auto field.
+func (o *BatchInstanceCreateRequest) SetAuto(v bool) {
+	o.Auto = &v
 }
 
 // GetInfinibandInterfaces returns the InfinibandInterfaces field value if set, zero value otherwise.
@@ -797,7 +838,12 @@ func (o BatchInstanceCreateRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Labels) {
 		toSerialize["labels"] = o.Labels
 	}
-	toSerialize["interfaces"] = o.Interfaces
+	if !IsNil(o.Interfaces) {
+		toSerialize["interfaces"] = o.Interfaces
+	}
+	if !IsNil(o.Auto) {
+		toSerialize["auto"] = o.Auto
+	}
 	if !IsNil(o.InfinibandInterfaces) {
 		toSerialize["infinibandInterfaces"] = o.InfinibandInterfaces
 	}
@@ -826,7 +872,6 @@ func (o *BatchInstanceCreateRequest) UnmarshalJSON(data []byte) (err error) {
 		"tenantId",
 		"instanceTypeId",
 		"vpcId",
-		"interfaces",
 	}
 
 	allProperties := make(map[string]interface{})

--- a/sdk/standard/model_instance.go
+++ b/sdk/standard/model_instance.go
@@ -71,7 +71,9 @@ type Instance struct {
 	// Indicates whether an update is available for the Instance. Updates can be applied on reboot
 	IsUpdatePending *bool `json:"isUpdatePending,omitempty"`
 	// Serial Console URL for the Instance. Format: ssh://<id>@siteSerialConsoleHostname
-	SerialConsoleUrl     NullableString        `json:"serialConsoleUrl,omitempty"`
+	SerialConsoleUrl NullableString `json:"serialConsoleUrl,omitempty"`
+	// True when this Instance uses NICo auto-resolved networking from the host's underlay (HostInband) network segments. When true, the caller's request `interfaces` list was empty, this `interfaces` field remains empty on readback, and the resolved per-interface details surface under `status.network.interfaces`.
+	Auto                 *bool                 `json:"auto,omitempty"`
 	Interfaces           []Interface           `json:"interfaces,omitempty"`
 	InfinibandInterfaces []InfiniBandInterface `json:"infinibandInterfaces,omitempty"`
 	NvLinkInterfaces     []NVLinkInterface     `json:"nvLinkInterfaces,omitempty"`
@@ -910,6 +912,38 @@ func (o *Instance) UnsetSerialConsoleUrl() {
 	o.SerialConsoleUrl.Unset()
 }
 
+// GetAuto returns the Auto field value if set, zero value otherwise.
+func (o *Instance) GetAuto() bool {
+	if o == nil || IsNil(o.Auto) {
+		var ret bool
+		return ret
+	}
+	return *o.Auto
+}
+
+// GetAutoOk returns a tuple with the Auto field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Instance) GetAutoOk() (*bool, bool) {
+	if o == nil || IsNil(o.Auto) {
+		return nil, false
+	}
+	return o.Auto, true
+}
+
+// HasAuto returns a boolean if a field has been set.
+func (o *Instance) HasAuto() bool {
+	if o != nil && !IsNil(o.Auto) {
+		return true
+	}
+
+	return false
+}
+
+// SetAuto gets a reference to the given bool and assigns it to the Auto field.
+func (o *Instance) SetAuto(v bool) {
+	o.Auto = &v
+}
+
 // GetInterfaces returns the Interfaces field value if set, zero value otherwise.
 func (o *Instance) GetInterfaces() []Interface {
 	if o == nil || IsNil(o.Interfaces) {
@@ -1380,6 +1414,9 @@ func (o Instance) ToMap() (map[string]interface{}, error) {
 	}
 	if o.SerialConsoleUrl.IsSet() {
 		toSerialize["serialConsoleUrl"] = o.SerialConsoleUrl.Get()
+	}
+	if !IsNil(o.Auto) {
+		toSerialize["auto"] = o.Auto
 	}
 	if !IsNil(o.Interfaces) {
 		toSerialize["interfaces"] = o.Interfaces

--- a/sdk/standard/model_instance_create_request.go
+++ b/sdk/standard/model_instance_create_request.go
@@ -64,8 +64,10 @@ type InstanceCreateRequest struct {
 	// When set to true, the Instance will be enabled with the Phone Home service.
 	PhoneHomeEnabled *bool             `json:"phoneHomeEnabled,omitempty"`
 	Labels           map[string]string `json:"labels,omitempty"`
-	// At least one interface must be specified. Either Subnet or VPC Prefix interfaces allowed. Only one of the Subnets or VPC Prefixes can be attached over Physical interface. If only one Subnet is specified, then it will be attached over physical interface regardless of the value of isPhysical. In case of VPC Prefix, isPhysical will always be true
-	Interfaces []InterfaceCreateRequest `json:"interfaces"`
+	// At least one interface must be specified unless `auto` is true. Either Subnet or VPC Prefix interfaces allowed. Only one of the Subnets or VPC Prefixes can be attached over Physical interface. If only one Subnet is specified, then it will be attached over physical interface regardless of the value of isPhysical. In case of VPC Prefix, isPhysical will always be true. Mutually exclusive with `auto`: when `auto` is true this list MUST be empty.
+	Interfaces []InterfaceCreateRequest `json:"interfaces,omitempty"`
+	// When true, asks NICo to auto-resolve the Instance's network interfaces from the host's underlay (HostInband) network segments. Intended for instances on zero-DPU hosts (or hosts with their DPU in NIC mode). When true: (1) the target VPC's `networkVirtualizationType` MUST be `FLAT`, (2) `interfaces` MUST be empty or omitted, and (3) `secondaryVpcIds` MUST be empty or omitted. Resolved interfaces surface on the Instance's read response.
+	Auto *bool `json:"auto,omitempty"`
 	// Associate one or more Partitions with this Instance
 	InfinibandInterfaces []InfiniBandInterfaceCreateRequest `json:"infinibandInterfaces,omitempty"`
 	// DPU Extension Services to deploy to the DPUs of this Instance
@@ -84,12 +86,11 @@ type _InstanceCreateRequest InstanceCreateRequest
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewInstanceCreateRequest(name string, tenantId string, vpcId string, interfaces []InterfaceCreateRequest) *InstanceCreateRequest {
+func NewInstanceCreateRequest(name string, tenantId string, vpcId string) *InstanceCreateRequest {
 	this := InstanceCreateRequest{}
 	this.Name = name
 	this.TenantId = tenantId
 	this.VpcId = vpcId
-	this.Interfaces = interfaces
 	return &this
 }
 
@@ -602,28 +603,68 @@ func (o *InstanceCreateRequest) SetLabels(v map[string]string) {
 	o.Labels = v
 }
 
-// GetInterfaces returns the Interfaces field value
+// GetInterfaces returns the Interfaces field value if set, zero value otherwise.
 func (o *InstanceCreateRequest) GetInterfaces() []InterfaceCreateRequest {
-	if o == nil {
+	if o == nil || IsNil(o.Interfaces) {
 		var ret []InterfaceCreateRequest
 		return ret
 	}
-
 	return o.Interfaces
 }
 
-// GetInterfacesOk returns a tuple with the Interfaces field value
+// GetInterfacesOk returns a tuple with the Interfaces field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *InstanceCreateRequest) GetInterfacesOk() ([]InterfaceCreateRequest, bool) {
-	if o == nil {
+	if o == nil || IsNil(o.Interfaces) {
 		return nil, false
 	}
 	return o.Interfaces, true
 }
 
-// SetInterfaces sets field value
+// HasInterfaces returns a boolean if a field has been set.
+func (o *InstanceCreateRequest) HasInterfaces() bool {
+	if o != nil && !IsNil(o.Interfaces) {
+		return true
+	}
+
+	return false
+}
+
+// SetInterfaces gets a reference to the given []InterfaceCreateRequest and assigns it to the Interfaces field.
 func (o *InstanceCreateRequest) SetInterfaces(v []InterfaceCreateRequest) {
 	o.Interfaces = v
+}
+
+// GetAuto returns the Auto field value if set, zero value otherwise.
+func (o *InstanceCreateRequest) GetAuto() bool {
+	if o == nil || IsNil(o.Auto) {
+		var ret bool
+		return ret
+	}
+	return *o.Auto
+}
+
+// GetAutoOk returns a tuple with the Auto field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *InstanceCreateRequest) GetAutoOk() (*bool, bool) {
+	if o == nil || IsNil(o.Auto) {
+		return nil, false
+	}
+	return o.Auto, true
+}
+
+// HasAuto returns a boolean if a field has been set.
+func (o *InstanceCreateRequest) HasAuto() bool {
+	if o != nil && !IsNil(o.Auto) {
+		return true
+	}
+
+	return false
+}
+
+// SetAuto gets a reference to the given bool and assigns it to the Auto field.
+func (o *InstanceCreateRequest) SetAuto(v bool) {
+	o.Auto = &v
 }
 
 // GetInfinibandInterfaces returns the InfinibandInterfaces field value if set, zero value otherwise.
@@ -832,7 +873,12 @@ func (o InstanceCreateRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Labels) {
 		toSerialize["labels"] = o.Labels
 	}
-	toSerialize["interfaces"] = o.Interfaces
+	if !IsNil(o.Interfaces) {
+		toSerialize["interfaces"] = o.Interfaces
+	}
+	if !IsNil(o.Auto) {
+		toSerialize["auto"] = o.Auto
+	}
 	if !IsNil(o.InfinibandInterfaces) {
 		toSerialize["infinibandInterfaces"] = o.InfinibandInterfaces
 	}
@@ -859,7 +905,6 @@ func (o *InstanceCreateRequest) UnmarshalJSON(data []byte) (err error) {
 		"name",
 		"tenantId",
 		"vpcId",
-		"interfaces",
 	}
 
 	allProperties := make(map[string]interface{})

--- a/sdk/standard/model_instance_update_request.go
+++ b/sdk/standard/model_instance_update_request.go
@@ -63,8 +63,10 @@ type InstanceUpdateRequest struct {
 	Labels map[string]string `json:"labels,omitempty"`
 	// IDs of additional VPCs the Instance should attach to through non-primary interfaces. This field may only be specified when every entry in `interfaces` uses `vpcPrefixId`. IDs must be unique, must be valid UUIDs, and must not include the primary `vpcId`.
 	SecondaryVpcIds []string `json:"secondaryVpcIds,omitempty"`
-	// Update Interfaces of the Instance
+	// Update Interfaces of the Instance. Mutually exclusive with `auto`: when `auto` is true this list MUST be empty.
 	Interfaces []InterfaceCreateRequest `json:"interfaces,omitempty"`
+	// When set, asks NICo to auto-resolve the Instance's network interfaces from the host's underlay (HostInband) segments. `null` leaves the value unchanged; `true` (re-)resolves; `false` returns to explicit interface configuration. When `true`, the Instance's VPC MUST already have `networkVirtualizationType: FLAT`, `interfaces` MUST be empty or omitted, and `secondaryVpcIds` MUST be empty or omitted.
+	Auto NullableBool `json:"auto,omitempty"`
 	// Update InfiniBand Interfaces of the Instance
 	InfinibandInterfaces []InfiniBandInterfaceCreateRequest `json:"infinibandInterfaces,omitempty"`
 	// Update NVLink Interfaces of the Instance. A subset of GPUs may be specified. Each item references a GPU index (`deviceInstance`) and an NVLink Logical Partition. Different interfaces may reference different NVLink Logical Partitions. Partial updates are not allowed, specified interfaces will delete or replace existing Interfaces. Updating is not allowed if Instance's VPC has `nvLinkLogicalPartitionId` attribute set.
@@ -691,6 +693,49 @@ func (o *InstanceUpdateRequest) SetInterfaces(v []InterfaceCreateRequest) {
 	o.Interfaces = v
 }
 
+// GetAuto returns the Auto field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *InstanceUpdateRequest) GetAuto() bool {
+	if o == nil || IsNil(o.Auto.Get()) {
+		var ret bool
+		return ret
+	}
+	return *o.Auto.Get()
+}
+
+// GetAutoOk returns a tuple with the Auto field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *InstanceUpdateRequest) GetAutoOk() (*bool, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.Auto.Get(), o.Auto.IsSet()
+}
+
+// HasAuto returns a boolean if a field has been set.
+func (o *InstanceUpdateRequest) HasAuto() bool {
+	if o != nil && o.Auto.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetAuto gets a reference to the given NullableBool and assigns it to the Auto field.
+func (o *InstanceUpdateRequest) SetAuto(v bool) {
+	o.Auto.Set(&v)
+}
+
+// SetAutoNil sets the value for Auto to be an explicit nil
+func (o *InstanceUpdateRequest) SetAutoNil() {
+	o.Auto.Set(nil)
+}
+
+// UnsetAuto ensures that no value is present for Auto, not even an explicit nil
+func (o *InstanceUpdateRequest) UnsetAuto() {
+	o.Auto.Unset()
+}
+
 // GetInfinibandInterfaces returns the InfinibandInterfaces field value if set, zero value otherwise.
 func (o *InstanceUpdateRequest) GetInfinibandInterfaces() []InfiniBandInterfaceCreateRequest {
 	if o == nil || IsNil(o.InfinibandInterfaces) {
@@ -841,6 +886,9 @@ func (o InstanceUpdateRequest) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.Interfaces) {
 		toSerialize["interfaces"] = o.Interfaces
+	}
+	if o.Auto.IsSet() {
+		toSerialize["auto"] = o.Auto.Get()
 	}
 	if !IsNil(o.InfinibandInterfaces) {
 		toSerialize["infinibandInterfaces"] = o.InfinibandInterfaces

--- a/sdk/standard/model_vpc.go
+++ b/sdk/standard/model_vpc.go
@@ -51,7 +51,7 @@ type VPC struct {
 	SiteId *string `json:"siteId,omitempty"`
 	// Legacy attribute, contains the same value as ID
 	ControllerVpcId NullableString `json:"controllerVpcId,omitempty"`
-	// Network virtualization type of the VPC
+	// Network virtualization type of the VPC. Flat VPCs hold instances on zero-DPU hosts (or hosts with their DPU in NIC mode); their interfaces are bound to underlay (HostInband) network segments and NICo does not drive their data plane.
 	NetworkVirtualizationType NullableString `json:"networkVirtualizationType,omitempty"`
 	// Routing profile type for the VPC. Populated when Site has Native Networking enabled and network virtualization type is `FNN`.
 	RoutingProfile NullableString `json:"routingProfile,omitempty"`

--- a/sdk/standard/model_vpc_create_request.go
+++ b/sdk/standard/model_vpc_create_request.go
@@ -46,7 +46,7 @@ type VpcCreateRequest struct {
 	Description NullableString `json:"description,omitempty"`
 	// ID of the Site where the VPC should be created
 	SiteId string `json:"siteId"`
-	// Network virtualization type of the VPC. If no value is specified, then defaults to `FNN` if Site has native networking enabled, or ETHERNET_VIRTUALIZER if native networking is disabled
+	// Network virtualization type of the VPC. If no value is specified, then defaults to `FNN` if Site has native networking enabled, or `ETHERNET_VIRTUALIZER` if native networking is disabled. Flat VPCs hold instances on zero-DPU hosts (or hosts with their DPU in NIC mode) and are never auto-selected -- `FLAT` must be specified explicitly.
 	NetworkVirtualizationType NullableString `json:"networkVirtualizationType,omitempty"`
 	// Specify routing profile for the VPC. Only supported when `networkVirtualizationType` is set to `FNN`, or when `networkVirtualizationType` is omitted and Site has Native Networking enabled. Requires Tenant to have elevated privilege. Current accepted values are `privileged-internal`, `internal`, and `external`.
 	RoutingProfile NullableString `json:"routingProfile,omitempty"`

--- a/workflow-schema/schema/site-agent/workflows/v1/nico_nico.pb.go
+++ b/workflow-schema/schema/site-agent/workflows/v1/nico_nico.pb.go
@@ -238,6 +238,14 @@ const (
 	VpcVirtualizationType_FNN_CLASSIC VpcVirtualizationType = 3
 	VpcVirtualizationType_FNN_L3      VpcVirtualizationType = 4
 	VpcVirtualizationType_FNN         VpcVirtualizationType = 5
+	// FLAT is for VPCs whose tenant instances live directly on the underlay
+	// (zero-DPU hosts, or hosts with their DPU in NIC mode). Their interfaces
+	// are bound to `HostInband` network segments rather than a Carbide-managed
+	// overlay. Flat VPCs are still real tenant VPCs with a VNI and NSGs, but
+	// Carbide doesn't drive their data plane -- routing and ACL enforcement
+	// between Flat VPCs and other VPCs is the network operator's
+	// responsibility.
+	VpcVirtualizationType_FLAT VpcVirtualizationType = 6
 )
 
 // Enum value maps for VpcVirtualizationType.
@@ -248,6 +256,7 @@ var (
 		3: "FNN_CLASSIC",
 		4: "FNN_L3",
 		5: "FNN",
+		6: "FLAT",
 	}
 	VpcVirtualizationType_value = map[string]int32{
 		"ETHERNET_VIRTUALIZER":           0,
@@ -255,6 +264,7 @@ var (
 		"FNN_CLASSIC":                    3,
 		"FNN_L3":                         4,
 		"FNN":                            5,
+		"FLAT":                           6,
 	}
 )
 
@@ -13707,8 +13717,22 @@ func (x *InstanceConfig) GetNvlink() *InstanceNVLinkConfig {
 // Desired network configuration for an instance
 type InstanceNetworkConfig struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Configures how instance network interfaces are set up
-	Interfaces    []*InstanceInterfaceConfig `protobuf:"bytes,1,rep,name=interfaces,proto3" json:"interfaces,omitempty"`
+	// Configures how instance network interfaces are set up.
+	// Mutually exclusive with `auto`: when `auto` is true, this
+	// MUST be empty. When `auto` is false, this lists the explicit
+	// interface configuration the caller wants applied.
+	Interfaces []*InstanceInterfaceConfig `protobuf:"bytes,1,rep,name=interfaces,proto3" json:"interfaces,omitempty"`
+	// When true, NICO (or potentially some pluggable SDN backend) will
+	// auto-resolve the instance's network interfaces from the host's
+	// HostInband network segments. Only valid for instances on zero-DPU
+	// hosts (no DPU, or DPU in NIC mode). When set, `interfaces` MUST be
+	// empty on the request.
+	//
+	// Callers reading the instance back also see `auto = true` with an
+	// empty `interfaces` list (what they sent is preserved verbatim).
+	// The resolved per-interface details surface in
+	// `Instance.status.network.interfaces` instead.
+	Auto          bool `protobuf:"varint,2,opt,name=auto,proto3" json:"auto,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -13748,6 +13772,13 @@ func (x *InstanceNetworkConfig) GetInterfaces() []*InstanceInterfaceConfig {
 		return x.Interfaces
 	}
 	return nil
+}
+
+func (x *InstanceNetworkConfig) GetAuto() bool {
+	if x != nil {
+		return x.Auto
+	}
+	return false
 }
 
 // Desired infiniband configuration for an instance
@@ -50169,11 +50200,12 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\x16dpu_extension_services\x18\x17 \x01(\v2).forge.InstanceDpuExtensionServicesConfigH\x01R\x14dpuExtensionServices\x88\x01\x01\x123\n" +
 	"\x06nvlink\x18\x18 \x01(\v2\x1b.forge.InstanceNVLinkConfigR\x06nvlinkB\x1c\n" +
 	"\x1a_network_security_group_idB\x19\n" +
-	"\x17_dpu_extension_servicesJ\x04\b\x15\x10\x16\"W\n" +
+	"\x17_dpu_extension_servicesJ\x04\b\x15\x10\x16\"k\n" +
 	"\x15InstanceNetworkConfig\x12>\n" +
 	"\n" +
 	"interfaces\x18\x01 \x03(\v2\x1e.forge.InstanceInterfaceConfigR\n" +
-	"interfaces\"a\n" +
+	"interfaces\x12\x12\n" +
+	"\x04auto\x18\x02 \x01(\bR\x04auto\"a\n" +
 	"\x18InstanceInfinibandConfig\x12E\n" +
 	"\rib_interfaces\x18\x01 \x03(\v2 .forge.InstanceIBInterfaceConfigR\fibInterfaces\"\\\n" +
 	"!InstanceDpuExtensionServiceConfig\x12\x1d\n" +
@@ -53288,14 +53320,15 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\x13RootBmcByMacAddress\x10\b\x12\x1c\n" +
 	"\x18BmcNICoAdminByMacAddress\x10\t\x12\b\n" +
 	"\x04NmxM\x10\n" +
-	"*\x7f\n" +
+	"*\x89\x01\n" +
 	"\x15VpcVirtualizationType\x12\x18\n" +
 	"\x14ETHERNET_VIRTUALIZER\x10\x00\x12&\n" +
 	"\x1eETHERNET_VIRTUALIZER_WITH_NVUE\x10\x02\x1a\x02\b\x01\x12\x0f\n" +
 	"\vFNN_CLASSIC\x10\x03\x12\n" +
 	"\n" +
 	"\x06FNN_L3\x10\x04\x12\a\n" +
-	"\x03FNN\x10\x05*Q\n" +
+	"\x03FNN\x10\x05\x12\b\n" +
+	"\x04FLAT\x10\x06*Q\n" +
 	"\x0fPrefixMatchType\x12\x10\n" +
 	"\fPREFIX_EXACT\x10\x00\x12\x13\n" +
 	"\x0fPREFIX_CONTAINS\x10\x01\x12\x17\n" +

--- a/workflow-schema/site-agent/workflows/v1/nico_nico.proto
+++ b/workflow-schema/site-agent/workflows/v1/nico_nico.proto
@@ -1422,6 +1422,14 @@ enum VpcVirtualizationType {
   FNN_CLASSIC = 3;
   FNN_L3 = 4;
   FNN = 5;
+  // FLAT is for VPCs whose tenant instances live directly on the underlay
+  // (zero-DPU hosts, or hosts with their DPU in NIC mode). Their interfaces
+  // are bound to `HostInband` network segments rather than a Carbide-managed
+  // overlay. Flat VPCs are still real tenant VPCs with a VNI and NSGs, but
+  // Carbide doesn't drive their data plane -- routing and ACL enforcement
+  // between Flat VPCs and other VPCs is the network operator's
+  // responsibility.
+  FLAT = 6;
 }
 
 message VpcUpdateRequest {
@@ -2423,8 +2431,23 @@ message InstanceConfig {
 
 // Desired network configuration for an instance
 message InstanceNetworkConfig {
-  // Configures how instance network interfaces are set up
+  // Configures how instance network interfaces are set up.
+  // Mutually exclusive with `auto`: when `auto` is true, this
+  // MUST be empty. When `auto` is false, this lists the explicit
+  // interface configuration the caller wants applied.
   repeated InstanceInterfaceConfig interfaces = 1;
+
+  // When true, NICO (or potentially some pluggable SDN backend) will
+  // auto-resolve the instance's network interfaces from the host's
+  // HostInband network segments. Only valid for instances on zero-DPU
+  // hosts (no DPU, or DPU in NIC mode). When set, `interfaces` MUST be
+  // empty on the request.
+  //
+  // Callers reading the instance back also see `auto = true` with an
+  // empty `interfaces` list (what they sent is preserved verbatim).
+  // The resolved per-interface details surface in
+  // `Instance.status.network.interfaces` instead.
+  bool auto = 2;
 }
 
 // Desired infiniband configuration for an instance

--- a/workflow/pkg/activity/instance/instance.go
+++ b/workflow/pkg/activity/instance/instance.go
@@ -264,13 +264,15 @@ func (mi ManageInstance) UpdateInstancesInDB(ctx context.Context, siteID uuid.UU
 			// from its parent machine when an instance is allocated.
 
 			_, serr := instanceDAO.Update(ctx, nil, cdbm.InstanceUpdateInput{
-				InstanceID:                             instance.ID,
-				NetworkSecurityGroupID:                 controllerInstance.Config.NetworkSecurityGroupId,
-				NetworkSecurityGroupPropagationDetails: sitePropagationStatus,
-				ControllerInstanceID:                   controllerInstanceID,
-				IsUpdatePending:                        isUpdatePending,
-				IsMissingOnSite:                        isMissingOnSite,
-				TpmEkCertificate:                       controllerInstance.TpmEkCertificate,
+				InstanceID: instance.ID,
+				InstanceUpdateCommon: cdbm.InstanceUpdateCommon{
+					NetworkSecurityGroupID:                 controllerInstance.Config.NetworkSecurityGroupId,
+					NetworkSecurityGroupPropagationDetails: sitePropagationStatus,
+					ControllerInstanceID:                   controllerInstanceID,
+					IsUpdatePending:                        isUpdatePending,
+					IsMissingOnSite:                        isMissingOnSite,
+					TpmEkCertificate:                       controllerInstance.TpmEkCertificate,
+				},
 			})
 			if serr != nil {
 				slogger.Error().Err(serr).Msg("failed to update missing on Site flag/controller Instance ID in DB")
@@ -926,7 +928,7 @@ func (mi ManageInstance) UpdateInstancesInDB(ctx context.Context, siteID uuid.UU
 			}
 
 			// Set isMissingOnSite flag to true and update status/create status detail, user can decide on deletion
-			_, serr := instanceDAO.Update(ctx, nil, cdbm.InstanceUpdateInput{InstanceID: instance.ID, IsMissingOnSite: cdb.GetBoolPtr(true)})
+			_, serr := instanceDAO.Update(ctx, nil, cdbm.InstanceUpdateInput{InstanceID: instance.ID, InstanceUpdateCommon: cdbm.InstanceUpdateCommon{IsMissingOnSite: cdb.GetBoolPtr(true)}})
 			if serr != nil {
 				// Log error and continue
 				slogger.Error().Err(serr).Msg("failed to set missing on Site flag in DB")
@@ -1155,7 +1157,7 @@ func (mi ManageInstance) updateInstanceStatusInDB(ctx context.Context, tx *cdb.T
 		return nil
 	}
 	instanceDAO := cdbm.NewInstanceDAO(mi.dbSession)
-	_, err := instanceDAO.Update(ctx, tx, cdbm.InstanceUpdateInput{InstanceID: instanceID, Status: status, PowerStatus: powerStatus})
+	_, err := instanceDAO.Update(ctx, tx, cdbm.InstanceUpdateInput{InstanceID: instanceID, InstanceUpdateCommon: cdbm.InstanceUpdateCommon{Status: status, PowerStatus: powerStatus}})
 	if err != nil {
 		return err
 	}

--- a/workflow/pkg/activity/instance/instance_test.go
+++ b/workflow/pkg/activity/instance/instance_test.go
@@ -488,7 +488,7 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 		},
 	)
 	assert.Nil(t, err)
-	_, err = instanceDAO.Update(ctx, nil, cdbm.InstanceUpdateInput{InstanceID: instance6.ID, IsMissingOnSite: cdb.GetBoolPtr(true)})
+	_, err = instanceDAO.Update(ctx, nil, cdbm.InstanceUpdateInput{InstanceID: instance6.ID, InstanceUpdateCommon: cdbm.InstanceUpdateCommon{IsMissingOnSite: cdb.GetBoolPtr(true)}})
 	assert.Nil(t, err)
 
 	// Set updated earlier than the inventory receipt interval


### PR DESCRIPTION
## Description

This closes https://github.com/NVIDIA/infra-controller-rest/issues/351, and is the REST-side counterpart to the Flat VPC and `auto` interface work that landed in Core (https://github.com/NVIDIA/infra-controller-core/pull/1775, https://github.com/NVIDIA/infra-controller-core/pull/1576, and https://github.com/NVIDIA/infra-controller-core/pull/1674), which together let tenants put instances on zero-DPU hosts (or hosts with their DPU in NIC mode).

The discussion on #351 was originally about whether to model this as `vpcId: null` or a special "unmanaged VPC" type. What landed in Core is closer to the latter -- Flat VPCs are real VPCs with VNIs, NSGs, and peering, but NICo doesn't drive their data plane.

Changes included:
- Brought the two new fields into `nico_nico.proto`.
- `Flat` is a new value in the `network_virtualization_type` enum across the API, DB, OpenAPI, and proto layers.
- `auto` is a new boolean on instance create / update that flips the interface configuration model from "explicit list" to "NICo resolves from HostInband segments." Mutually exclusive with `interfaces`, persisted on the instance row so partial updates can re-issue the signal without the caller re-supplying it.
- Defense-in-depth check at the REST layer that `auto: true` requires a Flat VPC. Core enforces the same rule, but we fail-fast here too to avoid round-tripping the site for an obviously bad request.

This also adds some "VPC capability-like" mappings (similar to what we have in Core) to drive logic decisions at the REST API layer.

Tests added!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **API** - API models or endpoints updated
- [x] **Workflow** - Workflow service updated
- [x] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **Flow** - Flow service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
