### PR TITLE
feat: Add manager-specific component config

### DIFF
--- a/flow/docs/component-manager-architecture.md
+++ b/flow/docs/component-manager-architecture.md
@@ -262,6 +262,12 @@ Generic YAML parsing and validation lives in
 `internal/task/componentmanager/config`. That package should not import
 provider implementations directly.
 
+Manager-specific behavior settings use the same pattern, but are keyed by
+descriptor identity instead of provider name. A manager that needs YAML config
+implements `cmconfig.ManagerConfigDecoder`; the decoded config is stored under
+`Config.ManagerConfigs[Descriptor().Identity()]`. Provider configs should stay
+focused on provider/client settings such as timeouts and endpoints.
+
 ### Step 3: Register the Provider Decoder
 
 Update the service-supported provider catalog in
@@ -398,9 +404,12 @@ func serviceDescriptors() []cmcatalog.Descriptor {
 }
 
 func serviceFactorySpecs(config cmconfig.Config) ([]componentmanager.FactorySpec, error) {
+    // Simplified example: production code should check that the config exists
+    // and has the expected type, returning an error instead of panicking.
+    cfg := config.ManagerConfigs[myimpl.Descriptor().Identity()].(*myimpl.Config)
     factorySpecs := []componentmanager.FactorySpec{
         // ... existing factory specs ...
-        myimpl.FactorySpec(), // Add new implementation
+        myimpl.FactorySpec(cfg), // Add new implementation
     }
     return factorySpecs, nil
 }
@@ -415,6 +424,11 @@ component_managers:
   compute: myimpl
   nvswitch: nico
   powershelf: psm
+
+manager_configs:
+  compute:
+    myimpl:
+      behavior_setting: "value"
 
 providers:
   myapi:

--- a/flow/docs/component-manager-config.md
+++ b/flow/docs/component-manager-config.md
@@ -6,10 +6,13 @@ This document explains the configuration files for the Component Manager system.
 
 The Component Manager configuration controls:
 1. Which implementation to use for each component type (compute, NVL switch, power shelf)
-2. Which API providers to enable and their settings
+2. Manager behavior settings for selected implementations
+3. Which API providers to enable and their client settings
 
-Timing parameters for power control and firmware update operations are configured
-**per-rule** via action parameters in operation rules, not in the component manager config.
+Timing parameters for power control and firmware update operations are generally
+configured **per-rule** via action parameters in operation rules. Manager-wide
+behavior settings, such as compute power-call staggering, live under
+`manager_configs`.
 
 ## Configuration Files
 
@@ -53,7 +56,6 @@ Available implementations:
 providers:
   nico:
     timeout: "<duration>"
-    compute_power_delay: "<duration>"
   nvswitchmanager:
     timeout: "<duration>"
   psm:
@@ -72,12 +74,28 @@ equivalent to omitting the section for provider-backed component managers.
 | `nvswitchmanager` | nvswitch/nvswitchmanager | NV-Switch Manager API for NVLink switch management |
 | `psm` | powershelf/psm | Power Shelf Manager API |
 
+### Manager Configs
+
+```yaml
+manager_configs:
+  compute:
+    nico:
+      compute_power_delay: "<duration>"
+```
+
+Configures behavior for a selected component manager implementation. The keys
+are the descriptor identity: component type, then implementation name. Entries
+must match the selected `component_managers` implementation.
+
+| Manager | Option | Type | Default | Description |
+|---------|--------|------|---------|-------------|
+| `compute/nico` | `compute_power_delay` | duration string | `2s` | Delay between sequential power control calls for compute trays. Prevents overwhelming the power delivery system. Set to `0s` to disable. |
+
 #### Provider Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `timeout` | duration string | `1m` (nico, nvswitchmanager), `30s` (psm) | gRPC call timeout |
-| `compute_power_delay` | duration string | `2s` (nico only) | Delay between sequential power control calls for compute trays. Prevents overwhelming the power delivery system. Set to `0s` to disable. |
 
 Duration strings use Go format: `30s`, `1m`, `2m30s`, etc.
 
@@ -92,10 +110,14 @@ component_managers:
   nvswitch: nico
   powershelf: nico
 
+manager_configs:
+  compute:
+    nico:
+      compute_power_delay: "2s"
+
 providers:
   nico:
     timeout: "1m"
-    compute_power_delay: "2s"
 ```
 
 ### Test Configuration

--- a/flow/docs/flow-architecture.md
+++ b/flow/docs/flow-architecture.md
@@ -697,6 +697,11 @@ component_managers:
   nvswitch: nico
   powershelf: psm
 
+manager_configs:
+  compute:
+    nico:
+      compute_power_delay: "2s"
+
 providers:
   nico:
     timeout: "1m"

--- a/flow/internal/task/componentmanager/builtin/builtin_test.go
+++ b/flow/internal/task/componentmanager/builtin/builtin_test.go
@@ -43,6 +43,12 @@ func (c testProviderConfig) NewProvider(context.Context) (providerapi.Provider, 
 	return nil, nil
 }
 
+type testManagerConfig struct{}
+
+func (c testManagerConfig) Validate(cmcatalog.DescriptorIdentity) error {
+	return nil
+}
+
 type testServiceProvider struct {
 	name string
 }
@@ -107,10 +113,13 @@ func TestLoadConfigUsesDefaultsWithoutPath(t *testing.T) {
 	nicoConfig, ok := config.ProviderConfigs[nicoprovider.ProviderName].(*nicoprovider.Config)
 	require.True(t, ok)
 	assert.Equal(t, nicoprovider.DefaultTimeout, nicoConfig.Timeout)
+
+	computeConfig, ok := config.ManagerConfigs[computenico.Descriptor().Identity()].(*computenico.Config)
+	require.True(t, ok)
 	assert.Equal(
 		t,
-		nicoprovider.DefaultComputePowerDelay,
-		nicoConfig.ComputePowerDelay,
+		computenico.DefaultComputePowerDelay,
+		computeConfig.ComputePowerDelay,
 	)
 }
 
@@ -153,6 +162,25 @@ providers: {}
 	require.NoError(t, err)
 	assert.Equal(t, computenico.ImplementationName, config.ComponentManagers[devicetypes.ComponentTypeCompute])
 	assert.True(t, config.HasProvider(nicoprovider.ProviderName))
+}
+
+func TestLoadConfigUsesExplicitManagerConfig(t *testing.T) {
+	path := writeServiceConfig(t, `
+component_managers:
+  compute: nico
+manager_configs:
+  compute:
+    nico:
+      compute_power_delay: 0s
+providers: {}
+`)
+
+	config, err := LoadConfig(path)
+
+	require.NoError(t, err)
+	computeConfig, ok := config.ManagerConfigs[computenico.Descriptor().Identity()].(*computenico.Config)
+	require.True(t, ok)
+	assert.Equal(t, 0*time.Second, computeConfig.ComputePowerDelay)
 }
 
 func TestNewProviderRegistry(t *testing.T) {
@@ -334,6 +362,19 @@ func TestServiceProviderConfigDecoderRegistry(t *testing.T) {
 	assert.True(t, ok)
 }
 
+func TestServiceManagerConfigDecoderRegistry(t *testing.T) {
+	registry, err := newManagerConfigDecoderRegistry()
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		[]cmcatalog.DescriptorIdentity{computenico.Descriptor().Identity()},
+		registry.List(),
+	)
+
+	assert.NotNil(t, registry.Get(computenico.Descriptor().Identity()))
+}
+
 func TestServiceCatalog(t *testing.T) {
 	catalog, err := newCatalog()
 
@@ -471,11 +512,11 @@ func TestServiceCatalog(t *testing.T) {
 	}
 }
 
-func TestNicoComputePowerDelayUsesProviderConfig(t *testing.T) {
+func TestNicoComputePowerDelayUsesManagerConfig(t *testing.T) {
 	delay := 7 * time.Second
 	config := cmconfig.Config{
-		ProviderConfigs: map[string]providerapi.ProviderConfig{
-			nicoprovider.ProviderName: &nicoprovider.Config{
+		ManagerConfigs: map[cmcatalog.DescriptorIdentity]cmconfig.ManagerConfig{
+			computenico.Descriptor().Identity(): &computenico.Config{
 				ComputePowerDelay: delay,
 			},
 		},
@@ -487,19 +528,17 @@ func TestNicoComputePowerDelayUsesProviderConfig(t *testing.T) {
 	assert.Equal(t, delay, got)
 }
 
-func TestNicoComputePowerDelayDefaultsWhenProviderConfigMissing(t *testing.T) {
+func TestNicoComputePowerDelayDefaultsWhenManagerConfigMissing(t *testing.T) {
 	got, err := nicoComputePowerDelay(cmconfig.Config{})
 
 	require.NoError(t, err)
-	assert.Equal(t, time.Duration(0), got)
+	assert.Equal(t, computenico.DefaultComputePowerDelay, got)
 }
 
 func TestNicoComputePowerDelayRejectsUnexpectedConfigType(t *testing.T) {
 	config := cmconfig.Config{
-		ProviderConfigs: map[string]providerapi.ProviderConfig{
-			nicoprovider.ProviderName: testProviderConfig{
-				name: nicoprovider.ProviderName,
-			},
+		ManagerConfigs: map[cmcatalog.DescriptorIdentity]cmconfig.ManagerConfig{
+			computenico.Descriptor().Identity(): testManagerConfig{},
 		},
 	}
 
@@ -507,11 +546,13 @@ func TestNicoComputePowerDelayRejectsUnexpectedConfigType(t *testing.T) {
 
 	assert.Equal(t, time.Duration(0), got)
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, componentmanager.ErrProviderConfigTypeMismatch))
+	assert.True(t, errors.Is(err, componentmanager.ErrManagerConfigTypeMismatch))
 
-	var mismatch componentmanager.ProviderConfigTypeMismatchError
+	var mismatch componentmanager.ManagerConfigTypeMismatchError
 	require.True(t, errors.As(err, &mismatch))
-	assert.Equal(t, nicoprovider.ProviderName, mismatch.Name)
+	assert.Equal(t, computenico.Descriptor().Identity(), mismatch.Identity)
+	assert.IsType(t, (*computenico.Config)(nil), mismatch.Want)
+	assert.Contains(t, err.Error(), "compute/nico.Config")
 }
 
 func writeServiceConfig(t *testing.T, data string) string {
@@ -531,7 +572,10 @@ func requireDescriptor(
 ) cmcatalog.Descriptor {
 	t.Helper()
 
-	descriptor, ok := catalog.Get(componentType, implementation)
+	descriptor, ok := catalog.Get(cmcatalog.DescriptorIdentity{
+		Type:           componentType,
+		Implementation: implementation,
+	})
 	require.True(t, ok)
 	return descriptor
 }

--- a/flow/internal/task/componentmanager/builtin/helpers.go
+++ b/flow/internal/task/componentmanager/builtin/helpers.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager"
 	cmcatalog "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/catalog"
+	computenico "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/compute/nico"
 	cmconfig "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/config"
 	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/providerapi"
-	nicoprovider "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/providers/nico"
 )
 
 // newProviderDecoderRegistry creates the provider config decoder registry used
@@ -24,6 +24,24 @@ func newProviderDecoderRegistry() (*providerapi.ProviderConfigDecoderRegistry, e
 			return nil, fmt.Errorf(
 				"register service provider config decoder %q: %w",
 				decoder.Name(),
+				err,
+			)
+		}
+	}
+
+	return registry, nil
+}
+
+// newManagerConfigDecoderRegistry creates the manager config decoder registry
+// used by the Flow service.
+func newManagerConfigDecoderRegistry() (*cmconfig.ManagerConfigDecoderRegistry, error) {
+	registry := cmconfig.NewManagerConfigDecoderRegistry()
+
+	for _, decoder := range serviceManagerConfigDecoders() {
+		if err := registry.Register(decoder); err != nil {
+			return nil, fmt.Errorf(
+				"register service manager config decoder %q: %w",
+				managerConfigDecoderName(decoder),
 				err,
 			)
 		}
@@ -48,21 +66,26 @@ func newCatalog() (cmcatalog.Catalog, error) {
 }
 
 func nicoComputePowerDelay(config cmconfig.Config) (time.Duration, error) {
-	providerConfig, ok := config.ProviderConfigs[nicoprovider.ProviderName]
+	identity := computenico.Descriptor().Identity()
+	managerConfig, ok := config.ManagerConfigs[identity]
 	if !ok {
-		return 0, nil
+		return computenico.DefaultComputePowerDelay, nil
 	}
-	if providerConfig == nil {
-		return 0, providerapi.ProviderNotConfiguredError{Name: nicoprovider.ProviderName}
+	if managerConfig == nil {
+		return 0, cmconfig.ManagerConfigNotConfiguredError{Identity: identity}
 	}
 
-	nicoConfig, ok := providerConfig.(*nicoprovider.Config)
+	nicoConfig, ok := managerConfig.(*computenico.Config)
 	if !ok {
-		return 0, componentmanager.ProviderConfigTypeMismatchError{
-			Name: nicoprovider.ProviderName,
-			Got:  providerConfig,
-			Want: "*nico.Config",
+		return 0, componentmanager.ManagerConfigTypeMismatchError{
+			Identity: identity,
+			Got:      managerConfig,
+			Want:     (*computenico.Config)(nil),
 		}
 	}
 	return nicoConfig.ComputePowerDelay, nil
+}
+
+func managerConfigDecoderName(decoder cmconfig.ManagerConfigDecoder) string {
+	return decoder.Identity().String()
 }

--- a/flow/internal/task/componentmanager/builtin/manifest.go
+++ b/flow/internal/task/componentmanager/builtin/manifest.go
@@ -45,6 +45,14 @@ func serviceProviderConfigDecoders() []providerapi.ProviderConfigDecoder {
 	}
 }
 
+// serviceManagerConfigDecoders returns all manager config decoders supported
+// by the Flow service.
+func serviceManagerConfigDecoders() []cmconfig.ManagerConfigDecoder {
+	return []cmconfig.ManagerConfigDecoder{
+		computenico.ConfigDecoder{},
+	}
+}
+
 // serviceDescriptors returns all component manager descriptors compiled into
 // the Flow service. Descriptors stay in a separate manifest even though
 // FactorySpec also contains a Descriptor because descriptor metadata is needed

--- a/flow/internal/task/componentmanager/builtin/setup.go
+++ b/flow/internal/task/componentmanager/builtin/setup.go
@@ -28,6 +28,14 @@ func LoadConfig(path string) (cmconfig.Config, error) {
 		)
 	}
 
+	managerDecoderRegistry, err := newManagerConfigDecoderRegistry()
+	if err != nil {
+		return cmconfig.Config{}, fmt.Errorf(
+			"initialize service manager config decoders: %w",
+			err,
+		)
+	}
+
 	catalog, err := newCatalog()
 	if err != nil {
 		return cmconfig.Config{}, err
@@ -39,6 +47,7 @@ func LoadConfig(path string) (cmconfig.Config, error) {
 			path,
 			decoders,
 			catalog,
+			managerDecoderRegistry,
 		)
 		if err != nil {
 			return cmconfig.Config{}, fmt.Errorf("load config from file: %w", err)
@@ -48,13 +57,15 @@ func LoadConfig(path string) (cmconfig.Config, error) {
 			defaultServiceComponentManagers(),
 			decoders,
 			catalog,
+			managerDecoderRegistry,
 		)
 		if err != nil {
 			return cmconfig.Config{}, fmt.Errorf("get default config: %w", err)
 		}
 	}
 
-	if err := config.Validate(decoders, catalog); err != nil {
+	err = config.Validate(decoders, catalog, managerDecoderRegistry)
+	if err != nil {
 		return cmconfig.Config{}, fmt.Errorf("validate loaded config: %w", err)
 	}
 

--- a/flow/internal/task/componentmanager/catalog/catalog.go
+++ b/flow/internal/task/componentmanager/catalog/catalog.go
@@ -14,16 +14,59 @@ import (
 )
 
 // Descriptor describes a component manager implementation registered in this
-// process. The descriptor identity is Type plus Implementation; provider names
-// stay separate because one manager can require multiple providers and one
-// provider can serve multiple component manager implementations. Capabilities
-// describe the operations this manager supports and are used to validate that
-// active managers can execute a task before it is dispatched.
+// process. DescriptorIdentity is Type plus Implementation; provider names stay
+// separate because one manager can require multiple providers and one provider
+// can serve multiple component manager implementations. Capabilities describe
+// the operations this manager supports and are used to validate that active
+// managers can execute a task before it is dispatched.
 type Descriptor struct {
-	Type              devicetypes.ComponentType
-	Implementation    string
+	DescriptorIdentity
 	RequiredProviders []string
 	Capabilities      capability.CapabilitySet
+}
+
+// DescriptorIdentity identifies a component manager implementation. It is the
+// stable key used by catalogs, factory specs, and manager-specific config.
+type DescriptorIdentity struct {
+	Type           devicetypes.ComponentType
+	Implementation string
+}
+
+// String returns the stable component-type/implementation form used in logs and
+// error messages.
+func (i DescriptorIdentity) String() string {
+	return devicetypes.ComponentTypeToString(i.Type) + "/" + i.Implementation
+}
+
+// Normalize validates an identity and returns its normalized value.
+func (i DescriptorIdentity) Normalize() (DescriptorIdentity, error) {
+	if i.Type == devicetypes.ComponentTypeUnknown {
+		return DescriptorIdentity{}, UnknownComponentTypeError{
+			Name: devicetypes.ComponentTypeToString(i.Type),
+		}
+	}
+
+	i.Implementation = strings.TrimSpace(i.Implementation)
+	if i.Implementation == "" {
+		return DescriptorIdentity{}, ComponentManagerImplementationNameEmptyError{
+			ComponentType: i.Type,
+		}
+	}
+
+	return i, nil
+}
+
+func compareDescriptorIdentities(a DescriptorIdentity, b DescriptorIdentity) int {
+	if n := cmp.Compare(a.Type, b.Type); n != 0 {
+		return n
+	}
+	return cmp.Compare(a.Implementation, b.Implementation)
+}
+
+// SortDescriptorIdentities sorts descriptor identities by component type and
+// then implementation name.
+func SortDescriptorIdentities(identities []DescriptorIdentity) {
+	slices.SortFunc(identities, compareDescriptorIdentities)
 }
 
 // Catalog contains the component manager implementations supported by a
@@ -63,17 +106,17 @@ func New(descriptors []Descriptor) (Catalog, error) {
 	return catalog, nil
 }
 
-// Get returns the descriptor for a component type and implementation.
-func (c Catalog) Get(
-	componentType devicetypes.ComponentType,
-	implementation string,
-) (Descriptor, bool) {
-	descriptors := c.descriptors[componentType]
+// Get returns the descriptor for a normalized descriptor identity. Get does
+// not normalize identity; callers should normalize identities built from raw
+// input before calling. Passing an unnormalized identity simply misses and
+// returns false.
+func (c Catalog) Get(identity DescriptorIdentity) (Descriptor, bool) {
+	descriptors := c.descriptors[identity.Type]
 	if descriptors == nil {
 		return Descriptor{}, false
 	}
 
-	descriptor, ok := descriptors[implementation]
+	descriptor, ok := descriptors[identity.Implementation]
 	if !ok {
 		return Descriptor{}, false
 	}
@@ -105,7 +148,12 @@ func (c Catalog) SelectedDescriptors(
 ) ([]Descriptor, error) {
 	descriptors := make([]Descriptor, 0, len(componentManagers))
 	for componentType, implName := range componentManagers {
-		descriptor, ok := c.Get(componentType, implName)
+		descriptor, ok := c.Get(
+			DescriptorIdentity{
+				Type:           componentType,
+				Implementation: implName,
+			},
+		)
 		if !ok {
 			available := c.Implementations(componentType)
 			if len(available) == 0 {
@@ -144,18 +192,12 @@ func (c Catalog) componentTypesForImplementation(
 
 // Normalize validates a descriptor and returns its normalized value.
 func (d Descriptor) Normalize() (Descriptor, error) {
-	if d.Type == devicetypes.ComponentTypeUnknown {
-		return Descriptor{}, UnknownComponentTypeError{
-			Name: devicetypes.ComponentTypeToString(d.Type),
-		}
+	identity, err := d.DescriptorIdentity.Normalize()
+	if err != nil {
+		return Descriptor{}, err
 	}
 
-	d.Implementation = strings.TrimSpace(d.Implementation)
-	if d.Implementation == "" {
-		return Descriptor{}, ComponentManagerImplementationNameEmptyError{
-			ComponentType: d.Type,
-		}
-	}
+	d.DescriptorIdentity = identity
 
 	requiredProviders := make([]string, 0, len(d.RequiredProviders))
 	seen := make(map[string]struct{}, len(d.RequiredProviders))
@@ -182,6 +224,11 @@ func (d Descriptor) Normalize() (Descriptor, error) {
 	return d, nil
 }
 
+// Identity returns the descriptor identity.
+func (d Descriptor) Identity() DescriptorIdentity {
+	return d.DescriptorIdentity
+}
+
 // Clone returns a descriptor copy whose mutable fields do not share storage
 // with the source descriptor.
 func (d Descriptor) Clone() Descriptor {
@@ -201,10 +248,7 @@ func (d Descriptor) Equal(other Descriptor) bool {
 
 func sortDescriptors(descriptors []Descriptor) {
 	slices.SortFunc(descriptors, func(a, b Descriptor) int {
-		if n := cmp.Compare(a.Type, b.Type); n != 0 {
-			return n
-		}
-		return cmp.Compare(a.Implementation, b.Implementation)
+		return compareDescriptorIdentities(a.Identity(), b.Identity())
 	})
 }
 

--- a/flow/internal/task/componentmanager/catalog/catalog_test.go
+++ b/flow/internal/task/componentmanager/catalog/catalog_test.go
@@ -16,8 +16,10 @@ import (
 
 func TestDescriptorNormalize(t *testing.T) {
 	descriptor, err := Descriptor{
-		Type:              devicetypes.ComponentTypeCompute,
-		Implementation:    " custom ",
+		DescriptorIdentity: DescriptorIdentity{
+			Type:           devicetypes.ComponentTypeCompute,
+			Implementation: " custom ",
+		},
 		RequiredProviders: []string{" beta ", "alpha", "beta"},
 		Capabilities: capability.CapabilitySet{
 			capability.CapabilityPowerControl,
@@ -28,8 +30,10 @@ func TestDescriptorNormalize(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, Descriptor{
-		Type:              devicetypes.ComponentTypeCompute,
-		Implementation:    "custom",
+		DescriptorIdentity: DescriptorIdentity{
+			Type:           devicetypes.ComponentTypeCompute,
+			Implementation: "custom",
+		},
 		RequiredProviders: []string{"alpha", "beta"},
 		Capabilities: capability.CapabilitySet{
 			capability.CapabilityFirmwareControl,
@@ -40,8 +44,10 @@ func TestDescriptorNormalize(t *testing.T) {
 
 func TestDescriptorEqual(t *testing.T) {
 	descriptor := Descriptor{
-		Type:              devicetypes.ComponentTypeCompute,
-		Implementation:    "custom",
+		DescriptorIdentity: DescriptorIdentity{
+			Type:           devicetypes.ComponentTypeCompute,
+			Implementation: "custom",
+		},
 		RequiredProviders: []string{"alpha", "beta"},
 		Capabilities: capability.CapabilitySet{
 			capability.CapabilityFirmwareControl,
@@ -50,8 +56,10 @@ func TestDescriptorEqual(t *testing.T) {
 	}
 
 	require.True(t, descriptor.Equal(Descriptor{
-		Type:              devicetypes.ComponentTypeCompute,
-		Implementation:    "custom",
+		DescriptorIdentity: DescriptorIdentity{
+			Type:           devicetypes.ComponentTypeCompute,
+			Implementation: "custom",
+		},
 		RequiredProviders: []string{"alpha", "beta"},
 		Capabilities: capability.CapabilitySet{
 			capability.CapabilityFirmwareControl,
@@ -59,8 +67,10 @@ func TestDescriptorEqual(t *testing.T) {
 		},
 	}))
 	require.False(t, descriptor.Equal(Descriptor{
-		Type:              devicetypes.ComponentTypeNVSwitch,
-		Implementation:    "custom",
+		DescriptorIdentity: DescriptorIdentity{
+			Type:           devicetypes.ComponentTypeNVSwitch,
+			Implementation: "custom",
+		},
 		RequiredProviders: []string{"alpha", "beta"},
 		Capabilities: capability.CapabilitySet{
 			capability.CapabilityFirmwareControl,
@@ -68,8 +78,10 @@ func TestDescriptorEqual(t *testing.T) {
 		},
 	}))
 	require.False(t, descriptor.Equal(Descriptor{
-		Type:              devicetypes.ComponentTypeCompute,
-		Implementation:    "other",
+		DescriptorIdentity: DescriptorIdentity{
+			Type:           devicetypes.ComponentTypeCompute,
+			Implementation: "other",
+		},
 		RequiredProviders: []string{"alpha", "beta"},
 		Capabilities: capability.CapabilitySet{
 			capability.CapabilityFirmwareControl,
@@ -77,8 +89,10 @@ func TestDescriptorEqual(t *testing.T) {
 		},
 	}))
 	require.False(t, descriptor.Equal(Descriptor{
-		Type:              devicetypes.ComponentTypeCompute,
-		Implementation:    "custom",
+		DescriptorIdentity: DescriptorIdentity{
+			Type:           devicetypes.ComponentTypeCompute,
+			Implementation: "custom",
+		},
 		RequiredProviders: []string{"alpha"},
 		Capabilities: capability.CapabilitySet{
 			capability.CapabilityFirmwareControl,
@@ -86,8 +100,10 @@ func TestDescriptorEqual(t *testing.T) {
 		},
 	}))
 	require.False(t, descriptor.Equal(Descriptor{
-		Type:              devicetypes.ComponentTypeCompute,
-		Implementation:    "custom",
+		DescriptorIdentity: DescriptorIdentity{
+			Type:           devicetypes.ComponentTypeCompute,
+			Implementation: "custom",
+		},
 		RequiredProviders: []string{"alpha", "beta"},
 		Capabilities:      capability.CapabilitySet{capability.CapabilityPowerControl},
 	}))
@@ -102,24 +118,30 @@ func TestDescriptorNormalizeRejectsInvalidDescriptor(t *testing.T) {
 		{
 			name: "unknown component type",
 			descriptor: Descriptor{
-				Type:           devicetypes.ComponentTypeUnknown,
-				Implementation: "custom",
+				DescriptorIdentity: DescriptorIdentity{
+					Type:           devicetypes.ComponentTypeUnknown,
+					Implementation: "custom",
+				},
 			},
 			wantErr: ErrUnknownComponentType,
 		},
 		{
 			name: "empty implementation",
 			descriptor: Descriptor{
-				Type:           devicetypes.ComponentTypeCompute,
-				Implementation: " ",
+				DescriptorIdentity: DescriptorIdentity{
+					Type:           devicetypes.ComponentTypeCompute,
+					Implementation: " ",
+				},
 			},
 			wantErr: ErrComponentManagerImplementationNameEmpty,
 		},
 		{
 			name: "empty required provider",
 			descriptor: Descriptor{
-				Type:              devicetypes.ComponentTypeCompute,
-				Implementation:    "custom",
+				DescriptorIdentity: DescriptorIdentity{
+					Type:           devicetypes.ComponentTypeCompute,
+					Implementation: "custom",
+				},
 				RequiredProviders: []string{"nico", " "},
 			},
 			wantErr: providerapi.ErrProviderNameEmpty,
@@ -127,18 +149,22 @@ func TestDescriptorNormalizeRejectsInvalidDescriptor(t *testing.T) {
 		{
 			name: "empty capability",
 			descriptor: Descriptor{
-				Type:           devicetypes.ComponentTypeCompute,
-				Implementation: "custom",
-				Capabilities:   capability.CapabilitySet{" "},
+				DescriptorIdentity: DescriptorIdentity{
+					Type:           devicetypes.ComponentTypeCompute,
+					Implementation: "custom",
+				},
+				Capabilities: capability.CapabilitySet{" "},
 			},
 			wantErr: capability.ErrNameEmpty,
 		},
 		{
 			name: "unknown capability",
 			descriptor: Descriptor{
-				Type:           devicetypes.ComponentTypeCompute,
-				Implementation: "custom",
-				Capabilities:   capability.CapabilitySet{"PowerStatsu"},
+				DescriptorIdentity: DescriptorIdentity{
+					Type:           devicetypes.ComponentTypeCompute,
+					Implementation: "custom",
+				},
+				Capabilities: capability.CapabilitySet{"PowerStatsu"},
 			},
 			wantErr: capability.ErrUnknown,
 		},
@@ -157,32 +183,49 @@ func TestDescriptorNormalizeRejectsInvalidDescriptor(t *testing.T) {
 func TestNewIndexesNormalizedDescriptors(t *testing.T) {
 	catalog, err := New([]Descriptor{
 		{
-			Type:              devicetypes.ComponentTypeCompute,
-			Implementation:    " custom ",
+			DescriptorIdentity: DescriptorIdentity{
+				Type:           devicetypes.ComponentTypeCompute,
+				Implementation: " custom ",
+			},
 			RequiredProviders: []string{" beta ", "alpha", "beta"},
 		},
 		{
-			Type:           devicetypes.ComponentTypeCompute,
-			Implementation: "builtin",
+			DescriptorIdentity: DescriptorIdentity{
+				Type:           devicetypes.ComponentTypeCompute,
+				Implementation: "builtin",
+			},
 		},
 		{
-			Type:           devicetypes.ComponentTypePowerShelf,
-			Implementation: "psm",
+			DescriptorIdentity: DescriptorIdentity{
+				Type:           devicetypes.ComponentTypePowerShelf,
+				Implementation: "psm",
+			},
 		},
 	})
 	require.NoError(t, err)
 
-	descriptor, ok := catalog.Get(devicetypes.ComponentTypeCompute, "custom")
+	descriptor, ok := catalog.Get(DescriptorIdentity{
+		Type:           devicetypes.ComponentTypeCompute,
+		Implementation: "custom",
+	})
 	require.True(t, ok)
 	require.Equal(t, Descriptor{
-		Type:              devicetypes.ComponentTypeCompute,
-		Implementation:    "custom",
+		DescriptorIdentity: DescriptorIdentity{
+			Type:           devicetypes.ComponentTypeCompute,
+			Implementation: "custom",
+		},
 		RequiredProviders: []string{"alpha", "beta"},
 	}, descriptor)
 
-	_, ok = catalog.Get(devicetypes.ComponentTypeCompute, "missing")
+	_, ok = catalog.Get(DescriptorIdentity{
+		Type:           devicetypes.ComponentTypeCompute,
+		Implementation: "missing",
+	})
 	require.False(t, ok)
-	_, ok = catalog.Get(devicetypes.ComponentTypeNVSwitch, "custom")
+	_, ok = catalog.Get(DescriptorIdentity{
+		Type:           devicetypes.ComponentTypeNVSwitch,
+		Implementation: "custom",
+	})
 	require.False(t, ok)
 
 	require.Equal(
@@ -204,8 +247,10 @@ func TestNewIndexesNormalizedDescriptors(t *testing.T) {
 func TestGetReturnsDescriptorCopy(t *testing.T) {
 	catalog, err := New([]Descriptor{
 		{
-			Type:              devicetypes.ComponentTypeCompute,
-			Implementation:    "custom",
+			DescriptorIdentity: DescriptorIdentity{
+				Type:           devicetypes.ComponentTypeCompute,
+				Implementation: "custom",
+			},
 			RequiredProviders: []string{"alpha", "beta"},
 			Capabilities: capability.CapabilitySet{
 				capability.CapabilityFirmwareControl,
@@ -215,12 +260,18 @@ func TestGetReturnsDescriptorCopy(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	descriptor, ok := catalog.Get(devicetypes.ComponentTypeCompute, "custom")
+	descriptor, ok := catalog.Get(DescriptorIdentity{
+		Type:           devicetypes.ComponentTypeCompute,
+		Implementation: "custom",
+	})
 	require.True(t, ok)
 	descriptor.RequiredProviders = append(descriptor.RequiredProviders[:1], "mutated")
 	descriptor.Capabilities = append(descriptor.Capabilities[:1], "Mutated")
 
-	descriptor, ok = catalog.Get(devicetypes.ComponentTypeCompute, "custom")
+	descriptor, ok = catalog.Get(DescriptorIdentity{
+		Type:           devicetypes.ComponentTypeCompute,
+		Implementation: "custom",
+	})
 	require.True(t, ok)
 	require.Equal(t, []string{"alpha", "beta"}, descriptor.RequiredProviders)
 	require.Equal(
@@ -232,7 +283,10 @@ func TestGetReturnsDescriptorCopy(t *testing.T) {
 	descriptor.RequiredProviders[0] = "mutated"
 	descriptor.Capabilities[0] = "Mutated"
 
-	descriptor, ok = catalog.Get(devicetypes.ComponentTypeCompute, "custom")
+	descriptor, ok = catalog.Get(DescriptorIdentity{
+		Type:           devicetypes.ComponentTypeCompute,
+		Implementation: "custom",
+	})
 	require.True(t, ok)
 	require.Equal(t, []string{"alpha", "beta"}, descriptor.RequiredProviders)
 	require.Equal(
@@ -245,12 +299,16 @@ func TestGetReturnsDescriptorCopy(t *testing.T) {
 func TestNewRejectsDuplicateDescriptor(t *testing.T) {
 	_, err := New([]Descriptor{
 		{
-			Type:           devicetypes.ComponentTypeCompute,
-			Implementation: " custom ",
+			DescriptorIdentity: DescriptorIdentity{
+				Type:           devicetypes.ComponentTypeCompute,
+				Implementation: " custom ",
+			},
 		},
 		{
-			Type:           devicetypes.ComponentTypeCompute,
-			Implementation: "custom",
+			DescriptorIdentity: DescriptorIdentity{
+				Type:           devicetypes.ComponentTypeCompute,
+				Implementation: "custom",
+			},
 		},
 	})
 
@@ -266,21 +324,27 @@ func TestNewRejectsDuplicateDescriptor(t *testing.T) {
 func TestSelectedDescriptors(t *testing.T) {
 	catalog, err := New([]Descriptor{
 		{
-			Type:              devicetypes.ComponentTypeNVSwitch,
-			Implementation:    "mock",
+			DescriptorIdentity: DescriptorIdentity{
+				Type:           devicetypes.ComponentTypeNVSwitch,
+				Implementation: "mock",
+			},
 			RequiredProviders: []string{},
 		},
 		{
-			Type:           devicetypes.ComponentTypePowerShelf,
-			Implementation: "multi-provider",
+			DescriptorIdentity: DescriptorIdentity{
+				Type:           devicetypes.ComponentTypePowerShelf,
+				Implementation: "multi-provider",
+			},
 			RequiredProviders: []string{
 				"beta",
 				"alpha",
 			},
 		},
 		{
-			Type:           devicetypes.ComponentTypeCompute,
-			Implementation: "custom",
+			DescriptorIdentity: DescriptorIdentity{
+				Type:           devicetypes.ComponentTypeCompute,
+				Implementation: "custom",
+			},
 			RequiredProviders: []string{
 				"zeta",
 				"alpha",
@@ -298,21 +362,27 @@ func TestSelectedDescriptors(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []Descriptor{
 		{
-			Type:           devicetypes.ComponentTypeCompute,
-			Implementation: "custom",
+			DescriptorIdentity: DescriptorIdentity{
+				Type:           devicetypes.ComponentTypeCompute,
+				Implementation: "custom",
+			},
 			RequiredProviders: []string{
 				"alpha",
 				"zeta",
 			},
 		},
 		{
-			Type:              devicetypes.ComponentTypeNVSwitch,
-			Implementation:    "mock",
+			DescriptorIdentity: DescriptorIdentity{
+				Type:           devicetypes.ComponentTypeNVSwitch,
+				Implementation: "mock",
+			},
 			RequiredProviders: []string{},
 		},
 		{
-			Type:           devicetypes.ComponentTypePowerShelf,
-			Implementation: "multi-provider",
+			DescriptorIdentity: DescriptorIdentity{
+				Type:           devicetypes.ComponentTypePowerShelf,
+				Implementation: "multi-provider",
+			},
 			RequiredProviders: []string{
 				"alpha",
 				"beta",
@@ -324,8 +394,10 @@ func TestSelectedDescriptors(t *testing.T) {
 func TestSelectedDescriptorsReturnsDescriptorCopies(t *testing.T) {
 	catalog, err := New([]Descriptor{
 		{
-			Type:              devicetypes.ComponentTypeCompute,
-			Implementation:    "custom",
+			DescriptorIdentity: DescriptorIdentity{
+				Type:           devicetypes.ComponentTypeCompute,
+				Implementation: "custom",
+			},
 			RequiredProviders: []string{"alpha", "beta"},
 			Capabilities: capability.CapabilitySet{
 				capability.CapabilityFirmwareControl,
@@ -349,8 +421,10 @@ func TestSelectedDescriptorsReturnsDescriptorCopies(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []Descriptor{
 		{
-			Type:              devicetypes.ComponentTypeCompute,
-			Implementation:    "custom",
+			DescriptorIdentity: DescriptorIdentity{
+				Type:           devicetypes.ComponentTypeCompute,
+				Implementation: "custom",
+			},
 			RequiredProviders: []string{"alpha", "beta"},
 			Capabilities: capability.CapabilitySet{
 				capability.CapabilityFirmwareControl,
@@ -363,8 +437,10 @@ func TestSelectedDescriptorsReturnsDescriptorCopies(t *testing.T) {
 func TestSelectedDescriptorsAllowsEmptySelection(t *testing.T) {
 	catalog, err := New([]Descriptor{
 		{
-			Type:           devicetypes.ComponentTypeCompute,
-			Implementation: "custom",
+			DescriptorIdentity: DescriptorIdentity{
+				Type:           devicetypes.ComponentTypeCompute,
+				Implementation: "custom",
+			},
 		},
 	})
 	require.NoError(t, err)
@@ -378,8 +454,10 @@ func TestSelectedDescriptorsAllowsEmptySelection(t *testing.T) {
 func TestSelectedDescriptorsRejectsUnregisteredComponentType(t *testing.T) {
 	catalog, err := New([]Descriptor{
 		{
-			Type:           devicetypes.ComponentTypeCompute,
-			Implementation: "custom",
+			DescriptorIdentity: DescriptorIdentity{
+				Type:           devicetypes.ComponentTypeCompute,
+				Implementation: "custom",
+			},
 		},
 	})
 	require.NoError(t, err)
@@ -400,20 +478,28 @@ func TestSelectedDescriptorsRejectsUnregisteredComponentType(t *testing.T) {
 func TestSelectedDescriptorsRejectsUnknownImplementation(t *testing.T) {
 	catalog, err := New([]Descriptor{
 		{
-			Type:           devicetypes.ComponentTypeCompute,
-			Implementation: "known",
+			DescriptorIdentity: DescriptorIdentity{
+				Type:           devicetypes.ComponentTypeCompute,
+				Implementation: "known",
+			},
 		},
 		{
-			Type:           devicetypes.ComponentTypeCompute,
-			Implementation: "alternate",
+			DescriptorIdentity: DescriptorIdentity{
+				Type:           devicetypes.ComponentTypeCompute,
+				Implementation: "alternate",
+			},
 		},
 		{
-			Type:           devicetypes.ComponentTypeNVSwitch,
-			Implementation: "switch",
+			DescriptorIdentity: DescriptorIdentity{
+				Type:           devicetypes.ComponentTypeNVSwitch,
+				Implementation: "switch",
+			},
 		},
 		{
-			Type:           devicetypes.ComponentTypePowerShelf,
-			Implementation: "switch",
+			DescriptorIdentity: DescriptorIdentity{
+				Type:           devicetypes.ComponentTypePowerShelf,
+				Implementation: "switch",
+			},
 		},
 	})
 	require.NoError(t, err)

--- a/flow/internal/task/componentmanager/compute/nico/config.go
+++ b/flow/internal/task/componentmanager/compute/nico/config.go
@@ -1,0 +1,104 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nico
+
+import (
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	cmcatalog "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/catalog"
+	cmconfig "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/config"
+	"github.com/NVIDIA/infra-controller-rest/flow/pkg/common/devicetypes"
+)
+
+const (
+	// DefaultComputePowerDelay is the default delay between sequential power
+	// control calls for compute trays. A small stagger avoids overwhelming the
+	// power delivery system.
+	DefaultComputePowerDelay = 2 * time.Second
+)
+
+// Config holds manager-specific configuration for compute/nico.
+type Config struct {
+	// ComputePowerDelay is the delay inserted between sequential power control
+	// calls when commanding multiple compute trays. 0 means no delay.
+	ComputePowerDelay time.Duration
+}
+
+type rawConfig struct {
+	ComputePowerDelay string `yaml:"compute_power_delay"`
+}
+
+// Validate verifies that this config is used with the compute/nico descriptor.
+func (*Config) Validate(expectedIdentity cmcatalog.DescriptorIdentity) error {
+	actualIdentity := ConfigDecoder{}.Identity()
+	if expectedIdentity != actualIdentity {
+		return cmconfig.ManagerConfigIdentityMismatchError{
+			Expected: expectedIdentity,
+			Actual:   actualIdentity,
+		}
+	}
+	return nil
+}
+
+// ConfigDecoder owns compute/nico manager config defaults and YAML decoding.
+type ConfigDecoder struct{}
+
+// Identity returns the descriptor identity handled by this decoder.
+func (ConfigDecoder) Identity() cmcatalog.DescriptorIdentity {
+	return cmcatalog.DescriptorIdentity{
+		Type:           devicetypes.ComponentTypeCompute,
+		Implementation: ImplementationName,
+	}
+}
+
+// DefaultConfig returns the default compute/nico manager config.
+func (ConfigDecoder) DefaultConfig() cmconfig.ManagerConfig {
+	return &Config{
+		ComputePowerDelay: DefaultComputePowerDelay,
+	}
+}
+
+// DecodeYAML decodes compute/nico manager YAML into a typed config.
+func (d ConfigDecoder) DecodeYAML(raw yaml.Node) (cmconfig.ManagerConfig, error) {
+	config := d.DefaultConfig().(*Config)
+
+	var parsed rawConfig
+	err := cmconfig.DecodeYAMLStrict(raw, &parsed)
+	if err != nil {
+		return nil, cmconfig.InvalidManagerConfigError{
+			Identity: d.Identity(),
+			Err:      err,
+		}
+	}
+
+	if parsed.ComputePowerDelay != "" {
+		delay, err := time.ParseDuration(parsed.ComputePowerDelay)
+		if err != nil {
+			return nil, cmconfig.InvalidManagerConfigFieldError{
+				Identity: d.Identity(),
+				Field:    "compute_power_delay",
+				Err:      err,
+			}
+		}
+		config.ComputePowerDelay = delay
+	}
+
+	return config, nil
+}

--- a/flow/internal/task/componentmanager/compute/nico/nico.go
+++ b/flow/internal/task/componentmanager/compute/nico/nico.go
@@ -74,8 +74,10 @@ func Factory(powerDelay time.Duration) componentmanager.ManagerFactory {
 // Descriptor returns the NICo compute manager descriptor.
 func Descriptor() cmcatalog.Descriptor {
 	return cmcatalog.Descriptor{
-		Type:              devicetypes.ComponentTypeCompute,
-		Implementation:    ImplementationName,
+		DescriptorIdentity: cmcatalog.DescriptorIdentity{
+			Type:           devicetypes.ComponentTypeCompute,
+			Implementation: ImplementationName,
+		},
 		RequiredProviders: []string{nicoprovider.ProviderName},
 		Capabilities: capability.CapabilitySet{
 			capability.CapabilityBringUpControl,

--- a/flow/internal/task/componentmanager/compute/nico/nico_test.go
+++ b/flow/internal/task/componentmanager/compute/nico/nico_test.go
@@ -6,17 +6,44 @@ package nico
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"github.com/NVIDIA/infra-controller-rest/flow/internal/nicoapi"
 	pb "github.com/NVIDIA/infra-controller-rest/flow/internal/nicoapi/gen"
+	cmconfig "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/config"
 	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/executor/temporalworkflow/common"
 	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/operations"
 	"github.com/NVIDIA/infra-controller-rest/flow/pkg/common/devicetypes"
 )
+
+func TestConfigDecoderDecodeYAML(t *testing.T) {
+	decoder := ConfigDecoder{}
+
+	decoded, err := decoder.DecodeYAML(yaml.Node{})
+	require.NoError(t, err)
+	config := decoded.(*Config)
+	assert.Equal(t, DefaultComputePowerDelay, config.ComputePowerDelay)
+
+	decoded, err = decoder.DecodeYAML(managerYAMLNode(t, `compute_power_delay: 0s`))
+	require.NoError(t, err)
+	config = decoded.(*Config)
+	assert.Equal(t, 0*time.Second, config.ComputePowerDelay)
+
+	_, err = decoder.DecodeYAML(managerYAMLNode(t, `compute_power_delay: nope`))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, cmconfig.ErrInvalidManagerConfigField))
+	assertInvalidManagerConfigField(t, err, "compute_power_delay")
+
+	_, err = decoder.DecodeYAML(managerYAMLNode(t, `compute_power_dely: 15s`))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, cmconfig.ErrInvalidManagerConfig))
+}
 
 func TestInjectExpectation(t *testing.T) {
 	testCases := map[string]struct {
@@ -86,6 +113,24 @@ func mustMarshal(t *testing.T, v any) json.RawMessage {
 		t.Fatalf("failed to marshal: %v", err)
 	}
 	return data
+}
+
+func assertInvalidManagerConfigField(t *testing.T, err error, field string) {
+	t.Helper()
+
+	var fieldErr cmconfig.InvalidManagerConfigFieldError
+	require.True(t, errors.As(err, &fieldErr))
+	assert.Equal(t, ConfigDecoder{}.Identity(), fieldErr.Identity)
+	assert.Equal(t, field, fieldErr.Field)
+}
+
+func managerYAMLNode(t *testing.T, data string) yaml.Node {
+	t.Helper()
+
+	var node yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(data), &node))
+	require.NotEmpty(t, node.Content)
+	return *node.Content[0]
 }
 
 // TestFirmwareControl_SubTargetsAccepted verifies that the compute/nico

--- a/flow/internal/task/componentmanager/config/config.go
+++ b/flow/internal/task/componentmanager/config/config.go
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package config loads, normalizes, and validates component manager
-// configuration.
+// configuration, including component-manager selections, manager-specific
+// configs, and provider/client configs.
 //
 // Config can be built from YAML through LoadConfig or ParseConfig, or from
 // embedded defaults through New. All constructor paths normalize component
-// manager implementation names, decode explicit provider config overrides, and
-// complete missing provider configs from the component manager catalog supplied
-// by the caller.
+// manager implementation names, decode explicit provider and manager config
+// overrides, and complete missing configs from the component manager catalog
+// supplied by the caller.
 package config
 
 import (
@@ -25,12 +26,19 @@ import (
 // normalized: component manager implementation names are trimmed, unknown
 // component types are rejected, explicit provider names are trimmed, duplicate
 // provider names are rejected after trimming, and missing provider configs
-// required by catalog descriptors are completed from provider defaults.
+// required by catalog descriptors are completed from provider defaults. Manager
+// configs are keyed by descriptor identity and completed from manager defaults
+// when a decoder is registered for the selected manager.
 type Config struct {
 	// ComponentManagers maps each component type to the component manager
 	// implementation responsible for managing that type. Each component manager
 	// implementation can use a provider to talk to its external service.
 	ComponentManagers map[devicetypes.ComponentType]string
+
+	// ManagerConfigs holds manager-specific typed configs keyed by descriptor
+	// identity. These configs control manager behavior and are separate from
+	// provider/client settings.
+	ManagerConfigs map[cmcatalog.DescriptorIdentity]ManagerConfig
 
 	// ProviderConfigs holds provider-specific typed configs keyed by provider
 	// name. Explicit provider configs override defaults; missing providers
@@ -41,12 +49,13 @@ type Config struct {
 }
 
 // New builds a component manager config from a component-manager
-// implementation map and derives default provider configs from the supplied
-// catalog.
+// implementation map and derives default provider configs, plus default
+// manager configs when manager decoders are supplied, from the catalog.
 func New(
 	componentManagers map[devicetypes.ComponentType]string,
 	decoders *providerapi.ProviderConfigDecoderRegistry,
 	managerCatalog cmcatalog.Catalog,
+	managerDecoderRegistry *ManagerConfigDecoderRegistry,
 ) (Config, error) {
 	if decoders == nil {
 		return Config{}, ErrProviderConfigDecoderRegistryRequired
@@ -60,9 +69,19 @@ func New(
 		}
 	}
 
-	if err := config.completeProviderConfigs(decoders, managerCatalog); err != nil {
+	err := config.completeProviderConfigs(decoders, managerCatalog)
+	if err != nil {
 		return Config{}, err
 	}
+
+	err = config.completeManagerConfigs(
+		managerDecoderRegistry,
+		managerCatalog,
+	)
+	if err != nil {
+		return Config{}, err
+	}
+
 	return config, nil
 }
 
@@ -72,6 +91,7 @@ func New(
 func newConfig() Config {
 	return Config{
 		ComponentManagers: make(map[devicetypes.ComponentType]string),
+		ManagerConfigs:    make(map[cmcatalog.DescriptorIdentity]ManagerConfig),
 		ProviderConfigs:   make(map[string]providerapi.ProviderConfig),
 	}
 }
@@ -164,10 +184,77 @@ func (c *Config) completeProviderConfigs(
 	return nil
 }
 
-// Validate verifies the generic component manager config contract.
+// addManagerConfig validates a manager config and stores it by descriptor
+// identity. Callers are responsible for passing a normalized expected identity.
+func (c *Config) addManagerConfig(
+	expectedIdentity cmcatalog.DescriptorIdentity,
+	managerConfig ManagerConfig,
+) error {
+	if c == nil {
+		return ErrConfigNotConfigured
+	}
+
+	if managerConfig == nil {
+		return ManagerConfigNotConfiguredError{Identity: expectedIdentity}
+	}
+
+	if err := managerConfig.Validate(expectedIdentity); err != nil {
+		return err
+	}
+
+	if c.ManagerConfigs == nil {
+		c.ManagerConfigs = make(map[cmcatalog.DescriptorIdentity]ManagerConfig)
+	}
+
+	if _, exists := c.ManagerConfigs[expectedIdentity]; exists {
+		return DuplicateManagerConfigError{Identity: expectedIdentity}
+	}
+
+	c.ManagerConfigs[expectedIdentity] = managerConfig
+	return nil
+}
+
+// completeManagerConfigs enables missing manager configs for selected
+// component managers when a manager config decoder is registered. Explicit
+// manager configs already present in the config are preserved.
+func (c *Config) completeManagerConfigs(
+	decoders *ManagerConfigDecoderRegistry,
+	managerCatalog cmcatalog.Catalog,
+) error {
+	if decoders == nil {
+		return nil
+	}
+
+	descriptors, err := managerCatalog.SelectedDescriptors(c.ComponentManagers)
+	if err != nil {
+		return err
+	}
+
+	for _, descriptor := range descriptors {
+		identity := descriptor.Identity()
+		decoder := decoders.Get(identity)
+		if decoder == nil {
+			continue
+		}
+
+		if c.HasManagerConfig(identity) {
+			continue
+		}
+
+		if err := c.addManagerConfig(identity, decoder.DefaultConfig()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Validate verifies the component manager config contract, including selected
+// descriptors, required providers, and manager-specific configs.
 func (c *Config) Validate(
 	decoders *providerapi.ProviderConfigDecoderRegistry,
 	managerCatalog cmcatalog.Catalog,
+	managerDecoderRegistry *ManagerConfigDecoderRegistry,
 ) error {
 	if c == nil {
 		return ErrConfigNotConfigured
@@ -185,8 +272,14 @@ func (c *Config) Validate(
 	if err != nil {
 		return err
 	}
+	selectedIdentities := make(
+		map[cmcatalog.DescriptorIdentity]struct{},
+		len(descriptors),
+	)
 
 	for _, descriptor := range descriptors {
+		selectedIdentities[descriptor.Identity()] = struct{}{}
+
 		for _, providerName := range descriptor.RequiredProviders {
 			if _, ok := decoders.Get(providerName); !ok {
 				return ProviderConfigDecoderNotRegisteredError{
@@ -206,6 +299,36 @@ func (c *Config) Validate(
 		}
 	}
 
+	for identity, managerConfig := range c.ManagerConfigs {
+		normalizedIdentity, err := identity.Normalize()
+		if err != nil {
+			return err
+		}
+
+		if identity != normalizedIdentity {
+			return ManagerConfigIdentityMismatchError{
+				Expected: normalizedIdentity,
+				Actual:   identity,
+			}
+		}
+
+		if _, ok := selectedIdentities[identity]; !ok {
+			return ManagerConfigNotSelectedError{Identity: identity}
+		}
+
+		if managerDecoderRegistry != nil && managerDecoderRegistry.Get(identity) == nil {
+			return ManagerConfigDecoderNotRegisteredError{Identity: identity}
+		}
+
+		if managerConfig == nil {
+			return ManagerConfigNotConfiguredError{Identity: identity}
+		}
+
+		if err := managerConfig.Validate(identity); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -213,6 +336,20 @@ func (c *Config) Validate(
 func (c *Config) HasProvider(name string) bool {
 	if c != nil && c.ProviderConfigs != nil {
 		if _, ok := c.ProviderConfigs[name]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+// HasManagerConfig checks if a manager config is enabled for a normalized
+// descriptor identity. HasManagerConfig does not normalize identity; callers
+// should normalize identities built from raw input before calling. Passing an
+// unnormalized identity simply misses and returns false.
+func (c *Config) HasManagerConfig(identity cmcatalog.DescriptorIdentity) bool {
+	if c != nil && c.ManagerConfigs != nil {
+		if _, ok := c.ManagerConfigs[identity]; ok {
 			return true
 		}
 	}

--- a/flow/internal/task/componentmanager/config/config_test.go
+++ b/flow/internal/task/componentmanager/config/config_test.go
@@ -51,6 +51,62 @@ func (d customProviderConfigDecoder) DecodeYAML(raw yaml.Node) (providerapi.Prov
 	return d.DefaultConfig(), nil
 }
 
+type customManagerConfig struct {
+	identity cmcatalog.DescriptorIdentity
+	value    string
+}
+
+func (c customManagerConfig) Validate(expectedIdentity cmcatalog.DescriptorIdentity) error {
+	if c.identity != expectedIdentity {
+		return ManagerConfigIdentityMismatchError{
+			Expected: expectedIdentity,
+			Actual:   c.identity,
+		}
+	}
+	return nil
+}
+
+type customManagerConfigDecoder struct {
+	identity       cmcatalog.DescriptorIdentity
+	configIdentity cmcatalog.DescriptorIdentity
+	defaultValue   string
+}
+
+func (d customManagerConfigDecoder) Identity() cmcatalog.DescriptorIdentity {
+	return d.identity
+}
+
+func (d customManagerConfigDecoder) DefaultConfig() ManagerConfig {
+	return customManagerConfig{
+		identity: d.managerConfigIdentity(),
+		value:    d.defaultValue,
+	}
+}
+
+func (d customManagerConfigDecoder) managerConfigIdentity() cmcatalog.DescriptorIdentity {
+	if d.configIdentity != (cmcatalog.DescriptorIdentity{}) {
+		return d.configIdentity
+	}
+	return d.identity
+}
+
+func (d customManagerConfigDecoder) DecodeYAML(raw yaml.Node) (ManagerConfig, error) {
+	config := d.DefaultConfig().(customManagerConfig)
+	var parsed struct {
+		Value string `yaml:"value"`
+	}
+	if err := DecodeYAMLStrict(raw, &parsed); err != nil {
+		return nil, InvalidManagerConfigError{
+			Identity: d.identity,
+			Err:      err,
+		}
+	}
+	if parsed.Value != "" {
+		config.value = parsed.Value
+	}
+	return config, nil
+}
+
 func TestParseConfigWithExplicitProviders(t *testing.T) {
 	config, err := parseConfigWithBuiltins(t, `
 component_managers:
@@ -60,7 +116,6 @@ component_managers:
 providers:
   nico:
     timeout: 45s
-    compute_power_delay: 0s
   psm:
     timeout: 20s
   nvswitchmanager:
@@ -75,7 +130,6 @@ providers:
 	nicoConfig, ok := config.ProviderConfigs[nico.ProviderName].(*nico.Config)
 	require.True(t, ok)
 	assert.Equal(t, 45*time.Second, nicoConfig.Timeout)
-	assert.Equal(t, 0*time.Second, nicoConfig.ComputePowerDelay)
 
 	psmConfig, ok := config.ProviderConfigs[psm.ProviderName].(*psm.Config)
 	require.True(t, ok)
@@ -164,11 +218,6 @@ providers:
 	nicoConfig, ok := config.ProviderConfigs[nico.ProviderName].(*nico.Config)
 	require.True(t, ok)
 	assert.Equal(t, nico.DefaultTimeout, nicoConfig.Timeout)
-	assert.Equal(
-		t,
-		nico.DefaultComputePowerDelay,
-		nicoConfig.ComputePowerDelay,
-	)
 
 	psmConfig, ok := config.ProviderConfigs[psm.ProviderName].(*psm.Config)
 	require.True(t, ok)
@@ -185,7 +234,7 @@ providers: {}
 
 	assert.True(t, config.HasProvider(nico.ProviderName))
 
-	err = config.Validate(serviceProviderConfigDecoderRegistry(t), testCatalog(t))
+	err = config.Validate(serviceProviderConfigDecoderRegistry(t), testCatalog(t), nil)
 	require.NoError(t, err)
 }
 
@@ -327,7 +376,7 @@ component_managers:
   compute: mock
 providers:
   custom: {}
-`), registry, testCatalog(t))
+`), registry, testCatalog(t), nil)
 	require.NoError(t, err)
 
 	assert.True(t, config.HasProvider("custom"))
@@ -341,7 +390,7 @@ func TestParseConfigDerivesProviderForDifferentImplementationName(t *testing.T) 
 	config, err := ParseConfig([]byte(`
 component_managers:
   compute: custom-manager
-`), registry, testCatalog(t))
+`), registry, testCatalog(t), nil)
 	require.NoError(t, err)
 
 	assert.True(t, config.HasProvider("custom"))
@@ -354,21 +403,182 @@ func TestParseConfigDerivesMultipleProvidersForManager(t *testing.T) {
 	config, err := ParseConfig([]byte(`
 component_managers:
   compute: multi-provider
-`), registry, testCatalog(t))
+`), registry, testCatalog(t), nil)
 	require.NoError(t, err)
 
 	assert.True(t, config.HasProvider("custom"))
 	assert.True(t, config.HasProvider(nico.ProviderName))
 }
 
+func TestParseConfigRejectsManagerConfigFieldInProviderConfig(t *testing.T) {
+	_, err := ParseConfig([]byte(`
+component_managers:
+  compute: nico
+providers:
+  nico:
+    compute_power_delay: 0s
+`), serviceProviderConfigDecoderRegistry(t), testCatalog(t), nil)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, providerapi.ErrInvalidProviderConfig))
+}
+
+func TestParseConfigWithExplicitManagerConfigs(t *testing.T) {
+	identity := testManagerConfigIdentity()
+	managerDecoders := testManagerConfigDecoderRegistry(t, customManagerConfigDecoder{
+		identity:     identity,
+		defaultValue: "default",
+	})
+
+	config, err := ParseConfig([]byte(`
+component_managers:
+  compute: configurable-manager
+manager_configs:
+  compute:
+    configurable-manager:
+      value: configured
+`), serviceProviderConfigDecoderRegistry(t), testCatalog(t), managerDecoders)
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		customManagerConfig{
+			identity: identity,
+			value:    "configured",
+		},
+		config.ManagerConfigs[identity],
+	)
+}
+
+func TestParseConfigRejectsManagerConfigUnknownImplementation(t *testing.T) {
+	_, err := ParseConfig([]byte(`
+component_managers:
+  compute: psm
+manager_configs:
+  compute:
+    psm:
+      value: configured
+`), serviceProviderConfigDecoderRegistry(t), testCatalog(t), NewManagerConfigDecoderRegistry())
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, cmcatalog.ErrUnknownComponentManagerImplementation))
+
+	var implErr cmcatalog.UnknownComponentManagerImplementationError
+	require.True(t, errors.As(err, &implErr))
+	assert.Equal(t, devicetypes.ComponentTypeCompute, implErr.ComponentType)
+	assert.Equal(t, psm.ProviderName, implErr.Implementation)
+	assert.Contains(t, implErr.Available, nico.ProviderName)
+}
+
+func TestParseConfigCompletesDefaultManagerConfigs(t *testing.T) {
+	identity := testManagerConfigIdentity()
+	managerDecoders := testManagerConfigDecoderRegistry(t, customManagerConfigDecoder{
+		identity:     identity,
+		defaultValue: "default",
+	})
+
+	config, err := New(
+		map[devicetypes.ComponentType]string{
+			devicetypes.ComponentTypeCompute: "configurable-manager",
+		},
+		serviceProviderConfigDecoderRegistry(t),
+		testCatalog(t),
+		managerDecoders,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		customManagerConfig{
+			identity: identity,
+			value:    "default",
+		},
+		config.ManagerConfigs[identity],
+	)
+}
+
+func TestNewConfigRejectsManagerConfigIdentityMismatch(t *testing.T) {
+	identity := testManagerConfigIdentity()
+	actualIdentity := cmcatalog.DescriptorIdentity{
+		Type:           devicetypes.ComponentTypeCompute,
+		Implementation: "custom-manager",
+	}
+	managerDecoders := testManagerConfigDecoderRegistry(t, customManagerConfigDecoder{
+		identity:       identity,
+		configIdentity: actualIdentity,
+		defaultValue:   "default",
+	})
+
+	_, err := New(
+		map[devicetypes.ComponentType]string{
+			devicetypes.ComponentTypeCompute: "configurable-manager",
+		},
+		serviceProviderConfigDecoderRegistry(t),
+		testCatalog(t),
+		managerDecoders,
+	)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrManagerConfigIdentityMismatch))
+
+	var mismatch ManagerConfigIdentityMismatchError
+	require.True(t, errors.As(err, &mismatch))
+	assert.Equal(t, identity, mismatch.Expected)
+	assert.Equal(t, actualIdentity, mismatch.Actual)
+}
+
+func TestValidateRejectsUnnormalizedManagerConfigIdentity(t *testing.T) {
+	identity := testManagerConfigIdentity()
+	rawIdentity := cmcatalog.DescriptorIdentity{
+		Type:           identity.Type,
+		Implementation: " configurable-manager ",
+	}
+	config := Config{
+		ComponentManagers: map[devicetypes.ComponentType]string{
+			devicetypes.ComponentTypeCompute: "configurable-manager",
+		},
+		ManagerConfigs: map[cmcatalog.DescriptorIdentity]ManagerConfig{
+			rawIdentity: customManagerConfig{identity: identity},
+		},
+		ProviderConfigs: map[string]providerapi.ProviderConfig{},
+	}
+
+	err := config.Validate(
+		serviceProviderConfigDecoderRegistry(t),
+		testCatalog(t),
+		testManagerConfigDecoderRegistry(t, customManagerConfigDecoder{identity: identity}),
+	)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrManagerConfigIdentityMismatch))
+
+	var mismatch ManagerConfigIdentityMismatchError
+	require.True(t, errors.As(err, &mismatch))
+	assert.Equal(t, identity, mismatch.Expected)
+	assert.Equal(t, rawIdentity, mismatch.Actual)
+}
+
 func TestParseConfigRequiresDecoderRegistry(t *testing.T) {
-	_, err := ParseConfig([]byte(`component_managers: {}`), nil, cmcatalog.Catalog{})
+	_, err := ParseConfig([]byte(`component_managers: {}`), nil, cmcatalog.Catalog{}, nil)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrProviderConfigDecoderRegistryRequired))
 }
 
+func TestParseConfigRequiresManagerDecoderRegistryForManagerConfigs(t *testing.T) {
+	_, err := ParseConfig([]byte(`
+component_managers:
+  compute: configurable-manager
+manager_configs:
+  compute:
+    configurable-manager:
+      value: configured
+`), serviceProviderConfigDecoderRegistry(t), testCatalog(t), nil)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrManagerConfigDecoderRegistryRequired))
+}
+
 func TestNewConfigRequiresDecoderRegistry(t *testing.T) {
-	_, err := New(map[devicetypes.ComponentType]string{}, nil, cmcatalog.Catalog{})
+	_, err := New(map[devicetypes.ComponentType]string{}, nil, cmcatalog.Catalog{}, nil)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrProviderConfigDecoderRegistryRequired))
 }
@@ -376,7 +586,7 @@ func TestNewConfigRequiresDecoderRegistry(t *testing.T) {
 func TestValidateRequiresConfig(t *testing.T) {
 	var config *Config
 
-	err := config.Validate(serviceProviderConfigDecoderRegistry(t), cmcatalog.Catalog{})
+	err := config.Validate(serviceProviderConfigDecoderRegistry(t), cmcatalog.Catalog{}, nil)
 
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrConfigNotConfigured))
@@ -393,6 +603,7 @@ func TestValidateReportsRequiredProviderManagerIdentity(t *testing.T) {
 	err := config.Validate(
 		serviceProviderConfigDecoderRegistry(t),
 		testCatalog(t),
+		nil,
 	)
 
 	require.Error(t, err)
@@ -460,6 +671,7 @@ func TestNewConfigDerivesDefaultProviderConfigs(t *testing.T) {
 		},
 		serviceProviderConfigDecoderRegistry(t),
 		testCatalog(t),
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -467,11 +679,6 @@ func TestNewConfigDerivesDefaultProviderConfigs(t *testing.T) {
 	nicoConfig, ok := config.ProviderConfigs[nico.ProviderName].(*nico.Config)
 	require.True(t, ok)
 	assert.Equal(t, nico.DefaultTimeout, nicoConfig.Timeout)
-	assert.Equal(
-		t,
-		nico.DefaultComputePowerDelay,
-		nicoConfig.ComputePowerDelay,
-	)
 }
 
 func TestLoadConfig(t *testing.T) {
@@ -486,6 +693,7 @@ component_managers:
 		path,
 		serviceProviderConfigDecoderRegistry(t),
 		testCatalog(t),
+		nil,
 	)
 	require.NoError(t, err)
 	assert.True(t, config.HasProvider(nico.ProviderName))
@@ -505,6 +713,7 @@ func parseConfigWithBuiltins(t *testing.T, data string) (Config, error) {
 		[]byte(data),
 		serviceProviderConfigDecoderRegistry(t),
 		testCatalog(t),
+		nil,
 	)
 }
 
@@ -513,50 +722,76 @@ func testCatalog(t *testing.T) cmcatalog.Catalog {
 
 	catalog, err := cmcatalog.New([]cmcatalog.Descriptor{
 		{
-			Type:           devicetypes.ComponentTypeCompute,
-			Implementation: "mock",
+			DescriptorIdentity: cmcatalog.DescriptorIdentity{
+				Type:           devicetypes.ComponentTypeCompute,
+				Implementation: "mock",
+			},
 		},
 		{
-			Type:           devicetypes.ComponentTypeNVSwitch,
-			Implementation: "mock",
+			DescriptorIdentity: cmcatalog.DescriptorIdentity{
+				Type:           devicetypes.ComponentTypeNVSwitch,
+				Implementation: "mock",
+			},
 		},
 		{
-			Type:           devicetypes.ComponentTypePowerShelf,
-			Implementation: "mock",
+			DescriptorIdentity: cmcatalog.DescriptorIdentity{
+				Type:           devicetypes.ComponentTypePowerShelf,
+				Implementation: "mock",
+			},
 		},
 		{
-			Type:              devicetypes.ComponentTypeCompute,
-			Implementation:    nico.ProviderName,
+			DescriptorIdentity: cmcatalog.DescriptorIdentity{
+				Type:           devicetypes.ComponentTypeCompute,
+				Implementation: nico.ProviderName,
+			},
 			RequiredProviders: []string{nico.ProviderName},
 		},
 		{
-			Type:              devicetypes.ComponentTypeNVSwitch,
-			Implementation:    nico.ProviderName,
+			DescriptorIdentity: cmcatalog.DescriptorIdentity{
+				Type:           devicetypes.ComponentTypeNVSwitch,
+				Implementation: nico.ProviderName,
+			},
 			RequiredProviders: []string{nico.ProviderName},
 		},
 		{
-			Type:              devicetypes.ComponentTypePowerShelf,
-			Implementation:    nico.ProviderName,
+			DescriptorIdentity: cmcatalog.DescriptorIdentity{
+				Type:           devicetypes.ComponentTypePowerShelf,
+				Implementation: nico.ProviderName,
+			},
 			RequiredProviders: []string{nico.ProviderName},
 		},
 		{
-			Type:              devicetypes.ComponentTypePowerShelf,
-			Implementation:    psm.ProviderName,
+			DescriptorIdentity: cmcatalog.DescriptorIdentity{
+				Type:           devicetypes.ComponentTypePowerShelf,
+				Implementation: psm.ProviderName,
+			},
 			RequiredProviders: []string{psm.ProviderName},
 		},
 		{
-			Type:              devicetypes.ComponentTypeNVSwitch,
-			Implementation:    nvswitchmanager.ProviderName,
+			DescriptorIdentity: cmcatalog.DescriptorIdentity{
+				Type:           devicetypes.ComponentTypeNVSwitch,
+				Implementation: nvswitchmanager.ProviderName,
+			},
 			RequiredProviders: []string{nvswitchmanager.ProviderName},
 		},
 		{
-			Type:              devicetypes.ComponentTypeCompute,
-			Implementation:    "custom-manager",
+			DescriptorIdentity: cmcatalog.DescriptorIdentity{
+				Type:           devicetypes.ComponentTypeCompute,
+				Implementation: "custom-manager",
+			},
 			RequiredProviders: []string{"custom"},
 		},
 		{
-			Type:           devicetypes.ComponentTypeCompute,
-			Implementation: "multi-provider",
+			DescriptorIdentity: cmcatalog.DescriptorIdentity{
+				Type:           devicetypes.ComponentTypeCompute,
+				Implementation: "configurable-manager",
+			},
+		},
+		{
+			DescriptorIdentity: cmcatalog.DescriptorIdentity{
+				Type:           devicetypes.ComponentTypeCompute,
+				Implementation: "multi-provider",
+			},
 			RequiredProviders: []string{
 				"custom",
 				nico.ProviderName,
@@ -574,5 +809,24 @@ func serviceProviderConfigDecoderRegistry(t *testing.T) *providerapi.ProviderCon
 	require.NoError(t, registry.Register(nico.ConfigDecoder{}))
 	require.NoError(t, registry.Register(psm.ConfigDecoder{}))
 	require.NoError(t, registry.Register(nvswitchmanager.ConfigDecoder{}))
+	return registry
+}
+
+func testManagerConfigIdentity() cmcatalog.DescriptorIdentity {
+	return cmcatalog.DescriptorIdentity{
+		Type:           devicetypes.ComponentTypeCompute,
+		Implementation: "configurable-manager",
+	}
+}
+
+func testManagerConfigDecoderRegistry(
+	t *testing.T,
+	decoders ...ManagerConfigDecoder,
+) *ManagerConfigDecoderRegistry {
+	t.Helper()
+	registry := NewManagerConfigDecoderRegistry()
+	for _, decoder := range decoders {
+		require.NoError(t, registry.Register(decoder))
+	}
 	return registry
 }

--- a/flow/internal/task/componentmanager/config/errors.go
+++ b/flow/internal/task/componentmanager/config/errors.go
@@ -32,13 +32,56 @@ var (
 	// provider names are normalized.
 	ErrDuplicateProviderConfig = errors.New("duplicate provider config")
 
+	// ErrDuplicateManagerConfig reports duplicate manager configuration after
+	// descriptor identities are normalized.
+	ErrDuplicateManagerConfig = errors.New("duplicate manager config")
+
 	// ErrProviderConfigDecoderNotRegistered reports that a provider is required
 	// but no config decoder is registered for it.
 	ErrProviderConfigDecoderNotRegistered = errors.New("provider config decoder is not registered")
 
+	// ErrManagerConfigDecoderNotRegistered reports that a manager config was
+	// provided but no decoder is registered for that descriptor identity.
+	ErrManagerConfigDecoderNotRegistered = errors.New("manager config decoder is not registered")
+
 	// ErrProviderConfigDecoderRegistryRequired reports that a config operation
 	// requires a provider config decoder registry argument.
 	ErrProviderConfigDecoderRegistryRequired = errors.New("provider config decoder registry is required")
+
+	// ErrManagerConfigDecoderRegistryRequired reports that manager YAML config
+	// was provided without a manager config decoder registry.
+	ErrManagerConfigDecoderRegistryRequired = errors.New("manager config decoder registry is required")
+
+	// ErrManagerConfigDecoderRegistryNotConfigured reports that a decoder
+	// registry was required but not configured.
+	ErrManagerConfigDecoderRegistryNotConfigured = errors.New("manager config decoder registry is not configured")
+
+	// ErrManagerConfigDecoderNotConfigured reports that a nil manager config
+	// decoder was provided for registration.
+	ErrManagerConfigDecoderNotConfigured = errors.New("manager config decoder is not configured")
+
+	// ErrManagerConfigDecoderAlreadyRegistered reports a duplicate manager
+	// config decoder registration.
+	ErrManagerConfigDecoderAlreadyRegistered = errors.New("manager config decoder already registered")
+
+	// ErrManagerConfigNotConfigured reports that a nil manager config was
+	// provided where a typed config value is required.
+	ErrManagerConfigNotConfigured = errors.New("manager config is not configured")
+
+	// ErrManagerConfigIdentityMismatch reports that a manager config value was
+	// used with a descriptor identity it does not support.
+	ErrManagerConfigIdentityMismatch = errors.New("manager config identity mismatch")
+
+	// ErrManagerConfigNotSelected reports that manager-specific config was
+	// provided for a manager that is not selected by component_managers.
+	ErrManagerConfigNotSelected = errors.New("manager config is not selected")
+
+	// ErrInvalidManagerConfig reports that manager-specific YAML was invalid.
+	ErrInvalidManagerConfig = errors.New("invalid manager config")
+
+	// ErrInvalidManagerConfigField reports that a manager config field value was
+	// invalid.
+	ErrInvalidManagerConfigField = errors.New("invalid manager config field")
 )
 
 // UnknownComponentTypeError includes the unrecognized component type string.
@@ -60,6 +103,23 @@ func (e DuplicateProviderConfigError) Error() string {
 
 func (e DuplicateProviderConfigError) Is(target error) bool {
 	return target == ErrDuplicateProviderConfig
+}
+
+// DuplicateManagerConfigError includes the normalized duplicate descriptor
+// identity.
+type DuplicateManagerConfigError struct {
+	Identity cmcatalog.DescriptorIdentity
+}
+
+func (e DuplicateManagerConfigError) Error() string {
+	return fmt.Sprintf(
+		"duplicate manager config for %q",
+		e.Identity.String(),
+	)
+}
+
+func (e DuplicateManagerConfigError) Is(target error) bool {
+	return target == ErrDuplicateManagerConfig
 }
 
 // ProviderConfigDecoderNotRegisteredError includes the provider name with no
@@ -88,6 +148,157 @@ func (e ProviderConfigDecoderNotRegisteredError) Error() string {
 
 func (e ProviderConfigDecoderNotRegisteredError) Is(target error) bool {
 	return target == ErrProviderConfigDecoderNotRegistered
+}
+
+// ManagerConfigDecoderNotRegisteredError includes the manager identity with no
+// registered config decoder.
+type ManagerConfigDecoderNotRegisteredError struct {
+	Identity cmcatalog.DescriptorIdentity
+}
+
+func (e ManagerConfigDecoderNotRegisteredError) Error() string {
+	return fmt.Sprintf(
+		"manager config decoder for %q is not registered",
+		e.Identity.String(),
+	)
+}
+
+func (e ManagerConfigDecoderNotRegisteredError) Is(target error) bool {
+	return target == ErrManagerConfigDecoderNotRegistered
+}
+
+// ManagerConfigDecoderAlreadyRegisteredError includes the duplicate descriptor
+// identity.
+type ManagerConfigDecoderAlreadyRegisteredError struct {
+	Identity cmcatalog.DescriptorIdentity
+}
+
+func (e ManagerConfigDecoderAlreadyRegisteredError) Error() string {
+	return fmt.Sprintf(
+		"manager config decoder for %q already registered",
+		e.Identity.String(),
+	)
+}
+
+func (e ManagerConfigDecoderAlreadyRegisteredError) Is(target error) bool {
+	return target == ErrManagerConfigDecoderAlreadyRegistered
+}
+
+// ManagerConfigNotConfiguredError includes the manager identity whose config
+// was required but nil.
+type ManagerConfigNotConfiguredError struct {
+	Identity cmcatalog.DescriptorIdentity
+}
+
+func (e ManagerConfigNotConfiguredError) Error() string {
+	if e.Identity == (cmcatalog.DescriptorIdentity{}) {
+		return ErrManagerConfigNotConfigured.Error()
+	}
+	return fmt.Sprintf(
+		"%s: %s",
+		ErrManagerConfigNotConfigured,
+		e.Identity.String(),
+	)
+}
+
+func (e ManagerConfigNotConfiguredError) Is(target error) bool {
+	return target == ErrManagerConfigNotConfigured
+}
+
+// ManagerConfigIdentityMismatchError includes the expected descriptor identity
+// and the identity supported by the manager config value.
+type ManagerConfigIdentityMismatchError struct {
+	Expected cmcatalog.DescriptorIdentity
+	Actual   cmcatalog.DescriptorIdentity
+}
+
+func (e ManagerConfigIdentityMismatchError) Error() string {
+	return fmt.Sprintf(
+		"manager config identity mismatch: expected %s, got %s",
+		e.Expected.String(),
+		e.Actual.String(),
+	)
+}
+
+func (e ManagerConfigIdentityMismatchError) Is(target error) bool {
+	return target == ErrManagerConfigIdentityMismatch
+}
+
+// ManagerConfigNotSelectedError includes a manager config identity that is not
+// selected by component_managers.
+type ManagerConfigNotSelectedError struct {
+	Identity               cmcatalog.DescriptorIdentity
+	SelectedImplementation string
+}
+
+func (e ManagerConfigNotSelectedError) Error() string {
+	if e.SelectedImplementation == "" {
+		return fmt.Sprintf(
+			"manager config for %s is not selected by component_managers",
+			e.Identity.String(),
+		)
+	}
+	return fmt.Sprintf(
+		"manager config for %s is not selected by component_managers; selected implementation is %q",
+		e.Identity.String(),
+		e.SelectedImplementation,
+	)
+}
+
+func (e ManagerConfigNotSelectedError) Is(target error) bool {
+	return target == ErrManagerConfigNotSelected
+}
+
+// InvalidManagerConfigError wraps manager-specific YAML decode errors.
+type InvalidManagerConfigError struct {
+	Identity cmcatalog.DescriptorIdentity
+	Err      error
+}
+
+func (e InvalidManagerConfigError) Error() string {
+	msg := fmt.Sprintf(
+		"invalid component manager %s config",
+		e.Identity.String(),
+	)
+	if e.Err == nil {
+		return msg
+	}
+	return fmt.Sprintf("%s: %v", msg, e.Err)
+}
+
+func (e InvalidManagerConfigError) Unwrap() error {
+	return e.Err
+}
+
+func (e InvalidManagerConfigError) Is(target error) bool {
+	return target == ErrInvalidManagerConfig
+}
+
+// InvalidManagerConfigFieldError wraps invalid manager config field values.
+type InvalidManagerConfigFieldError struct {
+	Identity cmcatalog.DescriptorIdentity
+	Field    string
+	Err      error
+}
+
+func (e InvalidManagerConfigFieldError) Error() string {
+	msg := fmt.Sprintf(
+		"invalid component manager %s %s",
+		e.Identity.String(),
+		e.Field,
+	)
+	if e.Err == nil {
+		return msg
+	}
+	return fmt.Sprintf("%s: %v", msg, e.Err)
+}
+
+func (e InvalidManagerConfigFieldError) Unwrap() error {
+	return e.Err
+}
+
+func (e InvalidManagerConfigFieldError) Is(target error) bool {
+	return target == ErrInvalidManagerConfigField
 }
 
 // RequiredProviderNotConfiguredError includes the required provider and the

--- a/flow/internal/task/componentmanager/config/manager_config.go
+++ b/flow/internal/task/componentmanager/config/manager_config.go
@@ -1,0 +1,147 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+// This file defines the manager-specific config contract: typed configs, YAML
+// decoders, the decoder registry, and shared decoding helpers.
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+
+	cmcatalog "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/catalog"
+)
+
+// ManagerConfig is a decoded manager-specific configuration value.
+type ManagerConfig interface {
+	// Validate verifies this config is valid for the normalized descriptor
+	// identity supplied by Config.ManagerConfigs.
+	Validate(expectedIdentity cmcatalog.DescriptorIdentity) error
+}
+
+// ManagerConfigDecoder owns manager-specific config defaults and YAML decoding
+// for one descriptor identity.
+type ManagerConfigDecoder interface {
+	// Identity returns the descriptor identity handled by this decoder.
+	Identity() cmcatalog.DescriptorIdentity
+
+	// DefaultConfig returns a typed default config for this manager.
+	DefaultConfig() ManagerConfig
+
+	// DecodeYAML decodes a manager-specific YAML node into a typed config.
+	DecodeYAML(raw yaml.Node) (ManagerConfig, error)
+}
+
+// ManagerConfigDecoderRegistry manages manager config decoders by descriptor
+// identity.
+type ManagerConfigDecoderRegistry struct {
+	mu       sync.RWMutex
+	decoders map[cmcatalog.DescriptorIdentity]ManagerConfigDecoder
+}
+
+// NewManagerConfigDecoderRegistry creates a new ManagerConfigDecoderRegistry.
+func NewManagerConfigDecoderRegistry() *ManagerConfigDecoderRegistry {
+	return &ManagerConfigDecoderRegistry{
+		decoders: make(map[cmcatalog.DescriptorIdentity]ManagerConfigDecoder),
+	}
+}
+
+// Register adds a manager config decoder to the registry using the decoder's
+// normalized descriptor identity.
+func (r *ManagerConfigDecoderRegistry) Register(decoder ManagerConfigDecoder) error {
+	if r == nil {
+		return ErrManagerConfigDecoderRegistryNotConfigured
+	}
+
+	if decoder == nil {
+		return ErrManagerConfigDecoderNotConfigured
+	}
+
+	identity, err := decoder.Identity().Normalize()
+	if err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.decoders[identity]; exists {
+		return ManagerConfigDecoderAlreadyRegisteredError{Identity: identity}
+	}
+
+	r.decoders[identity] = decoder
+	return nil
+}
+
+// Get retrieves a manager config decoder by normalized descriptor identity.
+// Get does not normalize identity; callers should normalize and handle any
+// error before calling. Passing an unnormalized identity simply misses and
+// returns nil. A nil registry behaves like an empty registry.
+func (r *ManagerConfigDecoderRegistry) Get(
+	identity cmcatalog.DescriptorIdentity,
+) ManagerConfigDecoder {
+	if r == nil {
+		return nil
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return r.decoders[identity]
+}
+
+// List returns all registered manager config decoder identities, sorted by
+// component type and implementation.
+func (r *ManagerConfigDecoderRegistry) List() []cmcatalog.DescriptorIdentity {
+	if r == nil {
+		return nil
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	identities := make([]cmcatalog.DescriptorIdentity, 0, len(r.decoders))
+	for identity := range r.decoders {
+		identities = append(identities, identity)
+	}
+	cmcatalog.SortDescriptorIdentities(identities)
+	return identities
+}
+
+// DecodeYAMLStrict decodes a YAML node into out and rejects unknown fields. An
+// empty node is treated as "no manager-specific YAML"; callers keep their
+// default config values in that case. The node is accepted by value to match
+// ManagerConfigDecoder.DecodeYAML; yaml.Node's nested content is still shared.
+func DecodeYAMLStrict(raw yaml.Node, out any) error {
+	if raw.Kind == 0 {
+		return nil
+	}
+
+	data, err := yaml.Marshal(&raw)
+	if err != nil {
+		return fmt.Errorf("marshal YAML node: %w", err)
+	}
+
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+
+	return decoder.Decode(out)
+}

--- a/flow/internal/task/componentmanager/config/yaml.go
+++ b/flow/internal/task/componentmanager/config/yaml.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -16,32 +17,36 @@ import (
 )
 
 // LoadConfig loads the component manager configuration from a YAML file using
-// the supplied provider config decoders and component manager catalog.
+// the supplied provider config decoders, manager config decoders, and component
+// manager catalog.
 func LoadConfig(
 	path string,
 	decoders *providerapi.ProviderConfigDecoderRegistry,
 	managerCatalog cmcatalog.Catalog,
+	managerDecoderRegistry *ManagerConfigDecoderRegistry,
 ) (Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return Config{}, fmt.Errorf("failed to read config file: %w", err)
 	}
 
-	return ParseConfig(data, decoders, managerCatalog)
+	return ParseConfig(data, decoders, managerCatalog, managerDecoderRegistry)
 }
 
 // ParseConfig parses the component manager configuration from YAML data using
-// the supplied provider config decoders and component manager catalog.
+// the supplied provider config decoders, manager config decoders, and component
+// manager catalog.
 func ParseConfig(
 	data []byte,
 	decoders *providerapi.ProviderConfigDecoderRegistry,
 	managerCatalog cmcatalog.Catalog,
+	managerDecoderRegistry *ManagerConfigDecoderRegistry,
 ) (Config, error) {
 	if decoders == nil {
 		return Config{}, ErrProviderConfigDecoderRegistryRequired
 	}
 
-	rawComponentManagers, rawProviders, err := parseConfigYAML(data)
+	rawComponentManagers, rawManagerConfigs, rawProviders, err := parseConfigYAML(data)
 	if err != nil {
 		return Config{}, err
 	}
@@ -49,6 +54,15 @@ func ParseConfig(
 	config := newConfig()
 
 	if err := setYAMLComponentManagers(&config, rawComponentManagers); err != nil {
+		return Config{}, err
+	}
+
+	if err := setYAMLManagerConfigs(
+		&config,
+		rawManagerConfigs,
+		managerDecoderRegistry,
+		managerCatalog,
+	); err != nil {
 		return Config{}, err
 	}
 
@@ -60,24 +74,35 @@ func ParseConfig(
 		return Config{}, err
 	}
 
+	if err := config.completeManagerConfigs(
+		managerDecoderRegistry,
+		managerCatalog,
+	); err != nil {
+		return Config{}, err
+	}
+
 	return config, nil
 }
 
 // parseConfigYAML decodes only the generic YAML envelope. Provider-specific
-// YAML remains as raw nodes so each provider decoder owns its own schema.
-func parseConfigYAML(data []byte) (map[string]string, map[string]yaml.Node, error) {
+// and manager-specific YAML remains as raw nodes so each decoder owns its own
+// schema.
+func parseConfigYAML(
+	data []byte,
+) (map[string]string, map[string]map[string]yaml.Node, map[string]yaml.Node, error) {
 	var raw struct {
-		ComponentManagers map[string]string    `yaml:"component_managers"`
-		Providers         map[string]yaml.Node `yaml:"providers"`
+		ComponentManagers map[string]string               `yaml:"component_managers"`
+		ManagerConfigs    map[string]map[string]yaml.Node `yaml:"manager_configs"`
+		Providers         map[string]yaml.Node            `yaml:"providers"`
 	}
 
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
 	decoder.KnownFields(true)
 	if err := decoder.Decode(&raw); err != nil {
-		return nil, nil, fmt.Errorf("failed to parse config: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to parse config: %w", err)
 	}
 
-	return raw.ComponentManagers, raw.Providers, nil
+	return raw.ComponentManagers, raw.ManagerConfigs, raw.Providers, nil
 }
 
 // setYAMLComponentManagers converts YAML component type keys to typed
@@ -96,6 +121,75 @@ func setYAMLComponentManagers(
 			return err
 		}
 	}
+	return nil
+}
+
+// setYAMLManagerConfigs decodes explicitly configured manager overrides from
+// the manager_configs YAML section. Missing manager configs are intentionally
+// handled later by completeManagerConfigs.
+func setYAMLManagerConfigs(
+	config *Config,
+	rawManagerConfigs map[string]map[string]yaml.Node,
+	decoders *ManagerConfigDecoderRegistry,
+	managerCatalog cmcatalog.Catalog,
+) error {
+	if len(rawManagerConfigs) == 0 {
+		return nil
+	}
+
+	if decoders == nil {
+		return ErrManagerConfigDecoderRegistryRequired
+	}
+
+	for rawType, rawImplementations := range rawManagerConfigs {
+		ct := devicetypes.ComponentTypeFromString(strings.TrimSpace(rawType))
+		if ct == devicetypes.ComponentTypeUnknown {
+			return UnknownComponentTypeError{Name: rawType}
+		}
+
+		for rawImplName, rawNode := range rawImplementations {
+			identity, err := (cmcatalog.DescriptorIdentity{
+				Type:           ct,
+				Implementation: rawImplName,
+			}).Normalize()
+			if err != nil {
+				return err
+			}
+
+			selectedImplementation := config.ComponentManagers[identity.Type]
+			if selectedImplementation != identity.Implementation {
+				return ManagerConfigNotSelectedError{
+					Identity:               identity,
+					SelectedImplementation: selectedImplementation,
+				}
+			}
+
+			if _, ok := managerCatalog.Get(identity); !ok {
+				return cmcatalog.UnknownComponentManagerImplementationError{
+					ComponentType:  identity.Type,
+					Implementation: identity.Implementation,
+					Available:      managerCatalog.Implementations(identity.Type),
+				}
+			}
+
+			decoder := decoders.Get(identity)
+			if decoder == nil {
+				return ManagerConfigDecoderNotRegisteredError{
+					Identity: identity,
+				}
+			}
+
+			managerConfig, err := decoder.DecodeYAML(rawNode)
+			if err != nil {
+				return fmt.Errorf("decode manager config %s: %w", identity, err)
+			}
+
+			if err := config.addManagerConfig(identity, managerConfig); err != nil {
+				return fmt.Errorf("add manager config %s: %w", identity, err)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/flow/internal/task/componentmanager/errors.go
+++ b/flow/internal/task/componentmanager/errors.go
@@ -6,6 +6,7 @@ package componentmanager
 import (
 	"errors"
 	"fmt"
+	"reflect"
 
 	"github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/capability"
 	cmcatalog "github.com/NVIDIA/infra-controller-rest/flow/internal/task/componentmanager/catalog"
@@ -122,6 +123,10 @@ var (
 	// ErrProviderConfigTypeMismatch reports that a provider config has a
 	// different concrete type than the caller expected.
 	ErrProviderConfigTypeMismatch = errors.New("provider config type mismatch")
+
+	// ErrManagerConfigTypeMismatch reports that a manager config has a
+	// different concrete type than the caller expected.
+	ErrManagerConfigTypeMismatch = errors.New("manager config type mismatch")
 )
 
 // ManagerNotConfiguredError includes the component type that has no active
@@ -339,18 +344,58 @@ type RequiredProviderNotConfiguredError = cmconfig.RequiredProviderNotConfigured
 type ProviderConfigTypeMismatchError struct {
 	Name string
 	Got  any
-	Want string
+	Want any
 }
 
 func (e ProviderConfigTypeMismatchError) Error() string {
 	return fmt.Sprintf(
-		"provider %q returned config type %T, want %s",
+		"provider %q returned config type %s, want %s",
 		e.Name,
-		e.Got,
-		e.Want,
+		typeName(e.Got),
+		typeName(e.Want),
 	)
 }
 
 func (e ProviderConfigTypeMismatchError) Is(target error) bool {
 	return target == ErrProviderConfigTypeMismatch
+}
+
+// ManagerConfigTypeMismatchError includes the manager config identity and the
+// type expected by the caller.
+type ManagerConfigTypeMismatchError struct {
+	Identity cmcatalog.DescriptorIdentity
+	Got      any
+	Want     any
+}
+
+func (e ManagerConfigTypeMismatchError) Error() string {
+	return fmt.Sprintf(
+		"manager config %s has type %s, want %s",
+		e.Identity.String(),
+		typeName(e.Got),
+		typeName(e.Want),
+	)
+}
+
+func (e ManagerConfigTypeMismatchError) Is(target error) bool {
+	return target == ErrManagerConfigTypeMismatch
+}
+
+func typeName(v any) string {
+	if v == nil {
+		return "<nil>"
+	}
+
+	t := reflect.TypeOf(v)
+	prefix := ""
+	for t.Kind() == reflect.Pointer {
+		prefix += "*"
+		t = t.Elem()
+	}
+
+	if t.PkgPath() == "" {
+		return prefix + t.String()
+	}
+
+	return prefix + t.PkgPath() + "." + t.Name()
 }

--- a/flow/internal/task/componentmanager/factory_spec_test.go
+++ b/flow/internal/task/componentmanager/factory_spec_test.go
@@ -45,13 +45,17 @@ func TestSelectFactorySpecsReturnsSelectedDescriptors(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []cmcatalog.Descriptor{
 		{
-			Type:              devicetypes.ComponentTypeCompute,
-			Implementation:    "custom",
+			DescriptorIdentity: cmcatalog.DescriptorIdentity{
+				Type:           devicetypes.ComponentTypeCompute,
+				Implementation: "custom",
+			},
 			RequiredProviders: []string{"nico"},
 		},
 		{
-			Type:           devicetypes.ComponentTypePowerShelf,
-			Implementation: "psm",
+			DescriptorIdentity: cmcatalog.DescriptorIdentity{
+				Type:           devicetypes.ComponentTypePowerShelf,
+				Implementation: "psm",
+			},
 			RequiredProviders: []string{
 				"alpha",
 				"beta",

--- a/flow/internal/task/componentmanager/mock/mock.go
+++ b/flow/internal/task/componentmanager/mock/mock.go
@@ -59,8 +59,10 @@ func FactoryFor(componentType devicetypes.ComponentType) componentmanager.Manage
 // type.
 func DescriptorFor(componentType devicetypes.ComponentType) cmcatalog.Descriptor {
 	return cmcatalog.Descriptor{
-		Type:           componentType,
-		Implementation: ImplementationName,
+		DescriptorIdentity: cmcatalog.DescriptorIdentity{
+			Type:           componentType,
+			Implementation: ImplementationName,
+		},
 		Capabilities: capability.CapabilitySet{
 			capability.CapabilityBringUpControl,
 			capability.CapabilityBringUpStatus,

--- a/flow/internal/task/componentmanager/nvswitch/nico/nico.go
+++ b/flow/internal/task/componentmanager/nvswitch/nico/nico.go
@@ -58,8 +58,10 @@ func Factory(providerRegistry *providerapi.ProviderRegistry) (componentmanager.C
 // Descriptor returns the NICo NVSwitch manager descriptor.
 func Descriptor() cmcatalog.Descriptor {
 	return cmcatalog.Descriptor{
-		Type:              devicetypes.ComponentTypeNVSwitch,
-		Implementation:    ImplementationName,
+		DescriptorIdentity: cmcatalog.DescriptorIdentity{
+			Type:           devicetypes.ComponentTypeNVSwitch,
+			Implementation: ImplementationName,
+		},
 		RequiredProviders: []string{nicoprovider.ProviderName},
 		Capabilities: capability.CapabilitySet{
 			capability.CapabilityFirmwareConsistencyCheck,

--- a/flow/internal/task/componentmanager/nvswitch/nvswitchmanager/nvswitchmanager.go
+++ b/flow/internal/task/componentmanager/nvswitch/nvswitchmanager/nvswitchmanager.go
@@ -56,8 +56,10 @@ func Factory(providerRegistry *providerapi.ProviderRegistry) (componentmanager.C
 // Descriptor returns the NV-Switch Manager NVSwitch manager descriptor.
 func Descriptor() cmcatalog.Descriptor {
 	return cmcatalog.Descriptor{
-		Type:              devicetypes.ComponentTypeNVSwitch,
-		Implementation:    ImplementationName,
+		DescriptorIdentity: cmcatalog.DescriptorIdentity{
+			Type:           devicetypes.ComponentTypeNVSwitch,
+			Implementation: ImplementationName,
+		},
 		RequiredProviders: []string{nsmprovider.ProviderName},
 		Capabilities: capability.CapabilitySet{
 			capability.CapabilityFirmwareControl,

--- a/flow/internal/task/componentmanager/powershelf/nico/nico.go
+++ b/flow/internal/task/componentmanager/powershelf/nico/nico.go
@@ -51,8 +51,10 @@ func Factory(providerRegistry *providerapi.ProviderRegistry) (componentmanager.C
 // Descriptor returns the NICo PowerShelf manager descriptor.
 func Descriptor() cmcatalog.Descriptor {
 	return cmcatalog.Descriptor{
-		Type:              devicetypes.ComponentTypePowerShelf,
-		Implementation:    ImplementationName,
+		DescriptorIdentity: cmcatalog.DescriptorIdentity{
+			Type:           devicetypes.ComponentTypePowerShelf,
+			Implementation: ImplementationName,
+		},
 		RequiredProviders: []string{nicoprovider.ProviderName},
 		Capabilities: capability.CapabilitySet{
 			capability.CapabilityFirmwareControl,

--- a/flow/internal/task/componentmanager/powershelf/psm/psm.go
+++ b/flow/internal/task/componentmanager/powershelf/psm/psm.go
@@ -58,8 +58,10 @@ func Factory(
 // Descriptor returns the PSM PowerShelf manager descriptor.
 func Descriptor() cmcatalog.Descriptor {
 	return cmcatalog.Descriptor{
-		Type:              devicetypes.ComponentTypePowerShelf,
-		Implementation:    ImplementationName,
+		DescriptorIdentity: cmcatalog.DescriptorIdentity{
+			Type:           devicetypes.ComponentTypePowerShelf,
+			Implementation: ImplementationName,
+		},
 		RequiredProviders: []string{psmprovider.ProviderName},
 		Capabilities: capability.CapabilitySet{
 			capability.CapabilityFirmwareControl,

--- a/flow/internal/task/componentmanager/providers/nico/provider.go
+++ b/flow/internal/task/componentmanager/providers/nico/provider.go
@@ -20,27 +20,16 @@ const (
 
 	// DefaultTimeout is the default timeout for NICo gRPC calls.
 	DefaultTimeout = time.Minute
-
-	// DefaultComputePowerDelay is the default delay between sequential
-	// power control calls for compute trays. A small stagger avoids
-	// overwhelming the power delivery system.
-	DefaultComputePowerDelay = 2 * time.Second
 )
 
 // Config holds configuration for the NICo provider.
 type Config struct {
 	// Timeout is the gRPC call timeout for NICo operations.
 	Timeout time.Duration
-
-	// ComputePowerDelay is the delay inserted between sequential power
-	// control calls when commanding multiple compute trays.
-	// 0 means no delay.
-	ComputePowerDelay time.Duration
 }
 
 type rawConfig struct {
-	Timeout           string `yaml:"timeout"`
-	ComputePowerDelay string `yaml:"compute_power_delay"`
+	Timeout string `yaml:"timeout"`
 }
 
 // Name returns the provider name for this config.
@@ -67,8 +56,7 @@ func (ConfigDecoder) Name() string {
 // DefaultConfig returns the default NICo provider config.
 func (ConfigDecoder) DefaultConfig() providerapi.ProviderConfig {
 	return &Config{
-		Timeout:           DefaultTimeout,
-		ComputePowerDelay: DefaultComputePowerDelay,
+		Timeout: DefaultTimeout,
 	}
 }
 
@@ -94,18 +82,6 @@ func (d ConfigDecoder) DecodeYAML(raw yaml.Node) (providerapi.ProviderConfig, er
 			}
 		}
 		config.Timeout = timeout
-	}
-
-	if parsed.ComputePowerDelay != "" {
-		delay, err := time.ParseDuration(parsed.ComputePowerDelay)
-		if err != nil {
-			return nil, providerapi.InvalidProviderConfigFieldError{
-				Provider: ProviderName,
-				Field:    "compute_power_delay",
-				Err:      err,
-			}
-		}
-		config.ComputePowerDelay = delay
 	}
 
 	return config, nil

--- a/flow/internal/task/componentmanager/providers/nico/provider_test.go
+++ b/flow/internal/task/componentmanager/providers/nico/provider_test.go
@@ -26,26 +26,18 @@ func TestConfigDecoderDecodeYAML(t *testing.T) {
 	require.NoError(t, err)
 	config := decoded.(*Config)
 	assert.Equal(t, DefaultTimeout, config.Timeout)
-	assert.Equal(t, DefaultComputePowerDelay, config.ComputePowerDelay)
 
 	decoded, err = decoder.DecodeYAML(providerYAMLNode(t, `
 timeout: 15s
-compute_power_delay: 0s
 `))
 	require.NoError(t, err)
 	config = decoded.(*Config)
 	assert.Equal(t, 15*time.Second, config.Timeout)
-	assert.Equal(t, 0*time.Second, config.ComputePowerDelay)
 
 	_, err = decoder.DecodeYAML(providerYAMLNode(t, `timeout: nope`))
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, providerapi.ErrInvalidProviderConfigField))
 	assertInvalidConfigField(t, err, "timeout")
-
-	_, err = decoder.DecodeYAML(providerYAMLNode(t, `compute_power_delay: nope`))
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, providerapi.ErrInvalidProviderConfigField))
-	assertInvalidConfigField(t, err, "compute_power_delay")
 
 	_, err = decoder.DecodeYAML(providerYAMLNode(t, `timout: 15s`))
 	require.Error(t, err)
@@ -54,6 +46,10 @@ compute_power_delay: 0s
 	var configErr providerapi.InvalidProviderConfigError
 	require.True(t, errors.As(err, &configErr))
 	assert.Equal(t, ProviderName, configErr.Provider)
+
+	_, err = decoder.DecodeYAML(providerYAMLNode(t, `compute_power_delay: 0s`))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, providerapi.ErrInvalidProviderConfig))
 }
 
 func assertInvalidConfigField(t *testing.T, err error, field string) {

--- a/flow/internal/task/componentmanager/registry_test.go
+++ b/flow/internal/task/componentmanager/registry_test.go
@@ -182,8 +182,10 @@ func TestRegistryGetDescriptor(t *testing.T) {
 
 func TestRegistryDescriptorResultsDoNotShareSliceStorage(t *testing.T) {
 	descriptor := cmcatalog.Descriptor{
-		Type:              devicetypes.ComponentTypeCompute,
-		Implementation:    "custom",
+		DescriptorIdentity: cmcatalog.DescriptorIdentity{
+			Type:           devicetypes.ComponentTypeCompute,
+			Implementation: "custom",
+		},
 		RequiredProviders: []string{"provider"},
 		Capabilities: capability.CapabilitySet{
 			capability.CapabilityPowerControl,
@@ -678,12 +680,16 @@ func TestRegistryDescriptors(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []cmcatalog.Descriptor{
 		{
-			Type:           devicetypes.ComponentTypeCompute,
-			Implementation: "compute",
+			DescriptorIdentity: cmcatalog.DescriptorIdentity{
+				Type:           devicetypes.ComponentTypeCompute,
+				Implementation: "compute",
+			},
 		},
 		{
-			Type:           devicetypes.ComponentTypeNVSwitch,
-			Implementation: "switch",
+			DescriptorIdentity: cmcatalog.DescriptorIdentity{
+				Type:           devicetypes.ComponentTypeNVSwitch,
+				Implementation: "switch",
+			},
 		},
 	}, descriptors)
 }

--- a/flow/internal/task/componentmanager/test_helpers_test.go
+++ b/flow/internal/task/componentmanager/test_helpers_test.go
@@ -46,8 +46,10 @@ func testDescriptor(
 	requiredProviders ...string,
 ) cmcatalog.Descriptor {
 	return cmcatalog.Descriptor{
-		Type:              componentType,
-		Implementation:    implementation,
+		DescriptorIdentity: cmcatalog.DescriptorIdentity{
+			Type:           componentType,
+			Implementation: implementation,
+		},
 		RequiredProviders: requiredProviders,
 	}
 }
@@ -75,9 +77,11 @@ func newRegistryWithCapabilities(
 	t.Helper()
 
 	descriptor := cmcatalog.Descriptor{
-		Type:           devicetypes.ComponentTypeCompute,
-		Implementation: "custom",
-		Capabilities:   capability.CapabilitySet(capabilities),
+		DescriptorIdentity: cmcatalog.DescriptorIdentity{
+			Type:           devicetypes.ComponentTypeCompute,
+			Implementation: "custom",
+		},
+		Capabilities: capability.CapabilitySet(capabilities),
 	}
 
 	registry, err := NewRegistry(

--- a/flow/internal/task/executor/temporalworkflow/activity/activity_test.go
+++ b/flow/internal/task/executor/temporalworkflow/activity/activity_test.go
@@ -274,9 +274,11 @@ func newCapabilityTestActivities(
 	t.Helper()
 
 	descriptor := cmcatalog.Descriptor{
-		Type:           devicetypes.ComponentTypeCompute,
-		Implementation: "limited",
-		Capabilities:   capability.CapabilitySet(capabilities),
+		DescriptorIdentity: cmcatalog.DescriptorIdentity{
+			Type:           devicetypes.ComponentTypeCompute,
+			Implementation: "limited",
+		},
+		Capabilities: capability.CapabilitySet(capabilities),
 	}
 	manager := &capabilityTestManager{descriptor: descriptor}
 	registry, err := componentmanager.NewRegistry(
@@ -317,9 +319,11 @@ func newDescriptorOnlyActivities(
 	t.Helper()
 
 	descriptor := cmcatalog.Descriptor{
-		Type:           devicetypes.ComponentTypeCompute,
-		Implementation: "descriptor-only",
-		Capabilities:   capability.CapabilitySet(capabilities),
+		DescriptorIdentity: cmcatalog.DescriptorIdentity{
+			Type:           devicetypes.ComponentTypeCompute,
+			Implementation: "descriptor-only",
+		},
+		Capabilities: capability.CapabilitySet(capabilities),
 	}
 	registry, err := componentmanager.NewRegistry(
 		[]componentmanager.FactorySpec{

--- a/flow/internal/task/executor/temporalworkflow/manager/pre_dispatch_validation_test.go
+++ b/flow/internal/task/executor/temporalworkflow/manager/pre_dispatch_validation_test.go
@@ -131,9 +131,11 @@ func newPreflightCapabilityRegistry(
 	t.Helper()
 
 	descriptor := cmcatalog.Descriptor{
-		Type:           devicetypes.ComponentTypeCompute,
-		Implementation: "limited",
-		Capabilities:   capability.CapabilitySet(capabilities),
+		DescriptorIdentity: cmcatalog.DescriptorIdentity{
+			Type:           devicetypes.ComponentTypeCompute,
+			Implementation: "limited",
+		},
+		Capabilities: capability.CapabilitySet(capabilities),
 	}
 
 	registry, err := componentmanager.NewRegistry(


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
- Introduce manager config decoders keyed by component manager descriptor identity, including explicit YAML support and legacy provider YAML migration for compute power delay.
- Update descriptor identity handling across the built-in catalog and refresh docs/tests around component manager config and capability validation.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [ ] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [x] **Flow** - Flow service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
