### PR TITLE
fix: Read service-account flag from request context not issuer config

### DIFF
--- a/api/internal/config/config.go
+++ b/api/internal/config/config.go
@@ -621,6 +621,9 @@ func (c *Config) ValidateIssuersConfig(issuers []IssuerConfig) error {
 				if mapping.OrgAttribute != "" {
 					return fmt.Errorf("issuer %s: claimMapping %d: orgAttribute cannot be specified when isServiceAccount is true", issuer.Name, j)
 				}
+				if !c.GetEnvDisconnected() {
+					return fmt.Errorf("issuer %s: claimMapping %d: isServiceAccount is only supported in disconnected mode", issuer.Name, j)
+				}
 			}
 
 			// Dynamic org mapping

--- a/api/pkg/api/handler/serviceaccount.go
+++ b/api/pkg/api/handler/serviceaccount.go
@@ -6,7 +6,6 @@ package handler
 import (
 	"net/http"
 
-	"github.com/NVIDIA/infra-controller-rest/api/internal/config"
 	"github.com/NVIDIA/infra-controller-rest/api/pkg/api/handler/util/common"
 	"github.com/NVIDIA/infra-controller-rest/api/pkg/api/model"
 	cauth "github.com/NVIDIA/infra-controller-rest/auth/pkg/config"
@@ -21,15 +20,13 @@ import (
 // GetCurrentServiceAccountHandler is the API Handler for getting the current Service Account
 type GetCurrentServiceAccountHandler struct {
 	dbSession  *cdb.Session
-	cfg        *config.Config
 	tracerSpan *cutil.TracerSpan
 }
 
 // NewGetCurrentServiceAccountHandler initializes and returns a new handler for getting the current Service Account
-func NewGetCurrentServiceAccountHandler(dbSession *cdb.Session, cfg *config.Config) GetCurrentServiceAccountHandler {
+func NewGetCurrentServiceAccountHandler(dbSession *cdb.Session) GetCurrentServiceAccountHandler {
 	return GetCurrentServiceAccountHandler{
 		dbSession:  dbSession,
-		cfg:        cfg,
 		tracerSpan: cutil.NewTracerSpan(),
 	}
 }

--- a/api/pkg/api/handler/serviceaccount.go
+++ b/api/pkg/api/handler/serviceaccount.go
@@ -9,6 +9,7 @@ import (
 	"github.com/NVIDIA/infra-controller-rest/api/internal/config"
 	"github.com/NVIDIA/infra-controller-rest/api/pkg/api/handler/util/common"
 	"github.com/NVIDIA/infra-controller-rest/api/pkg/api/model"
+	cauth "github.com/NVIDIA/infra-controller-rest/auth/pkg/config"
 	cutil "github.com/NVIDIA/infra-controller-rest/common/pkg/util"
 	cdb "github.com/NVIDIA/infra-controller-rest/db/pkg/db"
 	cdbm "github.com/NVIDIA/infra-controller-rest/db/pkg/db/model"
@@ -51,16 +52,7 @@ func (gcsah GetCurrentServiceAccountHandler) Handle(c echo.Context) error {
 	if dbUser == nil {
 		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve current user", nil)
 	}
-
-	// Check if service account is enabled for at least one auth configuration
-	serviceAccountEnabled := false
-	jwtOriginConfigs := gcsah.cfg.GetOrInitJWTOriginConfig()
-	for _, jwtOriginConfig := range jwtOriginConfigs.GetAllConfigs() {
-		if jwtOriginConfig.ServiceAccount {
-			serviceAccountEnabled = true
-			break
-		}
-	}
+	serviceAccountEnabled := cauth.GetIsServiceAccountFromContext(c)
 
 	if !serviceAccountEnabled {
 		logger.Info().Msg("service account is disabled for this org")

--- a/api/pkg/api/handler/serviceaccount_test.go
+++ b/api/pkg/api/handler/serviceaccount_test.go
@@ -30,8 +30,6 @@ func TestServiceAccountHandler_GetCurrent(t *testing.T) {
 
 	common.TestSetupSchema(t, dbSession)
 
-	cfg := common.GetTestConfig()
-
 	org1 := "test-org"
 	user1 := common.TestBuildUser(t, dbSession, uuid.NewString(), org1, []string{authz.ProviderAdminRole, authz.TenantAdminRole})
 
@@ -93,7 +91,6 @@ func TestServiceAccountHandler_GetCurrent(t *testing.T) {
 
 			handler := GetCurrentServiceAccountHandler{
 				dbSession: dbSession,
-				cfg:       cfg,
 			}
 
 			err := handler.Handle(ec)

--- a/api/pkg/api/handler/serviceaccount_test.go
+++ b/api/pkg/api/handler/serviceaccount_test.go
@@ -6,7 +6,6 @@ package handler
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -74,13 +73,6 @@ func TestServiceAccountHandler_GetCurrent(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cfg.JwtOriginConfig = cauth.NewJWTOriginConfig()
-
-			if test.serviceAccountEnabled {
-				// Add service account auth config
-				cfg.JwtOriginConfig.AddConfig(test.org, fmt.Sprintf("https://%s.com", test.org), fmt.Sprintf("https://%s.com", test.org), cauth.TokenOriginCustom, true, nil, nil)
-			}
-
 			// Setup echo server/context
 			e := echo.New()
 			req := httptest.NewRequest(http.MethodGet, "/service-account/current", nil)
@@ -93,6 +85,11 @@ func TestServiceAccountHandler_GetCurrent(t *testing.T) {
 			ec.Set("user", test.user)
 
 			ec.SetRequest(ec.Request().WithContext(ctx))
+
+			// Normally, the auth processor records the service-account flag on the request
+			// context based on the type of issuer/Origin/claimMappings, but in this test we
+			// set it manually for testing purposes.
+			cauth.SetIsServiceAccountInContext(ec, test.serviceAccountEnabled)
 
 			handler := GetCurrentServiceAccountHandler{
 				dbSession: dbSession,

--- a/api/pkg/api/routes.go
+++ b/api/pkg/api/routes.go
@@ -39,7 +39,7 @@ func NewAPIRoutes(dbSession *cdb.Session, tc tClient.Client, tnc tClient.Namespa
 		{
 			Path:    apiPathPrefix + "/service-account/current",
 			Method:  http.MethodGet,
-			Handler: apiHandler.NewGetCurrentServiceAccountHandler(dbSession, cfg),
+			Handler: apiHandler.NewGetCurrentServiceAccountHandler(dbSession),
 		},
 		// Infrastructure Provider endpoints
 		{

--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -21638,7 +21638,22 @@ components:
       properties:
         enabled:
           type: boolean
-          description: Indicates whether Service Account is enabled
+          description: |-
+            Indicates whether the calling token is authenticated as a Service Account.
+            This is determined per request from how the token's issuer is configured
+            at deployment time (the issuer config in the `nico-rest-api-config`
+            ConfigMap); it cannot be toggled via the API. Rules by issuer origin:
+              - `keycloak`: true for a client-credentials (service-to-service) token —
+                i.e. the token carries a client ID — when the issuer is deployed with
+                `keycloak.serviceAccount: true`.
+              - `custom`: true when the `claimMapping` matched for this org sets
+                `isServiceAccount: true`. Only permitted when the API runs in
+                disconnected mode.
+              - `kas-ssa` / `kas-legacy`: always false; service accounts are not
+                supported for these origins.
+
+            For details on issuer origins and configuration, see the NICo REST `auth`
+            module [README](https://github.com/NVIDIA/infra-controller-rest/tree/main/auth).
         infrastructureProviderId:
           type:
             - string

--- a/sdk/standard/model_service_account.go
+++ b/sdk/standard/model_service_account.go
@@ -22,7 +22,7 @@ var _ MappedNullable = &ServiceAccount{}
 
 // ServiceAccount Describes Service Account status and related entities
 type ServiceAccount struct {
-	// Indicates whether Service Account is enabled
+	// Indicates whether the calling token is authenticated as a Service Account. This is determined per request from how the token's issuer is configured at deployment time (the issuer config in the `nico-rest-api-config` ConfigMap); it cannot be toggled via the API. Rules by issuer origin:   - `keycloak`: true for a client-credentials (service-to-service) token —     i.e. the token carries a client ID — when the issuer is deployed with     `keycloak.serviceAccount: true`.   - `custom`: true when the `claimMapping` matched for this org sets     `isServiceAccount: true`. Only permitted when the API runs in     disconnected mode.   - `kas-ssa` / `kas-legacy`: always false; service accounts are not     supported for these origins.  For details on issuer origins and configuration, see the NICo REST `auth` module [README](https://github.com/NVIDIA/infra-controller-rest/tree/main/auth).
 	Enabled *bool `json:"enabled,omitempty"`
 	// ID of the Infrastructure Provider associated with Service Account
 	InfrastructureProviderId NullableString `json:"infrastructureProviderId,omitempty"`


### PR DESCRIPTION
## Description
`GetCurrentServiceAccountHandler` decided whether the caller was a service
account by scanning every configured issuer and returning `true` if any
issuer had service accounts enabled. This misclassified ordinary user
tokens as service accounts whenever the deployment had any
service-account-capable issuer configured.
This PR makes the handler read the per-request flag that the auth
processors already record via `cauth.SetIsServiceAccountInContext`
(`GetIsServiceAccountFromContext`), so `/service-account/current` reflects
the actual authenticated caller rather than global config. Keycloak and
custom (`claimMapping.isServiceAccount`) tokens both funnel into the same
context flag, so this works uniformly across origins.
It also restricts `claimMapping.isServiceAccount` to disconnected mode,
matching the existing issuer-level `serviceAccount` guard, since it grants
admin roles that must not be self-asserted from local config when a cloud
identity provider is the source of truth.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Fix** - Bug fixes (fix:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **API** - API models or endpoints updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->
None

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
