### PR TITLE
docs: Remove invalid Allocation Constraint endpoints from OpenAPI schema

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -100,7 +100,7 @@ jobs:
         run: npm install -g @redocly/cli@latest
 
       - name: Run OpenAPI lint
-        run: redocly lint ./openapi/spec.yaml --format=github-actions
+        run: redocly lint ./openapi/spec.yaml --format=github-actions --skip-rule=no-ambiguous-paths
 
   # ============================================================================
   # Check Generated Files - Ensure SDK and docs are updated when spec changes

--- a/Makefile
+++ b/Makefile
@@ -662,7 +662,7 @@ generate-sdk:
 
 # Validate OpenAPI spec using Redocly CLI (Docker)
 lint-openapi:
-	npx @redocly/cli lint ./openapi/spec.yaml
+	npx @redocly/cli lint --skip-rule=no-ambiguous-paths ./openapi/spec.yaml
 
 # Preview OpenAPI spec in Redoc UI (Docker)
 preview-openapi:

--- a/db/pkg/migrations/20260523061229_instance_network_auto.go
+++ b/db/pkg/migrations/20260523061229_instance_network_auto.go
@@ -1,19 +1,5 @@
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 package migrations
 

--- a/db/pkg/migrations/20260528235039_instance_auto_network_rename.go
+++ b/db/pkg/migrations/20260528235039_instance_auto_network_rename.go
@@ -1,19 +1,5 @@
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 package migrations
 

--- a/flow/.gitignore
+++ b/flow/.gitignore
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 build
 flow
 .local_envrc

--- a/flow/internal/db/migrations/20260306000000_add_conflict_support.down.sql
+++ b/flow/internal/db/migrations/20260306000000_add_conflict_support.down.sql
@@ -1,2 +1,5 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 DROP INDEX IF EXISTS idx_task_rack_status;
 ALTER TABLE task DROP COLUMN IF EXISTS queue_expires_at;

--- a/flow/internal/db/migrations/20260306000000_add_conflict_support.up.sql
+++ b/flow/internal/db/migrations/20260306000000_add_conflict_support.up.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Add queue_expires_at for waiting tasks (null for all other statuses).
 ALTER TABLE task ADD COLUMN IF NOT EXISTS queue_expires_at TIMESTAMPTZ;
 

--- a/flow/internal/db/migrations/20260313000000_add_task_started_at.down.sql
+++ b/flow/internal/db/migrations/20260313000000_add_task_started_at.down.sql
@@ -1,1 +1,4 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 ALTER TABLE task DROP COLUMN IF EXISTS started_at;

--- a/flow/internal/db/migrations/20260313000000_add_task_started_at.up.sql
+++ b/flow/internal/db/migrations/20260313000000_add_task_started_at.up.sql
@@ -1,2 +1,5 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Add started_at to record when a task actually begins execution.
 ALTER TABLE task ADD COLUMN IF NOT EXISTS started_at TIMESTAMPTZ;

--- a/flow/internal/db/migrations/20260316000000_add_task_attributes.down.sql
+++ b/flow/internal/db/migrations/20260316000000_add_task_attributes.down.sql
@@ -1,2 +1,5 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 ALTER TABLE task DROP COLUMN IF EXISTS attributes;
 ALTER TABLE task ADD COLUMN IF NOT EXISTS component_uuids jsonb;

--- a/flow/internal/db/migrations/20260316000000_add_task_attributes.up.sql
+++ b/flow/internal/db/migrations/20260316000000_add_task_attributes.up.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Add flexible attributes column for task metadata. New fields can be added
 -- to the Go TaskAttributes struct without further migrations.
 -- component_uuids is dropped: all component targeting is now stored in

--- a/flow/internal/db/migrations/20260401000000_bmc_cascade_delete.down.sql
+++ b/flow/internal/db/migrations/20260401000000_bmc_cascade_delete.down.sql
@@ -1,1 +1,4 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 ALTER TABLE bmc DROP CONSTRAINT IF EXISTS fk_bmc_component;

--- a/flow/internal/db/migrations/20260401000000_bmc_cascade_delete.up.sql
+++ b/flow/internal/db/migrations/20260401000000_bmc_cascade_delete.up.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Add foreign key with ON DELETE CASCADE so BMC rows are automatically removed
 -- when their parent component is hard-deleted (purged).
 ALTER TABLE bmc

--- a/flow/internal/db/migrations/20260409000000_create_trigger_functions.down.sql
+++ b/flow/internal/db/migrations/20260409000000_create_trigger_functions.down.sql
@@ -1,1 +1,4 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 DROP FUNCTION IF EXISTS set_updated_at;

--- a/flow/internal/db/migrations/20260409000000_create_trigger_functions.up.sql
+++ b/flow/internal/db/migrations/20260409000000_create_trigger_functions.up.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 -- set_updated_at is a shared trigger function that stamps updated_at to NOW()
 -- on every UPDATE. Attach it to any table that has an updated_at column.
 CREATE OR REPLACE FUNCTION set_updated_at()

--- a/flow/internal/db/migrations/20260410000000_create_task_schedule_table.down.sql
+++ b/flow/internal/db/migrations/20260410000000_create_task_schedule_table.down.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 DROP INDEX IF EXISTS idx_task_schedule_scope_rack;
 DROP TABLE IF EXISTS task_schedule_scope;
 DROP TRIGGER IF EXISTS task_schedule_set_updated_at ON task_schedule;

--- a/flow/internal/db/migrations/20260410000000_create_task_schedule_table.up.sql
+++ b/flow/internal/db/migrations/20260410000000_create_task_schedule_table.up.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 CREATE TABLE task_schedule (
     id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name                VARCHAR(255) NOT NULL UNIQUE,

--- a/flow/internal/db/migrations/20260517000000_add_task_attributes_gin_index.down.sql
+++ b/flow/internal/db/migrations/20260517000000_add_task_attributes_gin_index.down.sql
@@ -1,1 +1,4 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 DROP INDEX IF EXISTS idx_task_attributes_gin;

--- a/flow/internal/db/migrations/20260517000000_add_task_attributes_gin_index.up.sql
+++ b/flow/internal/db/migrations/20260517000000_add_task_attributes_gin_index.up.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 -- GIN index on task.attributes to support component-targeted task queries.
 --
 -- The intended query pattern (used by ListTasks when ComponentID is set) is:

--- a/flow/internal/db/migrations/20260520193000_component_rack_id_nullable.down.sql
+++ b/flow/internal/db/migrations/20260520193000_component_rack_id_nullable.down.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Reverts component.rack_id back to NOT NULL. Unattached components must be
 -- removed before downgrading; they cannot be assigned a rack retroactively.
 DELETE FROM component WHERE rack_id IS NULL;

--- a/flow/internal/db/migrations/20260520193000_component_rack_id_nullable.up.sql
+++ b/flow/internal/db/migrations/20260520193000_component_rack_id_nullable.up.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Allow ingesting a component before it has been assigned to a rack.
 -- The application layer still validates the referenced rack when rack_id is
 -- non-NULL; there is no FK on component.rack_id today, so dropping NOT NULL

--- a/flow/internal/nsmapi/nsmproto/nvswitch-manager.proto
+++ b/flow/internal/nsmapi/nsmproto/nvswitch-manager.proto
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";

--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -987,6 +987,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Site'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
       tags:
         - Site
       description: |-
@@ -1024,6 +1028,8 @@ paths:
       responses:
         '202':
           description: Deletion request was accepted
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
       tags:
         - Site
       description: |-
@@ -1449,6 +1455,8 @@ paths:
       responses:
         '202':
           description: Accepted
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
       description: |-
         Delete an Allocation by ID.
 
@@ -1494,6 +1502,10 @@ paths:
                         derivedResourceId: null
                         created: '2019-08-24T14:15:22Z'
                         updated: '2019-08-24T14:15:22Z'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
       description: |-
         Update an existing Allocation
 
@@ -1512,144 +1524,6 @@ paths:
                 value:
                   name: Echo Studios Compute
                   description: Echo Studios compute resource allocation in SJC4
-  '/v2/org/{org}/nico/allocation/{allocationId}/constraint':
-    parameters:
-      - schema:
-          type: string
-        name: org
-        in: path
-        required: true
-        description: Name of the Org
-      - schema:
-          type: string
-          format: uuid
-        name: allocationId
-        in: path
-        required: true
-        description: ID of the Allocation
-    get:
-      summary: Retrieve all Allocation Constraints
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/AllocationConstraint'
-              examples:
-                example-1:
-                  value:
-                    - id: 497f6eca-6276-4993-bfeb-53cbbbba6f08
-                      allocationId: 9ec871ce-3363-4de2-8f79-062881067628
-                      resourceType: InstanceType
-                      resourceTypeId: a59ee688-b5e5-4606-9891-f4a605edacd3
-                      constraintType: Reserved
-                      constraintValue: 10
-                      derivedResourceId: null
-                      instanceType:
-                        name: x3.large
-                        infrastructureProviderId: 63c29416-8833-4eaf-9e1c-7c0173cc3150
-                        siteId: c9f4f276-6f7a-4209-953c-2b9870ce7cc1
-                        status: Ready
-                      created: '2019-08-24T14:15:22Z'
-                      updated: '2019-08-24T14:15:22Z'
-          headers:
-            X-Pagination:
-              schema:
-                type: string
-                example: '{"pageNumber":1,"pageSize":20,"total":30,"orderBy": "CREATED_DESC"}'
-              description: Pagination result in JSON format
-        '403':
-          $ref: '#/components/responses/ForbiddenError'
-      operationId: get-all-allocation-constraint
-      description: |-
-        Retrieve all Allocation Constraints for a given Allocation ID.
-
-        If org has an Infrastructure Provider entity, then specified Allocation must have been created by the Provider and requesting user must have `PROVIDER_ADMIN` role.
-
-        If org does not have an Infrastructure Provider entity but has a Tenant entity, then specified Allocation must belong to the Tenant and requesting user must have `TENANT_ADMIN` role.
-      parameters:
-        - schema:
-            type: integer
-            example: 1
-            default: 1
-            minimum: 1
-          in: query
-          name: pageNumber
-          description: Page number for pagination query
-        - schema:
-            type: integer
-            minimum: 1
-            maximum: 100
-            example: 20
-          in: query
-          name: pageSize
-          description: Page size for pagination query
-        - schema:
-            type: string
-            enum:
-              - RESOURCE_TYPE_ASC
-              - RESOURCE_TYPE_DESC
-              - CREATED_ASC
-              - CREATED_DESC
-              - UPDATED_ASC
-              - UPDATED_DESC
-          in: query
-          name: orderBy
-          description: Ordering for pagination query
-      tags:
-        - Allocation
-    post:
-      summary: Create Allocation Constraint
-      operationId: create-allocation-constraint
-      responses:
-        '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AllocationConstraint'
-              examples:
-                example-1:
-                  value:
-                    id: 497f6eca-6276-4993-bfeb-53cbbbba6f08
-                    allocationId: 9ec871ce-3363-4de2-8f79-062881067628
-                    resourceType: InstanceType
-                    resourceTypeId: a59ee688-b5e5-4606-9891-f4a605edacd3
-                    constraintType: Reserved
-                    constraintValue: 10
-                    derivedResourceId: null
-                    instanceType:
-                      name: x3.large
-                      infrastructureProviderId: 63c29416-8833-4eaf-9e1c-7c0173cc3150
-                      siteId: c9f4f276-6f7a-4209-953c-2b9870ce7cc1
-                      status: Ready
-                    created: '2019-08-24T14:15:22Z'
-                    updated: '2019-08-24T14:15:22Z'
-        '400':
-          $ref: '#/components/responses/ValidationError'
-        '403':
-          $ref: '#/components/responses/ForbiddenError'
-      description: |-
-        Create an Allocation Constraint for a given Allocation ID.
-
-        Org must have an Infrastructure Provider entity and specified Allocation must have been created by the Provider. User must have authorization role with `PROVIDER_ADMIN` suffix.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AllocationConstraintCreateRequest'
-            examples:
-              example-1:
-                value:
-                  resourceType: InstanceType
-                  resourceTypeId: bd5a0240-eb62-4bff-91f7-335e6bb86459
-                  constraintType: Reserved
-                  constraintValue: 10
-      tags:
-        - Allocation
   '/v2/org/{org}/nico/allocation/{allocationId}/constraint/{allocationConstraintId}':
     parameters:
       - schema:
@@ -1671,46 +1545,6 @@ paths:
         in: path
         required: true
         description: ID of the Allocation Constraint
-    get:
-      summary: Retrieve Allocation Constraint
-      tags:
-        - Allocation
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/AllocationConstraint'
-              examples:
-                example-1:
-                  value:
-                    - id: 497f6eca-6276-4993-bfeb-53cbbbba6f08
-                      allocationId: 9ec871ce-3363-4de2-8f79-062881067628
-                      resourceType: InstanceType
-                      resourceTypeId: a59ee688-b5e5-4606-9891-f4a605edacd3
-                      constraintType: Reserved
-                      constraintValue: 10
-                      derivedResourceId: null
-                      instanceType:
-                        name: x3.large
-                        infrastructureProviderId: 63c29416-8833-4eaf-9e1c-7c0173cc3150
-                        siteId: c9f4f276-6f7a-4209-953c-2b9870ce7cc1
-                        status: Ready
-                      created: '2019-08-24T14:15:22Z'
-                      updated: '2019-08-24T14:15:22Z'
-        '403':
-          $ref: '#/components/responses/ForbiddenError'
-      operationId: get-allocation-constraint
-      description: |-
-        Retrieve an Allocation Constraint for a given Allocation ID.
-
-        If org has an Infrastructure Provider entity, then specified Allocation must have been created by the Provider and requesting user must have `PROVIDER_ADMIN` role.
-
-        If org does not have an Infrastructure Provider entity but has a Tenant entity, then specified Allocation must belong to the Tenant and requesting user must have `TENANT_ADMIN` role.
-      parameters: []
     patch:
       summary: Update Allocation Constraint
       operationId: update-allocation-constraint
@@ -1738,6 +1572,10 @@ paths:
                       status: Ready
                     created: '2019-08-24T14:15:22Z'
                     updated: '2019-08-24T14:15:22Z'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
       description: |
         Update an existing Allocation Constraint by ID
 
@@ -1757,18 +1595,6 @@ paths:
               example-1:
                 value:
                   constraintValue: 20
-      tags:
-        - Allocation
-    delete:
-      summary: Delete Allocation Constraint
-      operationId: delete-allocation-constraint
-      responses:
-        '202':
-          description: Accepted
-      description: |
-        Delete an existing Allocation Constraint by ID
-
-        Org must have an Infrastructure Provider. Specified Allocation must have been created by the Provider and requesting user must have `PROVIDER_ADMIN` role.
       tags:
         - Allocation
   '/v2/org/{org}/nico/ipblock':
@@ -2097,6 +1923,10 @@ paths:
                         updated: '2019-08-24T14:15:22Z'
                     created: '2019-08-24T14:15:22Z'
                     updated: '2019-08-24T14:15:22Z'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
       description: |-
         Update an existing IP Block
 
@@ -5833,6 +5663,8 @@ paths:
                         notice: '''displayName'' has been deprecated. Please take action immediately.'
                     created: '2019-08-24T14:15:22Z'
                     updated: '2019-08-24T14:15:22Z'
+        '400':
+          $ref: '#/components/responses/ValidationError'
         '403':
           $ref: '#/components/responses/ForbiddenError'
       description: |-
@@ -7063,6 +6895,8 @@ paths:
       responses:
         '202':
           description: Accepted
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
       description: |-
         Delete an Instance by ID
 
@@ -9157,6 +8991,10 @@ paths:
                         updated: '2019-08-24T14:15:22Z'
                     created: '2019-08-24T14:15:22Z'
                     updated: '2019-08-24T14:15:22Z'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
       tags:
         - Machine
       description: |
@@ -12292,6 +12130,8 @@ paths:
                     lastName: Doe
                     created: '2019-08-24T14:15:22Z'
                     updated: '2019-08-24T14:15:22Z'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
       operationId: get-user
       description: Retrieve details of the current user.
   '/v2/org/{org}/nico/metadata':
@@ -12311,6 +12151,8 @@ paths:
                   value:
                     version: 0.1.24
                     buildTime: '2019-08-24T14:15:22Z'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
       operationId: get-metadata
       description: Retrieve system metadata providing information about the API server
     parameters:
@@ -21562,6 +21404,18 @@ components:
               value:
                 source: nico
                 message: Could not find resource with specified ID
+                data: null
+    UnauthorizedError:
+      description: Error response when user is not authenticated
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/NICoAPIError'
+          examples:
+            example-1:
+              value:
+                source: nico
+                message: User is not authenticated
                 data: null
     ForbiddenError:
       description: Error response when user is not authorized to call an endpoint or retrieve/modify objects

--- a/powershelf-manager/.gitignore
+++ b/powershelf-manager/.gitignore
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 build
 psm

--- a/powershelf-manager/Makefile
+++ b/powershelf-manager/Makefile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 CURDATE := $(shell date +%s)
 
 gen-pb: ## Generate protobuf files

--- a/powershelf-manager/internal/proto/v1/powershelf-manager.proto
+++ b/powershelf-manager/internal/proto/v1/powershelf-manager.proto
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";

--- a/powershelf-manager/pkg/db/migrations/202509290356_initial.down.sql
+++ b/powershelf-manager/pkg/db/migrations/202509290356_initial.down.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 DROP INDEX IF EXISTS public.firmware_update_state_created_idx;
 DROP INDEX IF EXISTS public.firmware_update_created_at_idx;
 DROP INDEX IF EXISTS public.firmware_update_state_idx;

--- a/powershelf-manager/pkg/db/migrations/202509290356_initial.up.sql
+++ b/powershelf-manager/pkg/db/migrations/202509290356_initial.up.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 --
 -- Name: pmc; Type: TABLE; Schema: public
 -- Matches Go model: pkg/db/model/pmc.go

--- a/sdk/standard/api_allocation.go
+++ b/sdk/standard/api_allocation.go
@@ -163,145 +163,6 @@ func (a *AllocationAPIService) CreateAllocationExecute(r ApiCreateAllocationRequ
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ApiCreateAllocationConstraintRequest struct {
-	ctx                               context.Context
-	ApiService                        *AllocationAPIService
-	org                               string
-	allocationId                      string
-	allocationConstraintCreateRequest *AllocationConstraintCreateRequest
-}
-
-func (r ApiCreateAllocationConstraintRequest) AllocationConstraintCreateRequest(allocationConstraintCreateRequest AllocationConstraintCreateRequest) ApiCreateAllocationConstraintRequest {
-	r.allocationConstraintCreateRequest = &allocationConstraintCreateRequest
-	return r
-}
-
-func (r ApiCreateAllocationConstraintRequest) Execute() (*AllocationConstraint, *http.Response, error) {
-	return r.ApiService.CreateAllocationConstraintExecute(r)
-}
-
-/*
-CreateAllocationConstraint Create Allocation Constraint
-
-Create an Allocation Constraint for a given Allocation ID.
-
-Org must have an Infrastructure Provider entity and specified Allocation must have been created by the Provider. User must have authorization role with `PROVIDER_ADMIN` suffix.
-
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param org Name of the Org
-	@param allocationId ID of the Allocation
-	@return ApiCreateAllocationConstraintRequest
-*/
-func (a *AllocationAPIService) CreateAllocationConstraint(ctx context.Context, org string, allocationId string) ApiCreateAllocationConstraintRequest {
-	return ApiCreateAllocationConstraintRequest{
-		ApiService:   a,
-		ctx:          ctx,
-		org:          org,
-		allocationId: allocationId,
-	}
-}
-
-// Execute executes the request
-//
-//	@return AllocationConstraint
-func (a *AllocationAPIService) CreateAllocationConstraintExecute(r ApiCreateAllocationConstraintRequest) (*AllocationConstraint, *http.Response, error) {
-	var (
-		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
-		formFiles           []formFile
-		localVarReturnValue *AllocationConstraint
-	)
-
-	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AllocationAPIService.CreateAllocationConstraint")
-	if err != nil {
-		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
-	}
-
-	localVarPath := localBasePath + "/v2/org/{org}/nico/allocation/{allocationId}/constraint"
-	localVarPath = strings.Replace(localVarPath, "{"+"org"+"}", url.PathEscape(parameterValueToString(r.org, "org")), -1)
-	localVarPath = strings.Replace(localVarPath, "{"+"allocationId"+"}", url.PathEscape(parameterValueToString(r.allocationId, "allocationId")), -1)
-
-	localVarHeaderParams := make(map[string]string)
-	localVarQueryParams := url.Values{}
-	localVarFormParams := url.Values{}
-
-	// to determine the Content-Type header
-	localVarHTTPContentTypes := []string{"application/json"}
-
-	// set Content-Type header
-	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
-	if localVarHTTPContentType != "" {
-		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
-	}
-
-	// to determine the Accept header
-	localVarHTTPHeaderAccepts := []string{"application/json"}
-
-	// set Accept header
-	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
-	if localVarHTTPHeaderAccept != "" {
-		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	// body params
-	localVarPostBody = r.allocationConstraintCreateRequest
-	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
-	if err != nil {
-		return localVarReturnValue, nil, err
-	}
-
-	localVarHTTPResponse, err := a.client.callAPI(req)
-	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, localVarHTTPResponse, err
-	}
-
-	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
-	if err != nil {
-		return localVarReturnValue, localVarHTTPResponse, err
-	}
-
-	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHTTPResponse.Status,
-		}
-		if localVarHTTPResponse.StatusCode == 400 {
-			var v NICoAPIError
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHTTPResponse, newErr
-			}
-			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-			newErr.model = v
-			return localVarReturnValue, localVarHTTPResponse, newErr
-		}
-		if localVarHTTPResponse.StatusCode == 403 {
-			var v NICoAPIError
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHTTPResponse, newErr
-			}
-			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-			newErr.model = v
-		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
-	}
-
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-	if err != nil {
-		newErr := &GenericOpenAPIError{
-			body:  localVarBody,
-			error: err.Error(),
-		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
-	}
-
-	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
 type ApiDeleteAllocationRequest struct {
 	ctx          context.Context
 	ApiService   *AllocationAPIService
@@ -367,7 +228,7 @@ func (a *AllocationAPIService) DeleteAllocationExecute(r ApiDeleteAllocationRequ
 	}
 
 	// to determine the Accept header
-	localVarHTTPHeaderAccepts := []string{}
+	localVarHTTPHeaderAccepts := []string{"application/json"}
 
 	// set Accept header
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
@@ -396,107 +257,15 @@ func (a *AllocationAPIService) DeleteAllocationExecute(r ApiDeleteAllocationRequ
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
 		}
-		return localVarHTTPResponse, newErr
-	}
-
-	return localVarHTTPResponse, nil
-}
-
-type ApiDeleteAllocationConstraintRequest struct {
-	ctx                    context.Context
-	ApiService             *AllocationAPIService
-	org                    string
-	allocationId           string
-	allocationConstraintId string
-}
-
-func (r ApiDeleteAllocationConstraintRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteAllocationConstraintExecute(r)
-}
-
-/*
-DeleteAllocationConstraint Delete Allocation Constraint
-
-# Delete an existing Allocation Constraint by ID
-
-Org must have an Infrastructure Provider. Specified Allocation must have been created by the Provider and requesting user must have `PROVIDER_ADMIN` role.
-
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param org Name of the Org
-	@param allocationId ID of the Allocation
-	@param allocationConstraintId ID of the Allocation Constraint
-	@return ApiDeleteAllocationConstraintRequest
-*/
-func (a *AllocationAPIService) DeleteAllocationConstraint(ctx context.Context, org string, allocationId string, allocationConstraintId string) ApiDeleteAllocationConstraintRequest {
-	return ApiDeleteAllocationConstraintRequest{
-		ApiService:             a,
-		ctx:                    ctx,
-		org:                    org,
-		allocationId:           allocationId,
-		allocationConstraintId: allocationConstraintId,
-	}
-}
-
-// Execute executes the request
-func (a *AllocationAPIService) DeleteAllocationConstraintExecute(r ApiDeleteAllocationConstraintRequest) (*http.Response, error) {
-	var (
-		localVarHTTPMethod = http.MethodDelete
-		localVarPostBody   interface{}
-		formFiles          []formFile
-	)
-
-	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AllocationAPIService.DeleteAllocationConstraint")
-	if err != nil {
-		return nil, &GenericOpenAPIError{error: err.Error()}
-	}
-
-	localVarPath := localBasePath + "/v2/org/{org}/nico/allocation/{allocationId}/constraint/{allocationConstraintId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"org"+"}", url.PathEscape(parameterValueToString(r.org, "org")), -1)
-	localVarPath = strings.Replace(localVarPath, "{"+"allocationId"+"}", url.PathEscape(parameterValueToString(r.allocationId, "allocationId")), -1)
-	localVarPath = strings.Replace(localVarPath, "{"+"allocationConstraintId"+"}", url.PathEscape(parameterValueToString(r.allocationConstraintId, "allocationConstraintId")), -1)
-
-	localVarHeaderParams := make(map[string]string)
-	localVarQueryParams := url.Values{}
-	localVarFormParams := url.Values{}
-
-	// to determine the Content-Type header
-	localVarHTTPContentTypes := []string{}
-
-	// set Content-Type header
-	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
-	if localVarHTTPContentType != "" {
-		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
-	}
-
-	// to determine the Accept header
-	localVarHTTPHeaderAccepts := []string{}
-
-	// set Accept header
-	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
-	if localVarHTTPHeaderAccept != "" {
-		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
-	if err != nil {
-		return nil, err
-	}
-
-	localVarHTTPResponse, err := a.client.callAPI(req)
-	if err != nil || localVarHTTPResponse == nil {
-		return localVarHTTPResponse, err
-	}
-
-	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
-	if err != nil {
-		return localVarHTTPResponse, err
-	}
-
-	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHTTPResponse.Status,
+		if localVarHTTPResponse.StatusCode == 403 {
+			var v NICoAPIError
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarHTTPResponse, newErr
 	}
@@ -767,162 +536,6 @@ func (a *AllocationAPIService) GetAllAllocationExecute(r ApiGetAllAllocationRequ
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ApiGetAllAllocationConstraintRequest struct {
-	ctx          context.Context
-	ApiService   *AllocationAPIService
-	org          string
-	allocationId string
-	pageNumber   *int32
-	pageSize     *int32
-	orderBy      *string
-}
-
-// Page number for pagination query
-func (r ApiGetAllAllocationConstraintRequest) PageNumber(pageNumber int32) ApiGetAllAllocationConstraintRequest {
-	r.pageNumber = &pageNumber
-	return r
-}
-
-// Page size for pagination query
-func (r ApiGetAllAllocationConstraintRequest) PageSize(pageSize int32) ApiGetAllAllocationConstraintRequest {
-	r.pageSize = &pageSize
-	return r
-}
-
-// Ordering for pagination query
-func (r ApiGetAllAllocationConstraintRequest) OrderBy(orderBy string) ApiGetAllAllocationConstraintRequest {
-	r.orderBy = &orderBy
-	return r
-}
-
-func (r ApiGetAllAllocationConstraintRequest) Execute() ([]AllocationConstraint, *http.Response, error) {
-	return r.ApiService.GetAllAllocationConstraintExecute(r)
-}
-
-/*
-GetAllAllocationConstraint Retrieve all Allocation Constraints
-
-Retrieve all Allocation Constraints for a given Allocation ID.
-
-If org has an Infrastructure Provider entity, then specified Allocation must have been created by the Provider and requesting user must have `PROVIDER_ADMIN` role.
-
-If org does not have an Infrastructure Provider entity but has a Tenant entity, then specified Allocation must belong to the Tenant and requesting user must have `TENANT_ADMIN` role.
-
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param org Name of the Org
-	@param allocationId ID of the Allocation
-	@return ApiGetAllAllocationConstraintRequest
-*/
-func (a *AllocationAPIService) GetAllAllocationConstraint(ctx context.Context, org string, allocationId string) ApiGetAllAllocationConstraintRequest {
-	return ApiGetAllAllocationConstraintRequest{
-		ApiService:   a,
-		ctx:          ctx,
-		org:          org,
-		allocationId: allocationId,
-	}
-}
-
-// Execute executes the request
-//
-//	@return []AllocationConstraint
-func (a *AllocationAPIService) GetAllAllocationConstraintExecute(r ApiGetAllAllocationConstraintRequest) ([]AllocationConstraint, *http.Response, error) {
-	var (
-		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
-		formFiles           []formFile
-		localVarReturnValue []AllocationConstraint
-	)
-
-	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AllocationAPIService.GetAllAllocationConstraint")
-	if err != nil {
-		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
-	}
-
-	localVarPath := localBasePath + "/v2/org/{org}/nico/allocation/{allocationId}/constraint"
-	localVarPath = strings.Replace(localVarPath, "{"+"org"+"}", url.PathEscape(parameterValueToString(r.org, "org")), -1)
-	localVarPath = strings.Replace(localVarPath, "{"+"allocationId"+"}", url.PathEscape(parameterValueToString(r.allocationId, "allocationId")), -1)
-
-	localVarHeaderParams := make(map[string]string)
-	localVarQueryParams := url.Values{}
-	localVarFormParams := url.Values{}
-
-	if r.pageNumber != nil {
-		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
-	} else {
-		var defaultValue int32 = 1
-		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
-		r.pageNumber = &defaultValue
-	}
-	if r.pageSize != nil {
-		parameterAddToHeaderOrQuery(localVarQueryParams, "pageSize", r.pageSize, "form", "")
-	}
-	if r.orderBy != nil {
-		parameterAddToHeaderOrQuery(localVarQueryParams, "orderBy", r.orderBy, "form", "")
-	}
-	// to determine the Content-Type header
-	localVarHTTPContentTypes := []string{}
-
-	// set Content-Type header
-	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
-	if localVarHTTPContentType != "" {
-		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
-	}
-
-	// to determine the Accept header
-	localVarHTTPHeaderAccepts := []string{"application/json"}
-
-	// set Accept header
-	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
-	if localVarHTTPHeaderAccept != "" {
-		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
-	if err != nil {
-		return localVarReturnValue, nil, err
-	}
-
-	localVarHTTPResponse, err := a.client.callAPI(req)
-	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, localVarHTTPResponse, err
-	}
-
-	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
-	if err != nil {
-		return localVarReturnValue, localVarHTTPResponse, err
-	}
-
-	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHTTPResponse.Status,
-		}
-		if localVarHTTPResponse.StatusCode == 403 {
-			var v NICoAPIError
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHTTPResponse, newErr
-			}
-			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-			newErr.model = v
-		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
-	}
-
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-	if err != nil {
-		newErr := &GenericOpenAPIError{
-			body:  localVarBody,
-			error: err.Error(),
-		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
-	}
-
-	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
 type ApiGetAllocationRequest struct {
 	ctx                      context.Context
 	ApiService               *AllocationAPIService
@@ -1013,132 +626,6 @@ func (a *AllocationAPIService) GetAllocationExecute(r ApiGetAllocationRequest) (
 	if r.includeRelation != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "includeRelation", r.includeRelation, "form", "")
 	}
-	// to determine the Content-Type header
-	localVarHTTPContentTypes := []string{}
-
-	// set Content-Type header
-	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
-	if localVarHTTPContentType != "" {
-		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
-	}
-
-	// to determine the Accept header
-	localVarHTTPHeaderAccepts := []string{"application/json"}
-
-	// set Accept header
-	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
-	if localVarHTTPHeaderAccept != "" {
-		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
-	if err != nil {
-		return localVarReturnValue, nil, err
-	}
-
-	localVarHTTPResponse, err := a.client.callAPI(req)
-	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, localVarHTTPResponse, err
-	}
-
-	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
-	if err != nil {
-		return localVarReturnValue, localVarHTTPResponse, err
-	}
-
-	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHTTPResponse.Status,
-		}
-		if localVarHTTPResponse.StatusCode == 403 {
-			var v NICoAPIError
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHTTPResponse, newErr
-			}
-			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-			newErr.model = v
-		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
-	}
-
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-	if err != nil {
-		newErr := &GenericOpenAPIError{
-			body:  localVarBody,
-			error: err.Error(),
-		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
-	}
-
-	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-type ApiGetAllocationConstraintRequest struct {
-	ctx                    context.Context
-	ApiService             *AllocationAPIService
-	org                    string
-	allocationId           string
-	allocationConstraintId string
-}
-
-func (r ApiGetAllocationConstraintRequest) Execute() ([]AllocationConstraint, *http.Response, error) {
-	return r.ApiService.GetAllocationConstraintExecute(r)
-}
-
-/*
-GetAllocationConstraint Retrieve Allocation Constraint
-
-Retrieve an Allocation Constraint for a given Allocation ID.
-
-If org has an Infrastructure Provider entity, then specified Allocation must have been created by the Provider and requesting user must have `PROVIDER_ADMIN` role.
-
-If org does not have an Infrastructure Provider entity but has a Tenant entity, then specified Allocation must belong to the Tenant and requesting user must have `TENANT_ADMIN` role.
-
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param org Name of the Org
-	@param allocationId ID of the Allocation
-	@param allocationConstraintId ID of the Allocation Constraint
-	@return ApiGetAllocationConstraintRequest
-*/
-func (a *AllocationAPIService) GetAllocationConstraint(ctx context.Context, org string, allocationId string, allocationConstraintId string) ApiGetAllocationConstraintRequest {
-	return ApiGetAllocationConstraintRequest{
-		ApiService:             a,
-		ctx:                    ctx,
-		org:                    org,
-		allocationId:           allocationId,
-		allocationConstraintId: allocationConstraintId,
-	}
-}
-
-// Execute executes the request
-//
-//	@return []AllocationConstraint
-func (a *AllocationAPIService) GetAllocationConstraintExecute(r ApiGetAllocationConstraintRequest) ([]AllocationConstraint, *http.Response, error) {
-	var (
-		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
-		formFiles           []formFile
-		localVarReturnValue []AllocationConstraint
-	)
-
-	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AllocationAPIService.GetAllocationConstraint")
-	if err != nil {
-		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
-	}
-
-	localVarPath := localBasePath + "/v2/org/{org}/nico/allocation/{allocationId}/constraint/{allocationConstraintId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"org"+"}", url.PathEscape(parameterValueToString(r.org, "org")), -1)
-	localVarPath = strings.Replace(localVarPath, "{"+"allocationId"+"}", url.PathEscape(parameterValueToString(r.allocationId, "allocationId")), -1)
-	localVarPath = strings.Replace(localVarPath, "{"+"allocationConstraintId"+"}", url.PathEscape(parameterValueToString(r.allocationConstraintId, "allocationConstraintId")), -1)
-
-	localVarHeaderParams := make(map[string]string)
-	localVarQueryParams := url.Values{}
-	localVarFormParams := url.Values{}
-
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 
@@ -1308,6 +795,27 @@ func (a *AllocationAPIService) UpdateAllocationExecute(r ApiUpdateAllocationRequ
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
 		}
+		if localVarHTTPResponse.StatusCode == 400 {
+			var v NICoAPIError
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 403 {
+			var v NICoAPIError
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
@@ -1435,6 +943,27 @@ func (a *AllocationAPIService) UpdateAllocationConstraintExecute(r ApiUpdateAllo
 		newErr := &GenericOpenAPIError{
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 400 {
+			var v NICoAPIError
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 403 {
+			var v NICoAPIError
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}

--- a/sdk/standard/api_instance.go
+++ b/sdk/standard/api_instance.go
@@ -373,7 +373,7 @@ func (a *InstanceAPIService) DeleteInstanceExecute(r ApiDeleteInstanceRequest) (
 	}
 
 	// to determine the Accept header
-	localVarHTTPHeaderAccepts := []string{}
+	localVarHTTPHeaderAccepts := []string{"application/json"}
 
 	// set Accept header
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
@@ -403,6 +403,16 @@ func (a *InstanceAPIService) DeleteInstanceExecute(r ApiDeleteInstanceRequest) (
 		newErr := &GenericOpenAPIError{
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 403 {
+			var v NICoAPIError
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarHTTPResponse, newErr
 	}

--- a/sdk/standard/api_instance_type.go
+++ b/sdk/standard/api_instance_type.go
@@ -1176,6 +1176,17 @@ func (a *InstanceTypeAPIService) UpdateInstanceTypeExecute(r ApiUpdateInstanceTy
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
 		}
+		if localVarHTTPResponse.StatusCode == 400 {
+			var v NICoAPIError
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v NICoAPIError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))

--- a/sdk/standard/api_ip_block.go
+++ b/sdk/standard/api_ip_block.go
@@ -954,6 +954,27 @@ func (a *IPBlockAPIService) UpdateIpblockExecute(r ApiUpdateIpblockRequest) (*Ip
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
 		}
+		if localVarHTTPResponse.StatusCode == 400 {
+			var v NICoAPIError
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 403 {
+			var v NICoAPIError
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 

--- a/sdk/standard/api_machine.go
+++ b/sdk/standard/api_machine.go
@@ -1486,6 +1486,27 @@ func (a *MachineAPIService) UpdateMachineExecute(r ApiUpdateMachineRequest) (*Ma
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
 		}
+		if localVarHTTPResponse.StatusCode == 400 {
+			var v NICoAPIError
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 403 {
+			var v NICoAPIError
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 

--- a/sdk/standard/api_metadata.go
+++ b/sdk/standard/api_metadata.go
@@ -114,6 +114,16 @@ func (a *MetadataAPIService) GetMetadataExecute(r ApiGetMetadataRequest) (*Metad
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
 		}
+		if localVarHTTPResponse.StatusCode == 401 {
+			var v NICoAPIError
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 

--- a/sdk/standard/api_site.go
+++ b/sdk/standard/api_site.go
@@ -237,7 +237,7 @@ func (a *SiteAPIService) DeleteSiteExecute(r ApiDeleteSiteRequest) (*http.Respon
 	}
 
 	// to determine the Accept header
-	localVarHTTPHeaderAccepts := []string{}
+	localVarHTTPHeaderAccepts := []string{"application/json"}
 
 	// set Accept header
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
@@ -265,6 +265,16 @@ func (a *SiteAPIService) DeleteSiteExecute(r ApiDeleteSiteRequest) (*http.Respon
 		newErr := &GenericOpenAPIError{
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 403 {
+			var v NICoAPIError
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarHTTPResponse, newErr
 	}
@@ -906,6 +916,27 @@ func (a *SiteAPIService) UpdateSiteExecute(r ApiUpdateSiteRequest) (*Site, *http
 		newErr := &GenericOpenAPIError{
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 400 {
+			var v NICoAPIError
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 403 {
+			var v NICoAPIError
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}

--- a/sdk/standard/api_user.go
+++ b/sdk/standard/api_user.go
@@ -114,6 +114,16 @@ func (a *UserAPIService) GetUserExecute(r ApiGetUserRequest) (*User, *http.Respo
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
 		}
+		if localVarHTTPResponse.StatusCode == 401 {
+			var v NICoAPIError
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 

--- a/sdk/standard/client.go
+++ b/sdk/standard/client.go
@@ -587,10 +587,7 @@ func addFile(w *multipart.Writer, fieldName, path string) error {
 	if err != nil {
 		return err
 	}
-	err = file.Close()
-	if err != nil {
-		return err
-	}
+	defer file.Close()
 
 	part, err := w.CreateFormFile(fieldName, filepath.Base(path))
 	if err != nil {

--- a/sdk/standard/compat/instance_create.go
+++ b/sdk/standard/compat/instance_create.go
@@ -1,19 +1,5 @@
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 // Package compat holds deprecated, source-compatible wrappers around
 // standard SDK constructors whose signatures changed as a side effect

--- a/sdk/standard/go.mod
+++ b/sdk/standard/go.mod
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 module github.com/NVIDIA/infra-controller-rest/sdk/standard
 
 go 1.25.4

--- a/sdk/standard/model_expected_machine.go
+++ b/sdk/standard/model_expected_machine.go
@@ -60,7 +60,8 @@ type ExpectedMachine struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32     `json:"hostId,omitempty"`
+	HostId NullableInt32 `json:"hostId,omitempty"`
+	// User-defined key-value pairs for organizing and categorizing Expected Machines
 	Labels map[string]string `json:"labels,omitempty"`
 	// ISO 8601 datetime when the Expected Machine was created
 	Created *time.Time `json:"created,omitempty"`

--- a/sdk/standard/model_expected_machine_create_request.go
+++ b/sdk/standard/model_expected_machine_create_request.go
@@ -57,7 +57,8 @@ type ExpectedMachineCreateRequest struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32     `json:"hostId,omitempty"`
+	HostId NullableInt32 `json:"hostId,omitempty"`
+	// User-defined key-value pairs for organizing and categorizing Expected Machines
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_expected_machine_update_request.go
+++ b/sdk/standard/model_expected_machine_update_request.go
@@ -55,7 +55,8 @@ type ExpectedMachineUpdateRequest struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32     `json:"hostId,omitempty"`
+	HostId NullableInt32 `json:"hostId,omitempty"`
+	// User-defined key-value pairs for organizing and categorizing Expected Machines
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_expected_power_shelf.go
+++ b/sdk/standard/model_expected_power_shelf.go
@@ -50,7 +50,8 @@ type ExpectedPowerShelf struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32     `json:"hostId,omitempty"`
+	HostId NullableInt32 `json:"hostId,omitempty"`
+	// User-defined key-value pairs for organizing and categorizing Expected Power Shelves
 	Labels map[string]string `json:"labels,omitempty"`
 	// ISO 8601 datetime when the Expected Power Shelf was created
 	Created *time.Time `json:"created,omitempty"`

--- a/sdk/standard/model_expected_power_shelf_create_request.go
+++ b/sdk/standard/model_expected_power_shelf_create_request.go
@@ -53,7 +53,8 @@ type ExpectedPowerShelfCreateRequest struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32     `json:"hostId,omitempty"`
+	HostId NullableInt32 `json:"hostId,omitempty"`
+	// User-defined key-value pairs for organizing and categorizing Expected Power Shelves
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_expected_power_shelf_update_request.go
+++ b/sdk/standard/model_expected_power_shelf_update_request.go
@@ -51,7 +51,8 @@ type ExpectedPowerShelfUpdateRequest struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32     `json:"hostId,omitempty"`
+	HostId NullableInt32 `json:"hostId,omitempty"`
+	// User-defined key-value pairs for organizing and categorizing Expected Power Shelves
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_expected_rack.go
+++ b/sdk/standard/model_expected_rack.go
@@ -34,8 +34,9 @@ type ExpectedRack struct {
 	// Human-readable name of the Expected Rack
 	Name *string `json:"name,omitempty"`
 	// Human-readable description of the Expected Rack
-	Description *string           `json:"description,omitempty"`
-	Labels      map[string]string `json:"labels,omitempty"`
+	Description *string `json:"description,omitempty"`
+	// User-defined key-value pairs for organizing and categorizing Expected Racks. Well-known keys (`chassis.*`, `location.*`) are used to convey chassis identity and physical location.
+	Labels map[string]string `json:"labels,omitempty"`
 	// ISO 8601 datetime when the Expected Rack was created
 	Created *time.Time `json:"created,omitempty"`
 	// ISO 8601 datetime when the Expected Rack was last updated

--- a/sdk/standard/model_expected_rack_create_request.go
+++ b/sdk/standard/model_expected_rack_create_request.go
@@ -33,8 +33,9 @@ type ExpectedRackCreateRequest struct {
 	// Human-readable name of the Expected Rack
 	Name NullableString `json:"name,omitempty"`
 	// Human-readable description of the Expected Rack
-	Description NullableString    `json:"description,omitempty"`
-	Labels      map[string]string `json:"labels,omitempty"`
+	Description NullableString `json:"description,omitempty"`
+	// User-defined key-value pairs for organizing and categorizing Expected Racks. Well-known keys (`chassis.*`, `location.*`) are used to convey chassis identity and physical location.
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 type _ExpectedRackCreateRequest ExpectedRackCreateRequest

--- a/sdk/standard/model_expected_rack_update_request.go
+++ b/sdk/standard/model_expected_rack_update_request.go
@@ -31,8 +31,9 @@ type ExpectedRackUpdateRequest struct {
 	// Human-readable name of the Expected Rack
 	Name NullableString `json:"name,omitempty"`
 	// Human-readable description of the Expected Rack
-	Description NullableString    `json:"description,omitempty"`
-	Labels      map[string]string `json:"labels,omitempty"`
+	Description NullableString `json:"description,omitempty"`
+	// User-defined key-value pairs for organizing and categorizing Expected Racks. Well-known keys (`chassis.*`, `location.*`) are used to convey chassis identity and physical location.
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // NewExpectedRackUpdateRequest instantiates a new ExpectedRackUpdateRequest object

--- a/sdk/standard/model_expected_switch.go
+++ b/sdk/standard/model_expected_switch.go
@@ -50,7 +50,8 @@ type ExpectedSwitch struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32     `json:"hostId,omitempty"`
+	HostId NullableInt32 `json:"hostId,omitempty"`
+	// User-defined key-value pairs for organizing and categorizing Expected Switches
 	Labels map[string]string `json:"labels,omitempty"`
 	// ISO 8601 datetime when the Expected Switch was created
 	Created *time.Time `json:"created,omitempty"`

--- a/sdk/standard/model_expected_switch_create_request.go
+++ b/sdk/standard/model_expected_switch_create_request.go
@@ -57,7 +57,8 @@ type ExpectedSwitchCreateRequest struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32     `json:"hostId,omitempty"`
+	HostId NullableInt32 `json:"hostId,omitempty"`
+	// User-defined key-value pairs for organizing and categorizing Expected Switches
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_expected_switch_update_request.go
+++ b/sdk/standard/model_expected_switch_update_request.go
@@ -55,7 +55,8 @@ type ExpectedSwitchUpdateRequest struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32     `json:"hostId,omitempty"`
+	HostId NullableInt32 `json:"hostId,omitempty"`
+	// User-defined key-value pairs for organizing and categorizing Expected Switches
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_infini_band_partition.go
+++ b/sdk/standard/model_infini_band_partition.go
@@ -23,23 +23,24 @@ var _ MappedNullable = &InfiniBandPartition{}
 
 // InfiniBandPartition InfiniBand Partitions are network segments utilizing InfiniBand topology
 type InfiniBandPartition struct {
-	Id                      *string                    `json:"id,omitempty"`
-	Name                    *string                    `json:"name,omitempty"`
-	Description             NullableString             `json:"description,omitempty"`
-	SiteId                  *string                    `json:"siteId,omitempty"`
-	TenantId                *string                    `json:"tenantId,omitempty"`
-	ControllerIBPartitionId NullableString             `json:"controllerIBPartitionId,omitempty"`
-	PartitionKey            NullableString             `json:"partitionKey,omitempty"`
-	PartitionName           NullableString             `json:"partitionName,omitempty"`
-	ServiceLevel            NullableInt32              `json:"serviceLevel,omitempty"`
-	RateLimit               NullableFloat32            `json:"rateLimit,omitempty"`
-	Mtu                     NullableInt32              `json:"mtu,omitempty"`
-	EnableSharp             *bool                      `json:"enableSharp,omitempty"`
-	Labels                  map[string]string          `json:"labels,omitempty"`
-	Status                  *InfiniBandPartitionStatus `json:"status,omitempty"`
-	StatusHistory           []StatusDetail             `json:"statusHistory,omitempty"`
-	Created                 *time.Time                 `json:"created,omitempty"`
-	Updated                 *time.Time                 `json:"updated,omitempty"`
+	Id                      *string         `json:"id,omitempty"`
+	Name                    *string         `json:"name,omitempty"`
+	Description             NullableString  `json:"description,omitempty"`
+	SiteId                  *string         `json:"siteId,omitempty"`
+	TenantId                *string         `json:"tenantId,omitempty"`
+	ControllerIBPartitionId NullableString  `json:"controllerIBPartitionId,omitempty"`
+	PartitionKey            NullableString  `json:"partitionKey,omitempty"`
+	PartitionName           NullableString  `json:"partitionName,omitempty"`
+	ServiceLevel            NullableInt32   `json:"serviceLevel,omitempty"`
+	RateLimit               NullableFloat32 `json:"rateLimit,omitempty"`
+	Mtu                     NullableInt32   `json:"mtu,omitempty"`
+	EnableSharp             *bool           `json:"enableSharp,omitempty"`
+	// String key value pairs describing InfiniBand Partition labels. Up to 10 key value pairs can be specified
+	Labels        map[string]string          `json:"labels,omitempty"`
+	Status        *InfiniBandPartitionStatus `json:"status,omitempty"`
+	StatusHistory []StatusDetail             `json:"statusHistory,omitempty"`
+	Created       *time.Time                 `json:"created,omitempty"`
+	Updated       *time.Time                 `json:"updated,omitempty"`
 }
 
 // NewInfiniBandPartition instantiates a new InfiniBandPartition object

--- a/sdk/standard/model_infini_band_partition_create_request.go
+++ b/sdk/standard/model_infini_band_partition_create_request.go
@@ -29,7 +29,8 @@ type InfiniBandPartitionCreateRequest struct {
 	// Optional description of the Partition
 	Description NullableString `json:"description,omitempty"`
 	// ID of the Site the Partition should belong to
-	SiteId string            `json:"siteId"`
+	SiteId string `json:"siteId"`
+	// String key value pairs describing Partition labels. Up to 10 key value pairs can be specified
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_infini_band_partition_update_request.go
+++ b/sdk/standard/model_infini_band_partition_update_request.go
@@ -24,9 +24,10 @@ var _ MappedNullable = &InfiniBandPartitionUpdateRequest{}
 
 // InfiniBandPartitionUpdateRequest Request data to update an InfiniBand Partition
 type InfiniBandPartitionUpdateRequest struct {
-	Name        string            `json:"name"`
-	Description NullableString    `json:"description,omitempty"`
-	Labels      map[string]string `json:"labels,omitempty"`
+	Name        string         `json:"name"`
+	Description NullableString `json:"description,omitempty"`
+	// String key value pairs describing Partition labels. Up to 10 key value pairs can be specified
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 type _InfiniBandPartitionUpdateRequest InfiniBandPartitionUpdateRequest

--- a/sdk/standard/model_machine_update_request.go
+++ b/sdk/standard/model_machine_update_request.go
@@ -29,9 +29,10 @@ type MachineUpdateRequest struct {
 	// Set to `true` to enable maintenance mode and to `false` to disable maintenance mode. Can be set by Provider or Privileged Tenant.
 	SetMaintenanceMode NullableBool `json:"setMaintenanceMode,omitempty"`
 	// Optional message describing the reason for moving Machine into maintenance mode. Can be updated by Provider or Privileged Tenant.
-	MaintenanceMessage NullableString       `json:"maintenanceMessage,omitempty"`
-	Labels             map[string]string    `json:"labels,omitempty"`
-	OnlineRepair       *MachineOnlineRepair `json:"onlineRepair,omitempty"`
+	MaintenanceMessage NullableString `json:"maintenanceMessage,omitempty"`
+	// Machine labels will be overwritten, include existing labels to preserve them. Can be updated by Provider or Privileged Tenant.
+	Labels       map[string]string    `json:"labels,omitempty"`
+	OnlineRepair *MachineOnlineRepair `json:"onlineRepair,omitempty"`
 	// Required when `onlineRepair.enabled` is true. Must not be set when exiting online repair (`onlineRepair.enabled` false).
 	HealthIssue *MachineHealthIssue `json:"healthIssue,omitempty"`
 }

--- a/sdk/standard/model_vpc.go
+++ b/sdk/standard/model_vpc.go
@@ -50,8 +50,9 @@ type VPC struct {
 	// Propagation details for the attached Network Security Group
 	NetworkSecurityGroupPropagationDetails *NetworkSecurityGroupPropagationDetails `json:"networkSecurityGroupPropagationDetails,omitempty"`
 	// ID of the default NVLink Logical Partition that GPUs for all Instances in the VPC will attach to
-	NvLinkLogicalPartitionId NullableString    `json:"nvLinkLogicalPartitionId,omitempty"`
-	Labels                   map[string]string `json:"labels,omitempty"`
+	NvLinkLogicalPartitionId NullableString `json:"nvLinkLogicalPartitionId,omitempty"`
+	// String key value pairs describing VPC labels
+	Labels map[string]string `json:"labels,omitempty"`
 	// Status of the VPC
 	Status *VpcStatus `json:"status,omitempty"`
 	// History of status changes for the VPC

--- a/sdk/standard/model_vpc_create_request.go
+++ b/sdk/standard/model_vpc_create_request.go
@@ -41,8 +41,9 @@ type VpcCreateRequest struct {
 	// Explicitly requested VNI for the VPC
 	Vni NullableInt32 `json:"vni,omitempty"`
 	// ID of the default NVLink Logical Partition that GPUs for all Instances in the VPC will attach to
-	NvLinkLogicalPartitionId NullableString    `json:"nvLinkLogicalPartitionId,omitempty"`
-	Labels                   map[string]string `json:"labels,omitempty"`
+	NvLinkLogicalPartitionId NullableString `json:"nvLinkLogicalPartitionId,omitempty"`
+	// String key value pairs describing VPC labels. Up to 10 key value pairs can be specified
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 type _VpcCreateRequest VpcCreateRequest

--- a/sdk/standard/model_vpc_update_request.go
+++ b/sdk/standard/model_vpc_update_request.go
@@ -29,8 +29,9 @@ type VpcUpdateRequest struct {
 	// ID of the Network Security Group to attach to the VPC
 	NetworkSecurityGroupId NullableString `json:"networkSecurityGroupId,omitempty"`
 	// ID of the default NVLink Logical Partition that GPUs for all Instances in the VPC will attach to. Can only be updated if VPC currently has no active Instances
-	NvLinkLogicalPartitionId NullableString    `json:"nvLinkLogicalPartitionId,omitempty"`
-	Labels                   map[string]string `json:"labels,omitempty"`
+	NvLinkLogicalPartitionId NullableString `json:"nvLinkLogicalPartitionId,omitempty"`
+	// Update labels of the VPC. Up to 10 key value pairs can be specified. The labels will be entirely replaced by those sent in the request. Any labels not included in the request will be removed. To retain existing labels, first fetch them and include them along with this request.
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // NewVpcUpdateRequest instantiates a new VpcUpdateRequest object

--- a/site-agent/.gitignore
+++ b/site-agent/.gitignore
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
OpenAPI schema is incorrectly listing the following endpoints, this PR removed them.
- Create Allocation Constraint (User cannot explicitly create them, they are created as part of Allocation creation)
- Get Allocation Constraint (User cannot explicitly retrieve them, they are retrieved as part of Allocation creation)
- Delete Allocation Constraint (User cannot explicitly delete them, they are deleted as part of Allocation creation)

The PR also fixes missing 4xx responses for certain endpoints that were causing lint errors.

This PR also enables skipping `no-ambigous-path` lint error reported by redocly linter which is not taking into account the UUID format of strings to disambiguate paths.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Docs** - Changes in documentation or OpenAPI schema (docs:)

## Services Affected
<!-- Check one or more if appropriate -->
None

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->
None

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
None