### PR TITLE
fix: Update examples and descriptions of IPBlock VpcPrefix and Subnet IP Usage calculation

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -20122,7 +20122,7 @@ components:
         availableSmallestPrefixes:
           type: integer
           description: |
-            Total number of /30 prefixes that can still be acquired from this block
+            Total number of /30 prefixes that can still be acquired from this block (only reduced if prefixes are acquired, not reduced by acquired IPs)
           format: int64
           readOnly: true
         acquiredPrefixes:

--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -2006,16 +2006,17 @@ paths:
                     infrastructureProviderId: e94bcfda-f6cb-42e4-80ec-516811e5abbf
                     tenantId: null
                     routingType: Public
-                    prefix: 202.168.16.0
-                    prefixLength: 20
+                    prefix: 192.168.20.0
+                    prefixLength: 24
                     protocolVersion: IPv4
                     usageStats:
-                      availableIPs: 4094
+                      availableIPs: 256
                       acquiredIPs: 2
                       availablePrefixes:
-                        - 204.168.16.2/20
-                        - 204.168.16.4/20
-                      availableSmallestPrefixes: 2047
+                        - 192.168.20.32/27
+                        - 192.168.20.64/26
+                        - 192.168.20.128/25
+                      availableSmallestPrefixes: 56
                       acquiredPrefixes: 1
                     status: Pending
                     statusHistory:
@@ -14188,22 +14189,21 @@ components:
           vpcId: 5e28ad7c-5fb7-46d6-a28a-fc0ba6fdc4a3
           tenantId: f97df110-f4de-492e-8849-4a6af68026b0
           controllerNetworkSegmentId: abe7b0e8-67db-4e89-903e-fc4f2bd7f034
-          ipv4Prefix: 204.168.16.0
+          ipv4Prefix: 10.217.98.64
           ipv4BlockId: 8c1d1a06-90a2-4863-8ee1-6029265b9f0a
-          ipv4Gateway: 204.168.16.1
+          ipv4Gateway: 10.217.98.65
           ipv6Prefix: null
           ipv6BlockId: null
           ipv6Gateway: null
-          prefixLength: 20
+          prefixLength: 28
           routingType: Public
           status: Ready
           usageStats:
-            availableIPs: 4088
+            availableIPs: 16
             acquiredIPs: 6
             availablePrefixes:
-              - 204.168.16.6/31
-              - 204.168.16.8/31
-            availableSmallestPrefixes: 2044
+              - 10.217.98.64/28
+            availableSmallestPrefixes: 4
             acquiredPrefixes: 0
           statusHistory:
             - status: Ready

--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -13989,18 +13989,22 @@ components:
           siteId: ea144def-d68f-44c3-9485-4b103fa2686f
           vpcId: 5e28ad7c-5fb7-46d6-a28a-fc0ba6fdc4a3
           tenantId: f97df110-f4de-492e-8849-4a6af68026b0
-          prefix: 192.168.1.0/26
+          prefix: 192.168.1.0/24
           ipBlockId: 8c1d1a06-90a2-4863-8ee1-6029265b9f0a
-          prefixLength: 26
+          prefixLength: 24
           status: Ready
           usageStats:
-            availableIPs: 58
-            acquiredIPs: 6
+            availableIPs: 256
+            acquiredIPs: 2
             availablePrefixes:
-              - 192.168.1.4/31
-              - 192.168.1.8/31
-            availableSmallestPrefixes: 29
-            acquiredPrefixes: 3
+              - 192.168.1.0/28
+              - 192.168.1.16/30
+              - 192.168.1.24/29
+              - 192.168.1.32/27
+              - 192.168.1.64/26
+              - 192.168.1.128/25
+            availableSmallestPrefixes: 63
+            acquiredPrefixes: 1
           statusHistory:
             - status: Ready
               message: 'Received VPC prefix creation request, ready'
@@ -14008,6 +14012,29 @@ components:
               updated: '2019-08-24T14:15:22Z'
           created: '2019-08-24T14:15:22Z'
           updated: '2019-08-24T14:15:22Z'
+        - id: 42624127-ec6a-4829-b9ca-2f6ffb5d4215
+          name: northern-vpc-traffic-net
+          siteId: ea144def-d68f-44c3-9485-4b103fa2686f
+          vpcId: 4ea05fc4-2be8-4823-b574-e633b5ad3c4c
+          tenantId: f97df110-f4de-492e-8849-4a6af68026b0
+          prefix: 10.217.98.100/30
+          ipBlockId: 65e14c37-5a8f-4c41-9b1c-f2e162bee11c
+          prefixLength: 30
+          status: Ready
+          usageStats:
+            availableIPs: 4
+            acquiredIPs: 0
+            availablePrefixes:
+              - 10.217.98.100/30
+            availableSmallestPrefixes: 1  
+            acquiredPrefixes: 0
+          statusHistory:
+            - status: Ready
+              message: 'Received VPC prefix creation request, ready'
+              created: '2025-05-28T14:15:22Z'
+              updated: '2025-05-28T14:15:22Z'
+          created: '2025-05-28T14:15:22Z'
+          updated: '2025-05-28T14:15:22Z'
       properties:
         id:
           type: string
@@ -20077,7 +20104,7 @@ components:
         availableIPs:
           type: integer
           format: int64
-          description: Number of IP addresses available in the block
+          description: Total number of IP addresses in the block (acquired and unused)
           readOnly: true
         acquiredIPs:
           type: integer
@@ -20095,14 +20122,14 @@ components:
         availableSmallestPrefixes:
           type: integer
           description: |
-            Number of smallest prefixes available to acquire
+            Total number of /30 prefixes that can still be acquired from this block
           format: int64
           readOnly: true
         acquiredPrefixes:
           type: integer
           format: int64
-          description: Number of prefixes acquired from this block
-      description: Usa statistics for an IP Block
+          description: Total number of prefixes (of any size) acquired from this block
+      description: Usage statistics for an IP Block, VPC Prefix or Subnet
     IpBlockCreateRequest:
       title: IpBlockCreateRequest
       type: object

--- a/sdk/standard/client.go
+++ b/sdk/standard/client.go
@@ -601,7 +601,10 @@ func addFile(w *multipart.Writer, fieldName, path string) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	err = file.Close()
+	if err != nil {
+		return err
+	}
 
 	part, err := w.CreateFormFile(fieldName, filepath.Base(path))
 	if err != nil {

--- a/sdk/standard/model_expected_machine.go
+++ b/sdk/standard/model_expected_machine.go
@@ -74,8 +74,7 @@ type ExpectedMachine struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32 `json:"hostId,omitempty"`
-	// User-defined key-value pairs for organizing and categorizing Expected Machines
+	HostId NullableInt32     `json:"hostId,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
 	// ISO 8601 datetime when the Expected Machine was created
 	Created *time.Time `json:"created,omitempty"`

--- a/sdk/standard/model_expected_machine_create_request.go
+++ b/sdk/standard/model_expected_machine_create_request.go
@@ -71,8 +71,7 @@ type ExpectedMachineCreateRequest struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32 `json:"hostId,omitempty"`
-	// User-defined key-value pairs for organizing and categorizing Expected Machines
+	HostId NullableInt32     `json:"hostId,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_expected_machine_update_request.go
+++ b/sdk/standard/model_expected_machine_update_request.go
@@ -69,8 +69,7 @@ type ExpectedMachineUpdateRequest struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32 `json:"hostId,omitempty"`
-	// User-defined key-value pairs for organizing and categorizing Expected Machines
+	HostId NullableInt32     `json:"hostId,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_expected_power_shelf.go
+++ b/sdk/standard/model_expected_power_shelf.go
@@ -64,8 +64,7 @@ type ExpectedPowerShelf struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32 `json:"hostId,omitempty"`
-	// User-defined key-value pairs for organizing and categorizing Expected Power Shelves
+	HostId NullableInt32     `json:"hostId,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
 	// ISO 8601 datetime when the Expected Power Shelf was created
 	Created *time.Time `json:"created,omitempty"`

--- a/sdk/standard/model_expected_power_shelf_create_request.go
+++ b/sdk/standard/model_expected_power_shelf_create_request.go
@@ -67,8 +67,7 @@ type ExpectedPowerShelfCreateRequest struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32 `json:"hostId,omitempty"`
-	// User-defined key-value pairs for organizing and categorizing Expected Power Shelves
+	HostId NullableInt32     `json:"hostId,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_expected_power_shelf_update_request.go
+++ b/sdk/standard/model_expected_power_shelf_update_request.go
@@ -65,8 +65,7 @@ type ExpectedPowerShelfUpdateRequest struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32 `json:"hostId,omitempty"`
-	// User-defined key-value pairs for organizing and categorizing Expected Power Shelves
+	HostId NullableInt32     `json:"hostId,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_expected_rack.go
+++ b/sdk/standard/model_expected_rack.go
@@ -48,9 +48,8 @@ type ExpectedRack struct {
 	// Human-readable name of the Expected Rack
 	Name *string `json:"name,omitempty"`
 	// Human-readable description of the Expected Rack
-	Description *string `json:"description,omitempty"`
-	// User-defined key-value pairs for organizing and categorizing Expected Racks. Well-known keys (`chassis.*`, `location.*`) are used to convey chassis identity and physical location.
-	Labels map[string]string `json:"labels,omitempty"`
+	Description *string           `json:"description,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
 	// ISO 8601 datetime when the Expected Rack was created
 	Created *time.Time `json:"created,omitempty"`
 	// ISO 8601 datetime when the Expected Rack was last updated

--- a/sdk/standard/model_expected_rack_create_request.go
+++ b/sdk/standard/model_expected_rack_create_request.go
@@ -47,9 +47,8 @@ type ExpectedRackCreateRequest struct {
 	// Human-readable name of the Expected Rack
 	Name NullableString `json:"name,omitempty"`
 	// Human-readable description of the Expected Rack
-	Description NullableString `json:"description,omitempty"`
-	// User-defined key-value pairs for organizing and categorizing Expected Racks. Well-known keys (`chassis.*`, `location.*`) are used to convey chassis identity and physical location.
-	Labels map[string]string `json:"labels,omitempty"`
+	Description NullableString    `json:"description,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
 }
 
 type _ExpectedRackCreateRequest ExpectedRackCreateRequest

--- a/sdk/standard/model_expected_rack_update_request.go
+++ b/sdk/standard/model_expected_rack_update_request.go
@@ -45,9 +45,8 @@ type ExpectedRackUpdateRequest struct {
 	// Human-readable name of the Expected Rack
 	Name NullableString `json:"name,omitempty"`
 	// Human-readable description of the Expected Rack
-	Description NullableString `json:"description,omitempty"`
-	// User-defined key-value pairs for organizing and categorizing Expected Racks. Well-known keys (`chassis.*`, `location.*`) are used to convey chassis identity and physical location.
-	Labels map[string]string `json:"labels,omitempty"`
+	Description NullableString    `json:"description,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
 }
 
 // NewExpectedRackUpdateRequest instantiates a new ExpectedRackUpdateRequest object

--- a/sdk/standard/model_expected_switch.go
+++ b/sdk/standard/model_expected_switch.go
@@ -64,8 +64,7 @@ type ExpectedSwitch struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32 `json:"hostId,omitempty"`
-	// User-defined key-value pairs for organizing and categorizing Expected Switches
+	HostId NullableInt32     `json:"hostId,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
 	// ISO 8601 datetime when the Expected Switch was created
 	Created *time.Time `json:"created,omitempty"`

--- a/sdk/standard/model_expected_switch_create_request.go
+++ b/sdk/standard/model_expected_switch_create_request.go
@@ -71,8 +71,7 @@ type ExpectedSwitchCreateRequest struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32 `json:"hostId,omitempty"`
-	// User-defined key-value pairs for organizing and categorizing Expected Switches
+	HostId NullableInt32     `json:"hostId,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_expected_switch_update_request.go
+++ b/sdk/standard/model_expected_switch_update_request.go
@@ -69,8 +69,7 @@ type ExpectedSwitchUpdateRequest struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32 `json:"hostId,omitempty"`
-	// User-defined key-value pairs for organizing and categorizing Expected Switches
+	HostId NullableInt32     `json:"hostId,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_infini_band_partition.go
+++ b/sdk/standard/model_infini_band_partition.go
@@ -37,24 +37,23 @@ var _ MappedNullable = &InfiniBandPartition{}
 
 // InfiniBandPartition InfiniBand Partitions are network segments utilizing InfiniBand topology
 type InfiniBandPartition struct {
-	Id                      *string         `json:"id,omitempty"`
-	Name                    *string         `json:"name,omitempty"`
-	Description             NullableString  `json:"description,omitempty"`
-	SiteId                  *string         `json:"siteId,omitempty"`
-	TenantId                *string         `json:"tenantId,omitempty"`
-	ControllerIBPartitionId NullableString  `json:"controllerIBPartitionId,omitempty"`
-	PartitionKey            NullableString  `json:"partitionKey,omitempty"`
-	PartitionName           NullableString  `json:"partitionName,omitempty"`
-	ServiceLevel            NullableInt32   `json:"serviceLevel,omitempty"`
-	RateLimit               NullableFloat32 `json:"rateLimit,omitempty"`
-	Mtu                     NullableInt32   `json:"mtu,omitempty"`
-	EnableSharp             *bool           `json:"enableSharp,omitempty"`
-	// String key value pairs describing InfiniBand Partition labels. Up to 10 key value pairs can be specified
-	Labels        map[string]string          `json:"labels,omitempty"`
-	Status        *InfiniBandPartitionStatus `json:"status,omitempty"`
-	StatusHistory []StatusDetail             `json:"statusHistory,omitempty"`
-	Created       *time.Time                 `json:"created,omitempty"`
-	Updated       *time.Time                 `json:"updated,omitempty"`
+	Id                      *string                    `json:"id,omitempty"`
+	Name                    *string                    `json:"name,omitempty"`
+	Description             NullableString             `json:"description,omitempty"`
+	SiteId                  *string                    `json:"siteId,omitempty"`
+	TenantId                *string                    `json:"tenantId,omitempty"`
+	ControllerIBPartitionId NullableString             `json:"controllerIBPartitionId,omitempty"`
+	PartitionKey            NullableString             `json:"partitionKey,omitempty"`
+	PartitionName           NullableString             `json:"partitionName,omitempty"`
+	ServiceLevel            NullableInt32              `json:"serviceLevel,omitempty"`
+	RateLimit               NullableFloat32            `json:"rateLimit,omitempty"`
+	Mtu                     NullableInt32              `json:"mtu,omitempty"`
+	EnableSharp             *bool                      `json:"enableSharp,omitempty"`
+	Labels                  map[string]string          `json:"labels,omitempty"`
+	Status                  *InfiniBandPartitionStatus `json:"status,omitempty"`
+	StatusHistory           []StatusDetail             `json:"statusHistory,omitempty"`
+	Created                 *time.Time                 `json:"created,omitempty"`
+	Updated                 *time.Time                 `json:"updated,omitempty"`
 }
 
 // NewInfiniBandPartition instantiates a new InfiniBandPartition object

--- a/sdk/standard/model_infini_band_partition_create_request.go
+++ b/sdk/standard/model_infini_band_partition_create_request.go
@@ -43,8 +43,7 @@ type InfiniBandPartitionCreateRequest struct {
 	// Optional description of the Partition
 	Description NullableString `json:"description,omitempty"`
 	// ID of the Site the Partition should belong to
-	SiteId string `json:"siteId"`
-	// String key value pairs describing Partition labels. Up to 10 key value pairs can be specified
+	SiteId string            `json:"siteId"`
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_infini_band_partition_update_request.go
+++ b/sdk/standard/model_infini_band_partition_update_request.go
@@ -38,10 +38,9 @@ var _ MappedNullable = &InfiniBandPartitionUpdateRequest{}
 
 // InfiniBandPartitionUpdateRequest Request data to update an InfiniBand Partition
 type InfiniBandPartitionUpdateRequest struct {
-	Name        string         `json:"name"`
-	Description NullableString `json:"description,omitempty"`
-	// String key value pairs describing Partition labels. Up to 10 key value pairs can be specified
-	Labels map[string]string `json:"labels,omitempty"`
+	Name        string            `json:"name"`
+	Description NullableString    `json:"description,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
 }
 
 type _InfiniBandPartitionUpdateRequest InfiniBandPartitionUpdateRequest

--- a/sdk/standard/model_instance_update_request.go
+++ b/sdk/standard/model_instance_update_request.go
@@ -58,9 +58,8 @@ type InstanceUpdateRequest struct {
 	// Whether the custom iPXE data should be used for every boot.
 	AlwaysBootWithCustomIpxe NullableBool `json:"alwaysBootWithCustomIpxe,omitempty"`
 	// Indicates whether the Phone Home service should be enabled or disabled for Instance
-	PhoneHomeEnabled NullableBool `json:"phoneHomeEnabled,omitempty"`
-	// Update labels of the Instance. The labels will be entirely replaced by those sent in the request. Any labels not included in the request will be removed. To retain existing labels, first fetch them and include them along with this request.
-	Labels map[string]string `json:"labels,omitempty"`
+	PhoneHomeEnabled NullableBool      `json:"phoneHomeEnabled,omitempty"`
+	Labels           map[string]string `json:"labels,omitempty"`
 	// IDs of additional VPCs the Instance should attach to through non-primary interfaces. This field may only be specified when every entry in `interfaces` uses `vpcPrefixId`. IDs must be unique, must be valid UUIDs, and must not include the primary `vpcId`.
 	SecondaryVpcIds []string `json:"secondaryVpcIds,omitempty"`
 	// Update Interfaces of the Instance. Mutually exclusive with `auto`: when `auto` is true this list MUST be empty.

--- a/sdk/standard/model_ip_block_usage_stats.go
+++ b/sdk/standard/model_ip_block_usage_stats.go
@@ -42,7 +42,7 @@ type IpBlockUsageStats struct {
 	AcquiredIPs *int64 `json:"acquiredIPs,omitempty"`
 	// Example prefixes available to acquire
 	AvailablePrefixes []string `json:"availablePrefixes,omitempty"`
-	// Total number of /30 prefixes that can still be acquired from this block
+	// Total number of /30 prefixes that can still be acquired from this block (only reduced if prefixes are acquired, not reduced by acquired IPs)
 	AvailableSmallestPrefixes *int64 `json:"availableSmallestPrefixes,omitempty"`
 	// Total number of prefixes (of any size) acquired from this block
 	AcquiredPrefixes *int64 `json:"acquiredPrefixes,omitempty"`

--- a/sdk/standard/model_ip_block_usage_stats.go
+++ b/sdk/standard/model_ip_block_usage_stats.go
@@ -34,17 +34,17 @@ import (
 // checks if the IpBlockUsageStats type satisfies the MappedNullable interface at compile time
 var _ MappedNullable = &IpBlockUsageStats{}
 
-// IpBlockUsageStats Usa statistics for an IP Block
+// IpBlockUsageStats Usage statistics for an IP Block, VPC Prefix or Subnet
 type IpBlockUsageStats struct {
-	// Number of IP addresses available in the block
+	// Total number of IP addresses in the block (acquired and unused)
 	AvailableIPs *int64 `json:"availableIPs,omitempty"`
 	// Number of individual IP addresses acquired from the block
 	AcquiredIPs *int64 `json:"acquiredIPs,omitempty"`
 	// Example prefixes available to acquire
 	AvailablePrefixes []string `json:"availablePrefixes,omitempty"`
-	// Number of smallest prefixes available to acquire
+	// Total number of /30 prefixes that can still be acquired from this block
 	AvailableSmallestPrefixes *int64 `json:"availableSmallestPrefixes,omitempty"`
-	// Number of prefixes acquired from this block
+	// Total number of prefixes (of any size) acquired from this block
 	AcquiredPrefixes *int64 `json:"acquiredPrefixes,omitempty"`
 }
 

--- a/sdk/standard/model_machine_update_request.go
+++ b/sdk/standard/model_machine_update_request.go
@@ -43,10 +43,9 @@ type MachineUpdateRequest struct {
 	// Set to `true` to enable maintenance mode and to `false` to disable maintenance mode. Can be set by Provider or Privileged Tenant.
 	SetMaintenanceMode NullableBool `json:"setMaintenanceMode,omitempty"`
 	// Optional message describing the reason for moving Machine into maintenance mode. Can be updated by Provider or Privileged Tenant.
-	MaintenanceMessage NullableString `json:"maintenanceMessage,omitempty"`
-	// Machine labels will be overwritten, include existing labels to preserve them. Can be updated by Provider or Privileged Tenant.
-	Labels       map[string]string    `json:"labels,omitempty"`
-	OnlineRepair *MachineOnlineRepair `json:"onlineRepair,omitempty"`
+	MaintenanceMessage NullableString       `json:"maintenanceMessage,omitempty"`
+	Labels             map[string]string    `json:"labels,omitempty"`
+	OnlineRepair       *MachineOnlineRepair `json:"onlineRepair,omitempty"`
 	// Required when `onlineRepair.enabled` is true. Must not be set when exiting online repair (`onlineRepair.enabled` false).
 	HealthIssue *MachineHealthIssue `json:"healthIssue,omitempty"`
 }

--- a/sdk/standard/model_vpc.go
+++ b/sdk/standard/model_vpc.go
@@ -64,9 +64,8 @@ type VPC struct {
 	// Propagation details for the attached Network Security Group
 	NetworkSecurityGroupPropagationDetails *NetworkSecurityGroupPropagationDetails `json:"networkSecurityGroupPropagationDetails,omitempty"`
 	// ID of the default NVLink Logical Partition that GPUs for all Instances in the VPC will attach to
-	NvLinkLogicalPartitionId NullableString `json:"nvLinkLogicalPartitionId,omitempty"`
-	// String key value pairs describing VPC labels
-	Labels map[string]string `json:"labels,omitempty"`
+	NvLinkLogicalPartitionId NullableString    `json:"nvLinkLogicalPartitionId,omitempty"`
+	Labels                   map[string]string `json:"labels,omitempty"`
 	// Status of the VPC
 	Status *VpcStatus `json:"status,omitempty"`
 	// History of status changes for the VPC

--- a/sdk/standard/model_vpc_create_request.go
+++ b/sdk/standard/model_vpc_create_request.go
@@ -55,9 +55,8 @@ type VpcCreateRequest struct {
 	// Explicitly requested VNI for the VPC
 	Vni NullableInt32 `json:"vni,omitempty"`
 	// ID of the default NVLink Logical Partition that GPUs for all Instances in the VPC will attach to
-	NvLinkLogicalPartitionId NullableString `json:"nvLinkLogicalPartitionId,omitempty"`
-	// String key value pairs describing VPC labels. Up to 10 key value pairs can be specified
-	Labels map[string]string `json:"labels,omitempty"`
+	NvLinkLogicalPartitionId NullableString    `json:"nvLinkLogicalPartitionId,omitempty"`
+	Labels                   map[string]string `json:"labels,omitempty"`
 }
 
 type _VpcCreateRequest VpcCreateRequest

--- a/sdk/standard/model_vpc_update_request.go
+++ b/sdk/standard/model_vpc_update_request.go
@@ -43,9 +43,8 @@ type VpcUpdateRequest struct {
 	// ID of the Network Security Group to attach to the VPC
 	NetworkSecurityGroupId NullableString `json:"networkSecurityGroupId,omitempty"`
 	// ID of the default NVLink Logical Partition that GPUs for all Instances in the VPC will attach to. Can only be updated if VPC currently has no active Instances
-	NvLinkLogicalPartitionId NullableString `json:"nvLinkLogicalPartitionId,omitempty"`
-	// Update labels of the VPC. Up to 10 key value pairs can be specified. The labels will be entirely replaced by those sent in the request. Any labels not included in the request will be removed. To retain existing labels, first fetch them and include them along with this request.
-	Labels map[string]string `json:"labels,omitempty"`
+	NvLinkLogicalPartitionId NullableString    `json:"nvLinkLogicalPartitionId,omitempty"`
+	Labels                   map[string]string `json:"labels,omitempty"`
 }
 
 // NewVpcUpdateRequest instantiates a new VpcUpdateRequest object


### PR DESCRIPTION
## Description
-  Updated IPBlock Usage description to reflect VpcPrefix (`/30`), Subnet
-  Updated examples for VpcPrefix usageStats

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Fix** - Bug fixes (fix:)

## Services Affected
<!-- Check one or more if appropriate -->
- [ ] **API** - API models or endpoints updated
- [ ] **DB** - DB DAOs or migrations updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
