### PR TITLE
feat: Support env var overrides for every CLI config field

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -154,7 +154,46 @@ These flags apply to every command and override the corresponding config values.
 | `--keycloak-url` | `NICO_KEYCLOAK_URL` | Keycloak base URL (constructs `--token-url` if not set) |
 | `--keycloak-realm` | `NICO_KEYCLOAK_REALM` | Keycloak realm (default: `nico-dev`) |
 | `--client-id` | `NICO_CLIENT_ID` | OAuth client ID (default: `nico-api`) |
-| `--debug` | | Log the full HTTP request and response for the call |
+| `--debug` | | Log the full HTTP request and response for the call, plus every `NICO_*` environment variable in use |
+
+### Configuring with environment variables
+
+Every field in `~/.nico/config.yaml` can also be set via a `NICO_*` environment variable. When both a config value and an env var are present, the env var wins; an explicit command-line flag still beats both. Set any of these in your shell instead of editing the config file:
+
+| Env Var | Config field | Notes |
+|---------|--------------|-------|
+| `NICO_BASE_URL` | `api.base` | |
+| `NICO_ORG` | `api.org` | |
+| `NICO_API_NAME` | `api.name` | API path segment, defaults to `nico` |
+| `NICO_TOKEN` | `auth.token` | Direct bearer token |
+| `NICO_TOKEN_COMMAND` | `auth.token_command` | Shell command that prints a bearer token |
+| `NICO_AUTH_SCRIPT` | `auth.token_command` | Alias of `NICO_TOKEN_COMMAND` (canonical name wins when both set) |
+| `NICO_TOKEN_URL` | `auth.oidc.token_url` | |
+| `NICO_CLIENT_ID` | `auth.oidc.client_id` | |
+| `NICO_CLIENT_SECRET` | `auth.oidc.client_secret` | |
+| `NICO_OIDC_USERNAME` | `auth.oidc.username` | |
+| `NICO_OIDC_PASSWORD` | `auth.oidc.password` | |
+| `NICO_OIDC_TOKEN` | `auth.oidc.token` | Persisted bearer token (also honored by direct `NICO_TOKEN`) |
+| `NICO_OIDC_REFRESH_TOKEN` | `auth.oidc.refresh_token` | |
+| `NICO_OIDC_EXPIRES_AT` | `auth.oidc.expires_at` | RFC3339 timestamp |
+| `NICO_API_KEY` | `auth.api_key.key` | NGC API key |
+| `NICO_AUTHN_URL` | `auth.api_key.authn_url` | Required for legacy NGC keys; ignored for `nvapi-` bearer keys |
+| `NICO_API_KEY_TOKEN` | `auth.api_key.token` | Persisted token after NGC exchange |
+
+`NICO_KEYCLOAK_URL` and `NICO_KEYCLOAK_REALM` do not map to a single config field; they feed the login command and construct the OIDC `token_url` at login time.
+
+To see exactly which `NICO_*` variables are in use right now, pass `--debug` on any command:
+
+```bash
+nicocli --debug site list
+# stderr starts with:
+# [debug] env: 3 NICO_* variable(s) in use
+# [debug] env: NICO_BASE_URL = https://api.example.com  -> api.base
+# [debug] env: NICO_ORG      = my-org                   -> api.org
+# [debug] env: NICO_TOKEN    = eyJh...                  -> auth.token (sensitive)
+```
+
+In interactive mode, type `env` to see the same listing (`env --mask` redacts tokens, secrets, and passwords).
 
 ### Per-command flags
 

--- a/cli/pkg/app.go
+++ b/cli/pkg/app.go
@@ -19,6 +19,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	cli "github.com/urfave/cli/v2"
 )
@@ -113,11 +114,54 @@ func NewApp(specData []byte) (*cli.App, error) {
 			if cfg := c.String("config"); cfg != "" {
 				SetConfigPath(cfg)
 			}
+			if c.Bool("debug") {
+				printEnvOverridesForDebug(os.Stderr)
+			}
 			return nil
 		},
 	}
 
 	return app, nil
+}
+
+// printEnvOverridesForDebug writes the list of NICO_* env vars currently
+// set in the process environment to w, prefixed with "[debug] env:". The
+// listing reflects what nicocli will pull from the environment when it
+// applies overrides on top of the loaded config; flag-only env vars
+// (NICO_KEYCLOAK_URL, NICO_KEYCLOAK_REALM, NICO_CONFIG) are included so
+// users can see every NICO_* knob the CLI reads. Sensitive values are
+// printed in full because --debug is opt-in and is documented as logging
+// the full HTTP request and response, including the bearer token.
+func printEnvOverridesForDebug(w *os.File) {
+	overrides := EnvOverridesFromEnvironment()
+	if len(overrides) == 0 {
+		fmt.Fprintln(w, "[debug] env: no NICO_* environment variables set")
+		return
+	}
+	fmt.Fprintf(w, "[debug] env: %d NICO_* variable(s) in use\n", len(overrides))
+	for _, line := range splitLines(FormatEnvOverrides(overrides, false)) {
+		if line == "" {
+			continue
+		}
+		fmt.Fprintf(w, "[debug] env: %s\n", line)
+	}
+}
+
+// splitLines splits s on '\n' without keeping a trailing empty element,
+// so callers iterating it don't have to special-case the final newline.
+func splitLines(s string) []string {
+	var out []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			out = append(out, s[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		out = append(out, s[start:])
+	}
+	return out
 }
 
 func completionCommand() *cli.Command {

--- a/cli/pkg/auth.go
+++ b/cli/pkg/auth.go
@@ -71,6 +71,7 @@ func LoginCommand() *cli.Command {
 		},
 		Action: func(c *cli.Context) error {
 			cfg, _ := LoadConfig()
+			ApplyEnvOverrides(cfg)
 
 			tokenCommand := c.String("token-command")
 			if tokenCommand != "" {

--- a/cli/pkg/commands.go
+++ b/cli/pkg/commands.go
@@ -711,6 +711,7 @@ func coerceValue(v string, schemaType SchemaType) (interface{}, error) {
 
 func clientFromContext(c *cli.Context) (*Client, error) {
 	cfg, _ := LoadConfig()
+	ApplyEnvOverrides(cfg)
 
 	tokenCommand := c.String("token-command")
 	tokenCommandFromConfig := false

--- a/cli/pkg/env.go
+++ b/cli/pkg/env.go
@@ -277,6 +277,26 @@ func KnownEnvVarNames() []string {
 	return names
 }
 
+// KnownEnvVarDescriptors returns metadata for every NICO_* env var
+// nicocli recognizes, in registry order, with Value left empty and
+// Applied set to true for direct config-field overrides (false for
+// flag-only entries like NICO_KEYCLOAK_URL). Use this for static
+// documentation surfaces (help output, generated docs); use
+// EnvOverridesFromEnvironment when you want the values currently set
+// in the process environment.
+func KnownEnvVarDescriptors() []EnvOverride {
+	out := make([]EnvOverride, 0, len(envOverrideRegistry))
+	for _, entry := range envOverrideRegistry {
+		out = append(out, EnvOverride{
+			Name:       entry.name,
+			ConfigPath: entry.configPath,
+			Sensitive:  entry.sensitive,
+			Applied:    entry.apply != nil,
+		})
+	}
+	return out
+}
+
 // FormatEnvOverrides returns a multiline string describing each override
 // for human display. Layout:
 //

--- a/cli/pkg/env.go
+++ b/cli/pkg/env.go
@@ -1,0 +1,327 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// EnvOverride describes a single NICO_* environment variable, the config
+// field (or flag) it influences, and the value currently set in the process
+// environment. Values are returned exactly as os.Getenv reports them; the
+// caller is responsible for masking when displaying sensitive data.
+type EnvOverride struct {
+	// Name is the environment variable name (e.g. "NICO_BASE_URL").
+	Name string
+	// ConfigPath is a human-readable description of where the value lands.
+	// Direct config fields use dotted YAML paths (e.g. "api.base"); env
+	// vars that feed only the flag layer carry a parenthesized note instead.
+	ConfigPath string
+	// Value is the current value of the env var. Empty for unset env vars.
+	Value string
+	// Sensitive marks values that should be masked in casual display
+	// (tokens, passwords, client secrets, NGC API keys).
+	Sensitive bool
+	// Applied is true when ApplyEnvOverrides actually wrote this value
+	// back into the ConfigFile. Env vars that only feed flags
+	// (e.g. NICO_KEYCLOAK_URL) are reported but not applied here.
+	Applied bool
+}
+
+// envOverrideEntry is the static description of a known NICO_* env var.
+// apply may be nil for env vars that affect only the flag layer
+// (NICO_CONFIG, NICO_KEYCLOAK_URL, NICO_KEYCLOAK_REALM); they are still
+// reported by EnvOverridesFromEnvironment but ApplyEnvOverrides skips them.
+type envOverrideEntry struct {
+	name       string
+	configPath string
+	sensitive  bool
+	apply      func(cfg *ConfigFile, value string)
+}
+
+// envOverrideRegistry is the canonical list of every environment variable
+// nicocli understands. Keep this list in sync with cli/README.md and with
+// the urfave/cli flag EnvVars in app.go and auth.go: any flag's EnvVars
+// entry should also appear here so that the same variable also propagates
+// to fields that are only addressable through the config file (e.g. when
+// no matching flag exists, or when the value should reach config-only
+// callers like the TUI).
+var envOverrideRegistry = []envOverrideEntry{
+	// Config path override (handled by the global --config flag).
+	{
+		name:       "NICO_CONFIG",
+		configPath: "(--config; selects config file path)",
+	},
+
+	// api.* fields.
+	{
+		name:       "NICO_BASE_URL",
+		configPath: "api.base",
+		apply:      func(cfg *ConfigFile, v string) { cfg.API.Base = v },
+	},
+	{
+		name:       "NICO_ORG",
+		configPath: "api.org",
+		apply:      func(cfg *ConfigFile, v string) { cfg.API.Org = v },
+	},
+	{
+		name:       "NICO_API_NAME",
+		configPath: "api.name",
+		apply:      func(cfg *ConfigFile, v string) { cfg.API.Name = v },
+	},
+
+	// auth.* top-level fields. Order between NICO_TOKEN_COMMAND and the
+	// NICO_AUTH_SCRIPT alias matters: when both are set, urfave/cli takes
+	// the first non-empty entry in the flag's EnvVars list (currently
+	// "NICO_TOKEN_COMMAND" then "NICO_AUTH_SCRIPT"), so NICO_TOKEN_COMMAND
+	// must win. We achieve that by listing the alias first and the
+	// canonical name second, so the canonical apply runs last and
+	// overwrites the alias's apply.
+	{
+		name:       "NICO_TOKEN",
+		configPath: "auth.token",
+		sensitive:  true,
+		apply:      func(cfg *ConfigFile, v string) { cfg.Auth.Token = v },
+	},
+	{
+		name:       "NICO_AUTH_SCRIPT",
+		configPath: "auth.token_command",
+		apply:      func(cfg *ConfigFile, v string) { cfg.Auth.TokenCommand = v },
+	},
+	{
+		name:       "NICO_TOKEN_COMMAND",
+		configPath: "auth.token_command",
+		apply:      func(cfg *ConfigFile, v string) { cfg.Auth.TokenCommand = v },
+	},
+
+	// auth.oidc.* fields.
+	{
+		name:       "NICO_TOKEN_URL",
+		configPath: "auth.oidc.token_url",
+		apply:      func(cfg *ConfigFile, v string) { ensureOIDC(cfg).TokenURL = v },
+	},
+	{
+		name:       "NICO_CLIENT_ID",
+		configPath: "auth.oidc.client_id",
+		apply:      func(cfg *ConfigFile, v string) { ensureOIDC(cfg).ClientID = v },
+	},
+	{
+		name:       "NICO_CLIENT_SECRET",
+		configPath: "auth.oidc.client_secret",
+		sensitive:  true,
+		apply:      func(cfg *ConfigFile, v string) { ensureOIDC(cfg).ClientSecret = v },
+	},
+	{
+		name:       "NICO_OIDC_USERNAME",
+		configPath: "auth.oidc.username",
+		apply:      func(cfg *ConfigFile, v string) { ensureOIDC(cfg).Username = v },
+	},
+	{
+		name:       "NICO_OIDC_PASSWORD",
+		configPath: "auth.oidc.password",
+		sensitive:  true,
+		apply:      func(cfg *ConfigFile, v string) { ensureOIDC(cfg).Password = v },
+	},
+	{
+		name:       "NICO_OIDC_TOKEN",
+		configPath: "auth.oidc.token",
+		sensitive:  true,
+		apply:      func(cfg *ConfigFile, v string) { ensureOIDC(cfg).Token = v },
+	},
+	{
+		name:       "NICO_OIDC_REFRESH_TOKEN",
+		configPath: "auth.oidc.refresh_token",
+		sensitive:  true,
+		apply:      func(cfg *ConfigFile, v string) { ensureOIDC(cfg).RefreshToken = v },
+	},
+	{
+		name:       "NICO_OIDC_EXPIRES_AT",
+		configPath: "auth.oidc.expires_at",
+		apply:      func(cfg *ConfigFile, v string) { ensureOIDC(cfg).ExpiresAt = v },
+	},
+
+	// auth.api_key.* fields.
+	{
+		name:       "NICO_API_KEY",
+		configPath: "auth.api_key.key",
+		sensitive:  true,
+		apply:      func(cfg *ConfigFile, v string) { ensureAPIKey(cfg).Key = v },
+	},
+	{
+		name:       "NICO_AUTHN_URL",
+		configPath: "auth.api_key.authn_url",
+		apply:      func(cfg *ConfigFile, v string) { ensureAPIKey(cfg).AuthnURL = v },
+	},
+	{
+		name:       "NICO_API_KEY_TOKEN",
+		configPath: "auth.api_key.token",
+		sensitive:  true,
+		apply:      func(cfg *ConfigFile, v string) { ensureAPIKey(cfg).Token = v },
+	},
+
+	// Login-flow flag-only env vars. They have no direct config field but
+	// are honored by the login command via urfave EnvVars; surface them
+	// so users see them in --debug and the TUI env command.
+	{
+		name:       "NICO_KEYCLOAK_URL",
+		configPath: "(--keycloak-url; constructs auth.oidc.token_url at login)",
+	},
+	{
+		name:       "NICO_KEYCLOAK_REALM",
+		configPath: "(--keycloak-realm; used with NICO_KEYCLOAK_URL)",
+	},
+}
+
+func ensureOIDC(cfg *ConfigFile) *ConfigOIDC {
+	if cfg.Auth.OIDC == nil {
+		cfg.Auth.OIDC = &ConfigOIDC{}
+	}
+	return cfg.Auth.OIDC
+}
+
+func ensureAPIKey(cfg *ConfigFile) *ConfigAPIKey {
+	if cfg.Auth.APIKey == nil {
+		cfg.Auth.APIKey = &ConfigAPIKey{}
+	}
+	return cfg.Auth.APIKey
+}
+
+// ApplyEnvOverrides reads every NICO_* env var from the process
+// environment and writes its value into the matching ConfigFile field,
+// overriding whatever was loaded from the config YAML. It returns the list
+// of overrides that were actually applied (apply func != nil and env var
+// was set to a non-empty string), in registry order.
+//
+// Env vars that influence only the flag layer (e.g. NICO_KEYCLOAK_URL) are
+// not applied here -- urfave/cli reads them via the flag's EnvVars list.
+// Use EnvOverridesFromEnvironment to get every NICO_* env var that is set,
+// applied or not.
+func ApplyEnvOverrides(cfg *ConfigFile) []EnvOverride {
+	if cfg == nil {
+		return nil
+	}
+	var out []EnvOverride
+	for _, entry := range envOverrideRegistry {
+		v, ok := os.LookupEnv(entry.name)
+		if !ok || v == "" {
+			continue
+		}
+		applied := false
+		if entry.apply != nil {
+			entry.apply(cfg, v)
+			applied = true
+		}
+		out = append(out, EnvOverride{
+			Name:       entry.name,
+			ConfigPath: entry.configPath,
+			Value:      v,
+			Sensitive:  entry.sensitive,
+			Applied:    applied,
+		})
+	}
+	return out
+}
+
+// EnvOverridesFromEnvironment returns every NICO_* env var that is set
+// (to a non-empty value) in the current process environment, regardless
+// of whether ApplyEnvOverrides would write it back to ConfigFile. Useful
+// for the --debug listing and the interactive `env` command.
+func EnvOverridesFromEnvironment() []EnvOverride {
+	var out []EnvOverride
+	for _, entry := range envOverrideRegistry {
+		v, ok := os.LookupEnv(entry.name)
+		if !ok || v == "" {
+			continue
+		}
+		out = append(out, EnvOverride{
+			Name:       entry.name,
+			ConfigPath: entry.configPath,
+			Value:      v,
+			Sensitive:  entry.sensitive,
+			Applied:    entry.apply != nil,
+		})
+	}
+	return out
+}
+
+// KnownEnvVarNames returns every NICO_* env var nicocli recognizes,
+// sorted alphabetically. Useful for tests and documentation generation.
+func KnownEnvVarNames() []string {
+	seen := map[string]struct{}{}
+	for _, entry := range envOverrideRegistry {
+		seen[entry.name] = struct{}{}
+	}
+	names := make([]string, 0, len(seen))
+	for n := range seen {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// FormatEnvOverrides returns a multiline string describing each override
+// for human display. Layout:
+//
+//	NICO_BASE_URL=http://localhost:8388  -> api.base
+//	NICO_TOKEN=eyJh...REDACTED            -> auth.token (sensitive)
+//
+// When mask is true, sensitive values are replaced with a short prefix
+// followed by "...REDACTED". When mask is false, full values are printed.
+// The final line is terminated with a newline.
+func FormatEnvOverrides(overrides []EnvOverride, mask bool) string {
+	if len(overrides) == 0 {
+		return "(no NICO_* environment variables set)\n"
+	}
+	maxName := 0
+	for _, o := range overrides {
+		if l := len(o.Name); l > maxName {
+			maxName = l
+		}
+	}
+	var b strings.Builder
+	for _, o := range overrides {
+		val := o.Value
+		if mask && o.Sensitive {
+			val = maskSensitive(val)
+		}
+		marker := ""
+		if !o.Applied {
+			marker = " [flag-only]"
+		}
+		sensitiveTag := ""
+		if o.Sensitive {
+			sensitiveTag = " (sensitive)"
+		}
+		fmt.Fprintf(&b, "%-*s = %s  -> %s%s%s\n",
+			maxName, o.Name, val, o.ConfigPath, sensitiveTag, marker)
+	}
+	return b.String()
+}
+
+// maskSensitive returns a redacted form of a sensitive value: the first
+// six characters followed by "...REDACTED". Values shorter than seven
+// characters are fully redacted.
+func maskSensitive(v string) string {
+	if len(v) <= 6 {
+		return "REDACTED"
+	}
+	return v[:6] + "...REDACTED"
+}

--- a/cli/pkg/env_test.go
+++ b/cli/pkg/env_test.go
@@ -1,0 +1,279 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// clearAllNicoEnv unsets every known NICO_* env var before a test so that
+// the parent process environment can't leak into ApplyEnvOverrides results.
+// t.Setenv handles restoration on test exit for whatever the test sets.
+func clearAllNicoEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range KnownEnvVarNames() {
+		t.Setenv(name, "")
+	}
+}
+
+func TestApplyEnvOverrides_AllRegisteredFields(t *testing.T) {
+	clearAllNicoEnv(t)
+
+	t.Setenv("NICO_BASE_URL", "https://api.example.com")
+	t.Setenv("NICO_ORG", "test-org")
+	t.Setenv("NICO_API_NAME", "carbide")
+	t.Setenv("NICO_TOKEN", "direct-token")
+	t.Setenv("NICO_TOKEN_COMMAND", "/bin/get-token")
+	t.Setenv("NICO_TOKEN_URL", "https://auth.example.com/token")
+	t.Setenv("NICO_CLIENT_ID", "nico-cli")
+	t.Setenv("NICO_CLIENT_SECRET", "shh")
+	t.Setenv("NICO_OIDC_USERNAME", "alice")
+	t.Setenv("NICO_OIDC_PASSWORD", "swordfish")
+	t.Setenv("NICO_OIDC_TOKEN", "oidc-token")
+	t.Setenv("NICO_OIDC_REFRESH_TOKEN", "refresh-token")
+	t.Setenv("NICO_OIDC_EXPIRES_AT", "2026-12-31T00:00:00Z")
+	t.Setenv("NICO_API_KEY", "nvapi-xyz")
+	t.Setenv("NICO_AUTHN_URL", "https://authn.example.com/token")
+	t.Setenv("NICO_API_KEY_TOKEN", "exchanged-token")
+
+	cfg := &ConfigFile{}
+	applied := ApplyEnvOverrides(cfg)
+
+	assert.Equal(t, "https://api.example.com", cfg.API.Base)
+	assert.Equal(t, "test-org", cfg.API.Org)
+	assert.Equal(t, "carbide", cfg.API.Name)
+
+	assert.Equal(t, "direct-token", cfg.Auth.Token)
+	assert.Equal(t, "/bin/get-token", cfg.Auth.TokenCommand)
+
+	require.NotNil(t, cfg.Auth.OIDC)
+	assert.Equal(t, "https://auth.example.com/token", cfg.Auth.OIDC.TokenURL)
+	assert.Equal(t, "nico-cli", cfg.Auth.OIDC.ClientID)
+	assert.Equal(t, "shh", cfg.Auth.OIDC.ClientSecret)
+	assert.Equal(t, "alice", cfg.Auth.OIDC.Username)
+	assert.Equal(t, "swordfish", cfg.Auth.OIDC.Password)
+	assert.Equal(t, "oidc-token", cfg.Auth.OIDC.Token)
+	assert.Equal(t, "refresh-token", cfg.Auth.OIDC.RefreshToken)
+	assert.Equal(t, "2026-12-31T00:00:00Z", cfg.Auth.OIDC.ExpiresAt)
+
+	require.NotNil(t, cfg.Auth.APIKey)
+	assert.Equal(t, "nvapi-xyz", cfg.Auth.APIKey.Key)
+	assert.Equal(t, "https://authn.example.com/token", cfg.Auth.APIKey.AuthnURL)
+	assert.Equal(t, "exchanged-token", cfg.Auth.APIKey.Token)
+
+	assert.NotEmpty(t, applied)
+	for _, o := range applied {
+		assert.True(t, o.Applied, "%s should be marked applied", o.Name)
+		assert.NotEmpty(t, o.Value, "%s should carry its value", o.Name)
+	}
+}
+
+func TestApplyEnvOverrides_TrumpsConfigFile(t *testing.T) {
+	clearAllNicoEnv(t)
+
+	cfg := &ConfigFile{
+		API: ConfigAPI{
+			Base: "http://from-config",
+			Org:  "config-org",
+			Name: "nico",
+		},
+		Auth: ConfigAuth{
+			Token: "config-token",
+			OIDC: &ConfigOIDC{
+				TokenURL: "http://from-config/token",
+				ClientID: "config-client",
+			},
+		},
+	}
+
+	t.Setenv("NICO_BASE_URL", "http://from-env")
+	t.Setenv("NICO_ORG", "env-org")
+	t.Setenv("NICO_TOKEN", "env-token")
+	t.Setenv("NICO_TOKEN_URL", "http://from-env/token")
+
+	ApplyEnvOverrides(cfg)
+
+	assert.Equal(t, "http://from-env", cfg.API.Base, "NICO_BASE_URL must trump api.base")
+	assert.Equal(t, "env-org", cfg.API.Org, "NICO_ORG must trump api.org")
+	assert.Equal(t, "nico", cfg.API.Name, "unset NICO_API_NAME must leave api.name alone")
+	assert.Equal(t, "env-token", cfg.Auth.Token, "NICO_TOKEN must trump auth.token")
+	assert.Equal(t, "http://from-env/token", cfg.Auth.OIDC.TokenURL,
+		"NICO_TOKEN_URL must trump auth.oidc.token_url")
+	assert.Equal(t, "config-client", cfg.Auth.OIDC.ClientID,
+		"unset NICO_CLIENT_ID must preserve config-loaded ClientID")
+}
+
+func TestApplyEnvOverrides_AuthScriptAlias(t *testing.T) {
+	clearAllNicoEnv(t)
+
+	cfg := &ConfigFile{}
+	t.Setenv("NICO_AUTH_SCRIPT", "/bin/legacy-token")
+	ApplyEnvOverrides(cfg)
+	assert.Equal(t, "/bin/legacy-token", cfg.Auth.TokenCommand,
+		"NICO_AUTH_SCRIPT alias should set auth.token_command")
+}
+
+func TestApplyEnvOverrides_NICO_TOKEN_COMMAND_WinsOverAlias(t *testing.T) {
+	// Mirror urfave/cli's "first non-empty entry in EnvVars wins" rule
+	// for the --token-command flag (EnvVars: NICO_TOKEN_COMMAND first,
+	// NICO_AUTH_SCRIPT second). When both env vars are set the canonical
+	// NICO_TOKEN_COMMAND must win, regardless of which path applied it.
+	clearAllNicoEnv(t)
+
+	cfg := &ConfigFile{}
+	t.Setenv("NICO_AUTH_SCRIPT", "/bin/legacy")
+	t.Setenv("NICO_TOKEN_COMMAND", "/bin/preferred")
+	ApplyEnvOverrides(cfg)
+	assert.Equal(t, "/bin/preferred", cfg.Auth.TokenCommand,
+		"NICO_TOKEN_COMMAND must win over the NICO_AUTH_SCRIPT alias to "+
+			"match urfave/cli's flag-EnvVars precedence")
+}
+
+func TestApplyEnvOverrides_EmptyEnvIsIgnored(t *testing.T) {
+	clearAllNicoEnv(t)
+
+	cfg := &ConfigFile{
+		API:  ConfigAPI{Base: "http://kept"},
+		Auth: ConfigAuth{Token: "kept"},
+	}
+	t.Setenv("NICO_BASE_URL", "")
+	t.Setenv("NICO_TOKEN", "")
+	applied := ApplyEnvOverrides(cfg)
+	assert.Empty(t, applied)
+	assert.Equal(t, "http://kept", cfg.API.Base)
+	assert.Equal(t, "kept", cfg.Auth.Token)
+}
+
+func TestApplyEnvOverrides_NilCfg(t *testing.T) {
+	clearAllNicoEnv(t)
+	t.Setenv("NICO_BASE_URL", "http://anywhere")
+	out := ApplyEnvOverrides(nil)
+	assert.Nil(t, out)
+}
+
+func TestEnvOverridesFromEnvironment_ReportsUnappliedFlagOnlyVars(t *testing.T) {
+	clearAllNicoEnv(t)
+
+	t.Setenv("NICO_KEYCLOAK_URL", "http://kc.example.com")
+	t.Setenv("NICO_KEYCLOAK_REALM", "nico-prod")
+	t.Setenv("NICO_BASE_URL", "http://api")
+
+	overrides := EnvOverridesFromEnvironment()
+	require.Len(t, overrides, 3)
+
+	byName := map[string]EnvOverride{}
+	for _, o := range overrides {
+		byName[o.Name] = o
+	}
+
+	require.Contains(t, byName, "NICO_KEYCLOAK_URL")
+	assert.False(t, byName["NICO_KEYCLOAK_URL"].Applied,
+		"NICO_KEYCLOAK_URL is flag-only and should report Applied=false")
+
+	require.Contains(t, byName, "NICO_KEYCLOAK_REALM")
+	assert.False(t, byName["NICO_KEYCLOAK_REALM"].Applied)
+
+	require.Contains(t, byName, "NICO_BASE_URL")
+	assert.True(t, byName["NICO_BASE_URL"].Applied,
+		"NICO_BASE_URL maps directly to api.base and should report Applied=true")
+}
+
+func TestKnownEnvVarNames_CoversEveryConfigField(t *testing.T) {
+	// Sanity: KnownEnvVarNames should include every documented var.
+	got := KnownEnvVarNames()
+	assert.True(t, sort.StringsAreSorted(got),
+		"KnownEnvVarNames must be sorted")
+
+	required := []string{
+		// api.* fields.
+		"NICO_BASE_URL", "NICO_ORG", "NICO_API_NAME",
+		// auth.* top-level.
+		"NICO_TOKEN", "NICO_TOKEN_COMMAND",
+		// auth.oidc.* fields.
+		"NICO_TOKEN_URL", "NICO_CLIENT_ID", "NICO_CLIENT_SECRET",
+		"NICO_OIDC_USERNAME", "NICO_OIDC_PASSWORD",
+		"NICO_OIDC_TOKEN", "NICO_OIDC_REFRESH_TOKEN", "NICO_OIDC_EXPIRES_AT",
+		// auth.api_key.* fields.
+		"NICO_API_KEY", "NICO_AUTHN_URL", "NICO_API_KEY_TOKEN",
+		// flag-only / config selection.
+		"NICO_CONFIG", "NICO_AUTH_SCRIPT", "NICO_KEYCLOAK_URL", "NICO_KEYCLOAK_REALM",
+	}
+	for _, name := range required {
+		assert.Contains(t, got, name, "missing required env var: %s", name)
+	}
+}
+
+func TestFormatEnvOverrides_MaskingAndPlain(t *testing.T) {
+	overrides := []EnvOverride{
+		{Name: "NICO_BASE_URL", ConfigPath: "api.base", Value: "https://api.example.com", Applied: true},
+		{Name: "NICO_TOKEN", ConfigPath: "auth.token", Value: "eyJhbGciOiJIUzI1NiJ9.abc", Sensitive: true, Applied: true},
+		{Name: "NICO_KEYCLOAK_URL", ConfigPath: "(--keycloak-url)", Value: "http://kc", Applied: false},
+	}
+
+	plain := FormatEnvOverrides(overrides, false)
+	assert.Contains(t, plain, "NICO_BASE_URL")
+	assert.Contains(t, plain, "https://api.example.com")
+	assert.Contains(t, plain, "eyJhbGciOiJIUzI1NiJ9.abc",
+		"plain mode must show full sensitive values when caller asks for it")
+	assert.Contains(t, plain, "(sensitive)")
+	assert.Contains(t, plain, "[flag-only]",
+		"unapplied flag-only env vars should carry the [flag-only] marker")
+
+	masked := FormatEnvOverrides(overrides, true)
+	assert.Contains(t, masked, "NICO_BASE_URL")
+	assert.NotContains(t, masked, "eyJhbGciOiJIUzI1NiJ9.abc",
+		"masked mode must hide the sensitive token")
+	assert.Contains(t, masked, "REDACTED")
+	assert.Contains(t, masked, "https://api.example.com",
+		"non-sensitive values are not masked")
+
+	empty := FormatEnvOverrides(nil, false)
+	assert.True(t, strings.Contains(empty, "no NICO_* environment variables set"),
+		"empty list should produce a friendly placeholder")
+}
+
+func TestApplyEnvOverrides_OnceLoadedConfig(t *testing.T) {
+	// LoadConfigFromPath plus ApplyEnvOverrides is the production
+	// pipeline. This test pins down the contract that callers can use
+	// the two together to layer env on top of a YAML config.
+	clearAllNicoEnv(t)
+
+	dir := t.TempDir()
+	path := dir + "/config.yaml"
+	contents := "api:\n  base: http://config-only\n  org: config-org\n  name: nico\n"
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0600))
+
+	t.Setenv("NICO_BASE_URL", "http://from-env")
+
+	cfg, err := LoadConfigFromPath(path)
+	require.NoError(t, err)
+	require.Equal(t, "http://config-only", cfg.API.Base,
+		"LoadConfigFromPath must NOT auto-apply env (callers do it explicitly)")
+
+	applied := ApplyEnvOverrides(cfg)
+	require.Len(t, applied, 1)
+	assert.Equal(t, "http://from-env", cfg.API.Base)
+	assert.Equal(t, "config-org", cfg.API.Org,
+		"unset NICO_ORG should leave the YAML-loaded value alone")
+}

--- a/cli/pkg/env_test.go
+++ b/cli/pkg/env_test.go
@@ -199,6 +199,35 @@ func TestEnvOverridesFromEnvironment_ReportsUnappliedFlagOnlyVars(t *testing.T) 
 		"NICO_BASE_URL maps directly to api.base and should report Applied=true")
 }
 
+func TestKnownEnvVarDescriptors_DocsEveryRegisteredEntry(t *testing.T) {
+	descriptors := KnownEnvVarDescriptors()
+	require.NotEmpty(t, descriptors)
+
+	// Every entry must populate Name and ConfigPath; Value stays empty
+	// since this surface is for static documentation, not live env state.
+	for _, d := range descriptors {
+		assert.NotEmpty(t, d.Name)
+		assert.NotEmpty(t, d.ConfigPath, "%s missing ConfigPath", d.Name)
+		assert.Empty(t, d.Value, "%s should not carry a value here", d.Name)
+	}
+
+	// Spot-check that flag-only entries are reported with Applied=false
+	// and direct config-field entries with Applied=true.
+	byName := map[string]EnvOverride{}
+	for _, d := range descriptors {
+		byName[d.Name] = d
+	}
+	require.Contains(t, byName, "NICO_BASE_URL")
+	assert.True(t, byName["NICO_BASE_URL"].Applied,
+		"direct config field override should report Applied=true")
+	require.Contains(t, byName, "NICO_KEYCLOAK_URL")
+	assert.False(t, byName["NICO_KEYCLOAK_URL"].Applied,
+		"flag-only env var should report Applied=false")
+	require.Contains(t, byName, "NICO_TOKEN")
+	assert.True(t, byName["NICO_TOKEN"].Sensitive,
+		"NICO_TOKEN must stay flagged as sensitive")
+}
+
 func TestKnownEnvVarNames_CoversEveryConfigField(t *testing.T) {
 	// Sanity: KnownEnvVarNames should include every documented var.
 	got := KnownEnvVarNames()

--- a/cli/tui/commands.go
+++ b/cli/tui/commands.go
@@ -3673,6 +3673,21 @@ func cmdHelp(_ *Session, _ []string) error {
 	fmt.Fprintln(tw, "\t  label-capable lists: "+strings.Join(labelCapableListCommands, ", "))
 	fmt.Fprintln(tw, "exit\tExit interactive mode")
 	tw.Flush()
+
+	envTw := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintf(envTw, "\n%s\tCONFIG FIELD / NOTES\n", Bold("ENV VAR"))
+	fmt.Fprintln(envTw, "-------\t--------------------")
+	for _, d := range cli.KnownEnvVarDescriptors() {
+		notes := d.ConfigPath
+		if d.Sensitive {
+			notes += " (sensitive)"
+		}
+		fmt.Fprintf(envTw, "%s\t%s\n", d.Name, notes)
+	}
+	fmt.Fprintln(envTw, "\t  Env vars override config file values; explicit flags still win.")
+	fmt.Fprintln(envTw, "\t  Run 'env' to see currently set values, 'env --mask' to redact sensitive ones.")
+	envTw.Flush()
+
 	fmt.Printf("\n%s\n", Bold("KEYBINDINGS"))
 	fmt.Println("  Ctrl+C    Clear current line")
 	fmt.Println("  Ctrl+D    Quit interactive mode")

--- a/cli/tui/commands.go
+++ b/cli/tui/commands.go
@@ -27,6 +27,8 @@ import (
 	"strconv"
 	"strings"
 	"text/tabwriter"
+
+	cli "github.com/NVIDIA/infra-controller-rest/cli/pkg"
 )
 
 // Command represents a registered interactive command.
@@ -171,6 +173,7 @@ func AllCommands() []Command {
 		{Name: "service-account current", Description: "Get current service account status", Run: cmdServiceAccountCurrent},
 
 		{Name: "login", Description: "Login / refresh auth token", Run: cmdLogin},
+		{Name: "env", Description: "Show NICO_* environment variables in use", Run: cmdEnv},
 		{Name: "help", Description: "Show available commands", Run: cmdHelp},
 	}
 }
@@ -3620,6 +3623,32 @@ func cmdLogin(s *Session, _ []string) error {
 	}
 	s.RefreshClient(token)
 	fmt.Printf("%s Logged in successfully.\n", Green("OK"))
+	return nil
+}
+
+// cmdEnv prints every NICO_* environment variable currently set in the
+// process, the config field (or flag) it influences, and its value. Pass
+// "--mask" to redact sensitive values (tokens, secrets, passwords) for
+// safer display in shared screens.
+func cmdEnv(_ *Session, args []string) error {
+	mask := false
+	for _, a := range args {
+		if a == "--mask" || a == "-m" {
+			mask = true
+		}
+	}
+	overrides := cli.EnvOverridesFromEnvironment()
+	if len(overrides) == 0 {
+		fmt.Println(Dim("No NICO_* environment variables set."))
+		fmt.Println(Dim("Run 'help' for the full list of NICO_* variables nicocli understands."))
+		return nil
+	}
+	fmt.Printf("%s %d NICO_* variable(s) in use:\n", Bold("env:"), len(overrides))
+	fmt.Print(cli.FormatEnvOverrides(overrides, mask))
+	if !mask {
+		fmt.Printf("%s sensitive values shown in full; pass %s to redact.\n",
+			Dim("Tip:"), Bold("env --mask"))
+	}
 	return nil
 }
 

--- a/cli/tui/configselector.go
+++ b/cli/tui/configselector.go
@@ -120,6 +120,7 @@ func RunTUI(explicitConfig string) error {
 	if err != nil {
 		return fmt.Errorf("loading config: %w", err)
 	}
+	cli.ApplyEnvOverrides(cfg)
 
 	org := cfg.API.Org
 	if org == "" {


### PR DESCRIPTION
Some users of the NICo cli are using env vars to manage multiple environment configs instead of the built in config files. This change supports using env var overrides for any field that is supported in the config file.