### PR TITLE
fix: Machines with active DPU firmware updates should have Initializing status not Error

### DIFF
--- a/workflow/pkg/activity/machine/machine.go
+++ b/workflow/pkg/activity/machine/machine.go
@@ -120,6 +120,9 @@ const (
 	// Machine health attributes
 	MachinePreventAllocations             = "PreventAllocations"
 	MachinePreventAllocationStatusMessage = "Machine has one or more health probe alerts that prevents allocation"
+	MachineDPUFirmwareUpdateAlertID       = "HostUpdateInProgress"
+	MachineDPUFirmwareUpdateAlertTarget   = "DpuFirmware"
+	MachineDPUFirmwareUpdateStatusMessage = "Machine DPU firmware update is in progress"
 )
 
 // ManageMachine is an activity wrapper for Machine management tasks that allows injecting DB access
@@ -982,6 +985,7 @@ func getNICoMachineStatus(controllerMachine *cwssaws.Machine, logger zerolog.Log
 	hasTenant := (controllerMachineStatePrefix == controllerMachineStatePrefixAssigned)
 	hasPreventAlerts := false
 	hasMaintenanceDegraded := false
+	hasDPUFirmwareUpdateInProgress := false
 
 	if controllerMachine.Health != nil && controllerMachine.Health.Alerts != nil {
 		for _, alert := range controllerMachine.Health.Alerts {
@@ -995,6 +999,11 @@ func getNICoMachineStatus(controllerMachine *cwssaws.Machine, logger zerolog.Log
 			// Check for Maintenance+Degraded alert
 			if alert.Id == "Maintenance" && alert.Target != nil && *alert.Target == "Degraded" {
 				hasMaintenanceDegraded = true
+			}
+			if alert.Id == MachineDPUFirmwareUpdateAlertID &&
+				alert.Target != nil &&
+				*alert.Target == MachineDPUFirmwareUpdateAlertTarget {
+				hasDPUFirmwareUpdateInProgress = true
 			}
 		}
 	}
@@ -1010,6 +1019,9 @@ func getNICoMachineStatus(controllerMachine *cwssaws.Machine, logger zerolog.Log
 		if controllerMachine.MaintenanceReference != nil {
 			statusMessage = fmt.Sprintf("%s: %s", statusMessage, *controllerMachine.MaintenanceReference)
 		}
+	} else if hasDPUFirmwareUpdateInProgress {
+		machineStatus = cdbm.MachineStatusInitializing
+		statusMessage = MachineDPUFirmwareUpdateStatusMessage
 	} else if hasPreventAlerts {
 		// Has Prevent alerts
 		machineStatus = cdbm.MachineStatusError

--- a/workflow/pkg/activity/machine/machine_test.go
+++ b/workflow/pkg/activity/machine/machine_test.go
@@ -1427,6 +1427,7 @@ func TestGetForgeMachineStatus(t *testing.T) {
 		name                   string
 		args                   args
 		wantStatus             string
+		wantMessage            string
 		wantMachineAllocatable bool
 	}{
 		{
@@ -1498,6 +1499,75 @@ func TestGetForgeMachineStatus(t *testing.T) {
 				},
 			},
 			wantStatus:             cdbm.MachineStatusError,
+			wantMachineAllocatable: false,
+		},
+		{
+			name: "test get forge machine status - with automatic DPU firmware update alert",
+			args: args{
+				controllerMachine: &cwssaws.Machine{
+					State: controllerMachineStatePrefixReady,
+					Health: &cwssaws.HealthReport{
+						Alerts: []*cwssaws.HealthProbeAlert{
+							{
+								Id:      MachineDPUFirmwareUpdateAlertID,
+								Target:  cdb.GetStrPtr(MachineDPUFirmwareUpdateAlertTarget),
+								Message: "AutomaticDpuFirmwareUpdate//",
+								Classifications: []string{
+									MachinePreventAllocations,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantStatus:             cdbm.MachineStatusInitializing,
+			wantMessage:            MachineDPUFirmwareUpdateStatusMessage,
+			wantMachineAllocatable: false,
+		},
+		{
+			name: "test get forge machine status - with non-automatic DPU firmware update alert",
+			args: args{
+				controllerMachine: &cwssaws.Machine{
+					State: controllerMachineStatePrefixAssigned,
+					Health: &cwssaws.HealthReport{
+						Alerts: []*cwssaws.HealthProbeAlert{
+							{
+								Id:      MachineDPUFirmwareUpdateAlertID,
+								Target:  cdb.GetStrPtr(MachineDPUFirmwareUpdateAlertTarget),
+								Message: "ManualDpuFirmwareUpdate//",
+								Classifications: []string{
+									MachinePreventAllocations,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantStatus:             cdbm.MachineStatusInitializing,
+			wantMessage:            MachineDPUFirmwareUpdateStatusMessage,
+			wantMachineAllocatable: false,
+		},
+		{
+			name: "test get forge machine status - non-DPU firmware prevent alert remains error",
+			args: args{
+				controllerMachine: &cwssaws.Machine{
+					State: controllerMachineStatePrefixReady,
+					Health: &cwssaws.HealthReport{
+						Alerts: []*cwssaws.HealthProbeAlert{
+							{
+								Id:      MachineDPUFirmwareUpdateAlertID,
+								Target:  cdb.GetStrPtr("HostFirmware"),
+								Message: "HostFirmwareUpdate//",
+								Classifications: []string{
+									MachinePreventAllocations,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantStatus:             cdbm.MachineStatusError,
+			wantMessage:            MachinePreventAllocationStatusMessage,
 			wantMachineAllocatable: false,
 		},
 		{
@@ -1649,7 +1719,11 @@ func TestGetForgeMachineStatus(t *testing.T) {
 			status, message, isAllocatable := getNICoMachineStatus(tt.args.controllerMachine, log.Logger)
 			assert.Equal(t, tt.wantMachineAllocatable, isAllocatable)
 			assert.Equal(t, tt.wantStatus, status)
-			assert.NotEmpty(t, message)
+			if tt.wantMessage != "" {
+				assert.Equal(t, tt.wantMessage, message)
+			} else {
+				assert.NotEmpty(t, message)
+			}
 		})
 	}
 }


### PR DESCRIPTION
  ## Description
  This PR updates Machine status mapping so DPU firmware updates are shown as `Initializing` instead of `Error`.

  The change detects DPU firmware update alerts using the stable health alert shape:

  - `id: HostUpdateInProgress`
  - `target: DpuFirmware`

  This applies to any DPU firmware update, not only automatic updates. Other `PreventAllocations` alerts continue to map to
  `Error`.

  ## Type of Change
  - [ ] **Add** - New feature or capability
  - [ ] **Change** - Changes in existing functionality
  - [x] **Fix** - Bug fixes
  - [ ] **Remove** - Removed features or deprecated functionality
  - [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

  ## Related Issues (Optional)
  https://github.com/NVIDIA/infra-controller/issues/1956

  ## Breaking Changes
  - [ ] This PR contains breaking changes

  ## Testing
  - [x] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [ ] Manual testing performed
  - [ ] No testing required (docs, internal refactor, etc.)

  Tested with:

  `go test ./workflow/pkg/activity/machine -run TestGetForgeMachineStatus -count=1`

