### PR TITLE
fix: Correct AuditEntry queryParams/body types in OpenAPI spec

### DIFF
--- a/common/pkg/util/converter_test.go
+++ b/common/pkg/util/converter_test.go
@@ -1,19 +1,5 @@
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 package util
 

--- a/flow/internal/task/componentmanager/compute/nico/config.go
+++ b/flow/internal/task/componentmanager/compute/nico/config.go
@@ -1,19 +1,5 @@
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 package nico
 

--- a/flow/internal/task/componentmanager/config/manager_config.go
+++ b/flow/internal/task/componentmanager/config/manager_config.go
@@ -1,19 +1,5 @@
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 package config
 

--- a/flow/internal/task/message/message.go
+++ b/flow/internal/task/message/message.go
@@ -1,19 +1,5 @@
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 package message
 

--- a/flow/internal/task/operations/summary.go
+++ b/flow/internal/task/operations/summary.go
@@ -1,19 +1,5 @@
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 package operations
 

--- a/flow/internal/task/operations/summary_test.go
+++ b/flow/internal/task/operations/summary_test.go
@@ -1,19 +1,5 @@
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 package operations
 

--- a/flow/internal/task/report/report.go
+++ b/flow/internal/task/report/report.go
@@ -1,19 +1,5 @@
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 // Package report defines the JSON document persisted in task.report and
 // the Tracker that mutates it as a rule-based workflow advances.

--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -12222,9 +12222,12 @@ paths:
                   value:
                     - id: e313b3ca-c47a-4ec1-a79b-a147fad51a50
                       endpoint: /v2/org/test-org-1/nico/ep
-                      queryParams: '{"test":["1234"]}'
+                      queryParams:
+                        test:
+                          - '1234'
                       method: POST
-                      body: '{"key1":"value1"}'
+                      body:
+                        key1: value1
                       statusCode: 200
                       clientIP: 12.123.43.112
                       userID: 5d9fe319-14d4-40e3-8e5a-7d79e680d55b
@@ -12239,9 +12242,12 @@ paths:
                       apiVersion: 0.1.91
                     - id: e313b3ca-c47a-4ec1-a79b-a147fad51a50
                       endpoint: /v2/org/test-org-1/nico/ep
-                      queryParams: '{"test":["1234"]}'
+                      queryParams:
+                        test:
+                          - '1234'
                       method: POST
-                      body: '{"key1":"value1"}'
+                      body:
+                        key1: value1
                       statusCode: 403
                       statusMessage: User does not have permissions
                       clientIP: 12.123.43.112
@@ -12322,9 +12328,12 @@ paths:
                   value:
                     id: e313b3ca-c47a-4ec1-a79b-a147fad51a50
                     endpoint: /v2/org/test-org-1/nico/ep
-                    queryParams: '{"test":["1234"]}'
+                    queryParams:
+                      test:
+                        - '1234'
                     method: POST
-                    body: '{"key1":"value1"}'
+                    body:
+                      key1: value1
                     statusCode: 200
                     clientIP: 12.123.43.112
                     userID: 5d9fe319-14d4-40e3-8e5a-7d79e680d55b
@@ -21481,9 +21490,12 @@ components:
       examples:
         - id: e313b3ca-c47a-4ec1-a79b-a147fad51a50
           endpoint: /v2/org/test-org-1/nico/ep
-          queryParams: '{"test":["1234"]}'
+          queryParams:
+            test:
+              - '1234'
           method: POST
-          body: '{"key1":"value1"}'
+          body:
+            key1: value1
           statusCode: 200
           clientIP: 12.123.43.112
           userID: 5d9fe319-14d4-40e3-8e5a-7d79e680d55b
@@ -21498,9 +21510,12 @@ components:
           apiVersion: 0.1.91
         - id: e313b3ca-c47a-4ec1-a79b-a147fad51a50
           endpoint: /v2/org/test-org-1/nico/ep
-          queryParams: '{"test":["1234"]}'
+          queryParams:
+            test:
+              - '1234'
           method: POST
-          body: '{"key1":"value1"}'
+          body:
+            key1: value1
           statusCode: 403
           statusMessage: User does not have permissions
           clientIP: 12.123.43.112
@@ -21524,14 +21539,18 @@ components:
           type: string
           description: API endpoint
         queryParams:
-          type: string
-          description: Query parameters
+          type: object
+          description: Query parameters from the request URL, keyed by parameter name. Each value is the list of values supplied for that parameter.
+          additionalProperties:
+            type: array
+            items:
+              type: string
         method:
           type: string
           description: HTTP method
         body:
-          type: string
-          description: HTTP body in JSON format
+          type: object
+          description: Request body parsed as a JSON object. Empty when the request had no body. Sensitive fields (e.g. passwords) are obfuscated.
         statusCode:
           type: integer
           description: HTTP response status code

--- a/sdk/standard/api_allocation.go
+++ b/sdk/standard/api_allocation.go
@@ -463,6 +463,7 @@ func (a *AllocationAPIService) GetAllAllocationExecute(r ApiGetAllAllocationRequ
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {

--- a/sdk/standard/api_audit.go
+++ b/sdk/standard/api_audit.go
@@ -112,6 +112,7 @@ func (a *AuditAPIService) GetAllAuditEntryExecute(r ApiGetAllAuditEntryRequest) 
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {

--- a/sdk/standard/api_dpu_extension_service.go
+++ b/sdk/standard/api_dpu_extension_service.go
@@ -501,6 +501,7 @@ func (a *DPUExtensionServiceAPIService) GetAllDpuExtensionServiceExecute(r ApiGe
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {

--- a/sdk/standard/api_expected_machine.go
+++ b/sdk/standard/api_expected_machine.go
@@ -710,6 +710,7 @@ func (a *ExpectedMachineAPIService) GetAllExpectedMachineExecute(r ApiGetAllExpe
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {

--- a/sdk/standard/api_expected_power_shelf.go
+++ b/sdk/standard/api_expected_power_shelf.go
@@ -399,6 +399,7 @@ func (a *ExpectedPowerShelfAPIService) GetAllExpectedPowerShelfExecute(r ApiGetA
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {

--- a/sdk/standard/api_expected_rack.go
+++ b/sdk/standard/api_expected_rack.go
@@ -533,6 +533,7 @@ func (a *ExpectedRackAPIService) GetAllExpectedRackExecute(r ApiGetAllExpectedRa
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {

--- a/sdk/standard/api_expected_switch.go
+++ b/sdk/standard/api_expected_switch.go
@@ -399,6 +399,7 @@ func (a *ExpectedSwitchAPIService) GetAllExpectedSwitchExecute(r ApiGetAllExpect
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {

--- a/sdk/standard/api_infini_band_partition.go
+++ b/sdk/standard/api_infini_band_partition.go
@@ -397,6 +397,7 @@ func (a *InfiniBandPartitionAPIService) GetAllInfinibandInterfaceExecute(r ApiGe
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {
@@ -586,6 +587,7 @@ func (a *InfiniBandPartitionAPIService) GetAllInfinibandPartitionExecute(r ApiGe
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {

--- a/sdk/standard/api_instance.go
+++ b/sdk/standard/api_instance.go
@@ -614,6 +614,7 @@ func (a *InstanceAPIService) GetAllInstanceExecute(r ApiGetAllInstanceRequest) (
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {
@@ -790,6 +791,7 @@ func (a *InstanceAPIService) GetAllInstanceInfinibandInterfaceExecute(r ApiGetAl
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {
@@ -963,6 +965,7 @@ func (a *InstanceAPIService) GetAllInstanceNvlinkInterfaceExecute(r ApiGetAllIns
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {
@@ -1136,6 +1139,7 @@ func (a *InstanceAPIService) GetAllInterfaceExecute(r ApiGetAllInterfaceRequest)
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {

--- a/sdk/standard/api_instance_type.go
+++ b/sdk/standard/api_instance_type.go
@@ -694,6 +694,7 @@ func (a *InstanceTypeAPIService) GetAllInstanceTypeExecute(r ApiGetAllInstanceTy
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {
@@ -999,6 +1000,7 @@ func (a *InstanceTypeAPIService) GetInstanceTypeMachineAssociationExecute(r ApiG
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {

--- a/sdk/standard/api_ip_block.go
+++ b/sdk/standard/api_ip_block.go
@@ -396,6 +396,7 @@ func (a *IPBlockAPIService) GetAllDerivedIpblockExecute(r ApiGetAllDerivedIpbloc
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {
@@ -615,6 +616,7 @@ func (a *IPBlockAPIService) GetAllIpblockExecute(r ApiGetAllIpblockRequest) ([]I
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {

--- a/sdk/standard/api_machine.go
+++ b/sdk/standard/api_machine.go
@@ -392,6 +392,7 @@ func (a *MachineAPIService) GetAllMachineExecute(r ApiGetAllMachineRequest) ([]M
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {
@@ -632,6 +633,7 @@ func (a *MachineAPIService) GetAllMachineCapabilitiesExecute(r ApiGetAllMachineC
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {

--- a/sdk/standard/api_network_security_group.go
+++ b/sdk/standard/api_network_security_group.go
@@ -493,6 +493,7 @@ func (a *NetworkSecurityGroupAPIService) GetAllNetworkSecurityGroupExecute(r Api
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {

--- a/sdk/standard/api_nv_link_logical_partition.go
+++ b/sdk/standard/api_nv_link_logical_partition.go
@@ -405,6 +405,7 @@ func (a *NVLinkLogicalPartitionAPIService) GetAllNvlinkInterfaceExecute(r ApiGet
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {
@@ -624,6 +625,7 @@ func (a *NVLinkLogicalPartitionAPIService) GetAllNvlinkLogicalPartitionExecute(r
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {

--- a/sdk/standard/api_operating_system.go
+++ b/sdk/standard/api_operating_system.go
@@ -405,6 +405,7 @@ func (a *OperatingSystemAPIService) GetAllOperatingSystemExecute(r ApiGetAllOper
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {

--- a/sdk/standard/api_rack.go
+++ b/sdk/standard/api_rack.go
@@ -703,6 +703,7 @@ func (a *RackAPIService) GetAllRackExecute(r ApiGetAllRackRequest) ([]Rack, *htt
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {
@@ -1021,12 +1022,14 @@ func (a *RackAPIService) GetRackTasksExecute(r ApiGetRackTasksRequest) ([]RackTa
 		parameterAddToHeaderOrQuery(localVarQueryParams, "activeOnly", r.activeOnly, "form", "")
 	} else {
 		var defaultValue bool = false
+		parameterAddToHeaderOrQuery(localVarQueryParams, "activeOnly", defaultValue, "form", "")
 		r.activeOnly = &defaultValue
 	}
 	if r.pageNumber != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {

--- a/sdk/standard/api_site.go
+++ b/sdk/standard/api_site.go
@@ -459,6 +459,7 @@ func (a *SiteAPIService) GetAllSiteExecute(r ApiGetAllSiteRequest) ([]Site, *htt
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {

--- a/sdk/standard/api_sku.go
+++ b/sdk/standard/api_sku.go
@@ -119,6 +119,7 @@ func (a *SKUAPIService) GetAllSkuExecute(r ApiGetAllSkuRequest) ([]Sku, *http.Re
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {

--- a/sdk/standard/api_ssh_key.go
+++ b/sdk/standard/api_ssh_key.go
@@ -377,6 +377,7 @@ func (a *SSHKeyAPIService) GetAllSshKeyExecute(r ApiGetAllSshKeyRequest) ([]SshK
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {

--- a/sdk/standard/api_ssh_key_group.go
+++ b/sdk/standard/api_ssh_key_group.go
@@ -397,6 +397,7 @@ func (a *SSHKeyGroupAPIService) GetAllSshKeyGroupExecute(r ApiGetAllSshKeyGroupR
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {

--- a/sdk/standard/api_subnet.go
+++ b/sdk/standard/api_subnet.go
@@ -407,6 +407,7 @@ func (a *SubnetAPIService) GetAllSubnetExecute(r ApiGetAllSubnetRequest) ([]Subn
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {

--- a/sdk/standard/api_tenant_account.go
+++ b/sdk/standard/api_tenant_account.go
@@ -393,6 +393,7 @@ func (a *TenantAccountAPIService) GetAllTenantAccountExecute(r ApiGetAllTenantAc
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {

--- a/sdk/standard/api_tray.go
+++ b/sdk/standard/api_tray.go
@@ -464,6 +464,7 @@ func (a *TrayAPIService) GetAllTrayExecute(r ApiGetAllTrayRequest) ([]Tray, *htt
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {
@@ -772,12 +773,14 @@ func (a *TrayAPIService) GetTrayTasksExecute(r ApiGetTrayTasksRequest) ([]RackTa
 		parameterAddToHeaderOrQuery(localVarQueryParams, "activeOnly", r.activeOnly, "form", "")
 	} else {
 		var defaultValue bool = false
+		parameterAddToHeaderOrQuery(localVarQueryParams, "activeOnly", defaultValue, "form", "")
 		r.activeOnly = &defaultValue
 	}
 	if r.pageNumber != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {

--- a/sdk/standard/api_vpc.go
+++ b/sdk/standard/api_vpc.go
@@ -405,6 +405,7 @@ func (a *VPCAPIService) GetAllVpcExecute(r ApiGetAllVpcRequest) ([]VPC, *http.Re
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {

--- a/sdk/standard/api_vpc_peering.go
+++ b/sdk/standard/api_vpc_peering.go
@@ -412,6 +412,7 @@ func (a *VPCPeeringAPIService) GetAllVpcPeeringExecute(r ApiGetAllVpcPeeringRequ
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {

--- a/sdk/standard/api_vpc_prefix.go
+++ b/sdk/standard/api_vpc_prefix.go
@@ -405,6 +405,7 @@ func (a *VPCPrefixAPIService) GetAllVpcPrefixExecute(r ApiGetAllVpcPrefixRequest
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", r.pageNumber, "form", "")
 	} else {
 		var defaultValue int32 = 1
+		parameterAddToHeaderOrQuery(localVarQueryParams, "pageNumber", defaultValue, "form", "")
 		r.pageNumber = &defaultValue
 	}
 	if r.pageSize != nil {

--- a/sdk/standard/client.go
+++ b/sdk/standard/client.go
@@ -590,10 +590,7 @@ func addFile(w *multipart.Writer, fieldName, path string) error {
 	if err != nil {
 		return err
 	}
-	err = file.Close()
-	if err != nil {
-		return err
-	}
+	defer file.Close()
 
 	part, err := w.CreateFormFile(fieldName, filepath.Base(path))
 	if err != nil {

--- a/sdk/standard/model_audit_entry.go
+++ b/sdk/standard/model_audit_entry.go
@@ -27,12 +27,12 @@ type AuditEntry struct {
 	Id *string `json:"id,omitempty"`
 	// API endpoint
 	Endpoint *string `json:"endpoint,omitempty"`
-	// Query parameters
-	QueryParams *string `json:"queryParams,omitempty"`
+	// Query parameters from the request URL, keyed by parameter name. Each value is the list of values supplied for that parameter.
+	QueryParams map[string][]string `json:"queryParams,omitempty"`
 	// HTTP method
 	Method *string `json:"method,omitempty"`
-	// HTTP body in JSON format
-	Body *string `json:"body,omitempty"`
+	// Request body parsed as a JSON object. Empty when the request had no body. Sensitive fields (e.g. passwords) are obfuscated.
+	Body map[string]interface{} `json:"body,omitempty"`
 	// HTTP response status code
 	StatusCode *int32 `json:"statusCode,omitempty"`
 	// HTTP response status message
@@ -137,19 +137,19 @@ func (o *AuditEntry) SetEndpoint(v string) {
 }
 
 // GetQueryParams returns the QueryParams field value if set, zero value otherwise.
-func (o *AuditEntry) GetQueryParams() string {
+func (o *AuditEntry) GetQueryParams() map[string][]string {
 	if o == nil || IsNil(o.QueryParams) {
-		var ret string
+		var ret map[string][]string
 		return ret
 	}
-	return *o.QueryParams
+	return o.QueryParams
 }
 
 // GetQueryParamsOk returns a tuple with the QueryParams field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AuditEntry) GetQueryParamsOk() (*string, bool) {
+func (o *AuditEntry) GetQueryParamsOk() (map[string][]string, bool) {
 	if o == nil || IsNil(o.QueryParams) {
-		return nil, false
+		return map[string][]string{}, false
 	}
 	return o.QueryParams, true
 }
@@ -163,9 +163,9 @@ func (o *AuditEntry) HasQueryParams() bool {
 	return false
 }
 
-// SetQueryParams gets a reference to the given string and assigns it to the QueryParams field.
-func (o *AuditEntry) SetQueryParams(v string) {
-	o.QueryParams = &v
+// SetQueryParams gets a reference to the given map[string][]string and assigns it to the QueryParams field.
+func (o *AuditEntry) SetQueryParams(v map[string][]string) {
+	o.QueryParams = v
 }
 
 // GetMethod returns the Method field value if set, zero value otherwise.
@@ -201,19 +201,19 @@ func (o *AuditEntry) SetMethod(v string) {
 }
 
 // GetBody returns the Body field value if set, zero value otherwise.
-func (o *AuditEntry) GetBody() string {
+func (o *AuditEntry) GetBody() map[string]interface{} {
 	if o == nil || IsNil(o.Body) {
-		var ret string
+		var ret map[string]interface{}
 		return ret
 	}
-	return *o.Body
+	return o.Body
 }
 
 // GetBodyOk returns a tuple with the Body field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AuditEntry) GetBodyOk() (*string, bool) {
+func (o *AuditEntry) GetBodyOk() (map[string]interface{}, bool) {
 	if o == nil || IsNil(o.Body) {
-		return nil, false
+		return map[string]interface{}{}, false
 	}
 	return o.Body, true
 }
@@ -227,9 +227,9 @@ func (o *AuditEntry) HasBody() bool {
 	return false
 }
 
-// SetBody gets a reference to the given string and assigns it to the Body field.
-func (o *AuditEntry) SetBody(v string) {
-	o.Body = &v
+// SetBody gets a reference to the given map[string]interface{} and assigns it to the Body field.
+func (o *AuditEntry) SetBody(v map[string]interface{}) {
+	o.Body = v
 }
 
 // GetStatusCode returns the StatusCode field value if set, zero value otherwise.

--- a/sdk/standard/model_expected_machine.go
+++ b/sdk/standard/model_expected_machine.go
@@ -60,7 +60,8 @@ type ExpectedMachine struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32     `json:"hostId,omitempty"`
+	HostId NullableInt32 `json:"hostId,omitempty"`
+	// User-defined key-value pairs for organizing and categorizing Expected Machines
 	Labels map[string]string `json:"labels,omitempty"`
 	// ISO 8601 datetime when the Expected Machine was created
 	Created *time.Time `json:"created,omitempty"`

--- a/sdk/standard/model_expected_machine_create_request.go
+++ b/sdk/standard/model_expected_machine_create_request.go
@@ -57,7 +57,8 @@ type ExpectedMachineCreateRequest struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32     `json:"hostId,omitempty"`
+	HostId NullableInt32 `json:"hostId,omitempty"`
+	// User-defined key-value pairs for organizing and categorizing Expected Machines
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_expected_machine_update_request.go
+++ b/sdk/standard/model_expected_machine_update_request.go
@@ -55,7 +55,8 @@ type ExpectedMachineUpdateRequest struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32     `json:"hostId,omitempty"`
+	HostId NullableInt32 `json:"hostId,omitempty"`
+	// User-defined key-value pairs for organizing and categorizing Expected Machines
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_expected_power_shelf.go
+++ b/sdk/standard/model_expected_power_shelf.go
@@ -50,7 +50,8 @@ type ExpectedPowerShelf struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32     `json:"hostId,omitempty"`
+	HostId NullableInt32 `json:"hostId,omitempty"`
+	// User-defined key-value pairs for organizing and categorizing Expected Power Shelves
 	Labels map[string]string `json:"labels,omitempty"`
 	// ISO 8601 datetime when the Expected Power Shelf was created
 	Created *time.Time `json:"created,omitempty"`

--- a/sdk/standard/model_expected_power_shelf_create_request.go
+++ b/sdk/standard/model_expected_power_shelf_create_request.go
@@ -53,7 +53,8 @@ type ExpectedPowerShelfCreateRequest struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32     `json:"hostId,omitempty"`
+	HostId NullableInt32 `json:"hostId,omitempty"`
+	// User-defined key-value pairs for organizing and categorizing Expected Power Shelves
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_expected_power_shelf_update_request.go
+++ b/sdk/standard/model_expected_power_shelf_update_request.go
@@ -51,7 +51,8 @@ type ExpectedPowerShelfUpdateRequest struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32     `json:"hostId,omitempty"`
+	HostId NullableInt32 `json:"hostId,omitempty"`
+	// User-defined key-value pairs for organizing and categorizing Expected Power Shelves
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_expected_rack.go
+++ b/sdk/standard/model_expected_rack.go
@@ -34,8 +34,9 @@ type ExpectedRack struct {
 	// Human-readable name of the Expected Rack
 	Name *string `json:"name,omitempty"`
 	// Human-readable description of the Expected Rack
-	Description *string           `json:"description,omitempty"`
-	Labels      map[string]string `json:"labels,omitempty"`
+	Description *string `json:"description,omitempty"`
+	// User-defined key-value pairs for organizing and categorizing Expected Racks. Well-known keys (`chassis.*`, `location.*`) are used to convey chassis identity and physical location.
+	Labels map[string]string `json:"labels,omitempty"`
 	// ISO 8601 datetime when the Expected Rack was created
 	Created *time.Time `json:"created,omitempty"`
 	// ISO 8601 datetime when the Expected Rack was last updated

--- a/sdk/standard/model_expected_rack_create_request.go
+++ b/sdk/standard/model_expected_rack_create_request.go
@@ -33,8 +33,9 @@ type ExpectedRackCreateRequest struct {
 	// Human-readable name of the Expected Rack
 	Name NullableString `json:"name,omitempty"`
 	// Human-readable description of the Expected Rack
-	Description NullableString    `json:"description,omitempty"`
-	Labels      map[string]string `json:"labels,omitempty"`
+	Description NullableString `json:"description,omitempty"`
+	// User-defined key-value pairs for organizing and categorizing Expected Racks. Well-known keys (`chassis.*`, `location.*`) are used to convey chassis identity and physical location.
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 type _ExpectedRackCreateRequest ExpectedRackCreateRequest

--- a/sdk/standard/model_expected_rack_update_request.go
+++ b/sdk/standard/model_expected_rack_update_request.go
@@ -31,8 +31,9 @@ type ExpectedRackUpdateRequest struct {
 	// Human-readable name of the Expected Rack
 	Name NullableString `json:"name,omitempty"`
 	// Human-readable description of the Expected Rack
-	Description NullableString    `json:"description,omitempty"`
-	Labels      map[string]string `json:"labels,omitempty"`
+	Description NullableString `json:"description,omitempty"`
+	// User-defined key-value pairs for organizing and categorizing Expected Racks. Well-known keys (`chassis.*`, `location.*`) are used to convey chassis identity and physical location.
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // NewExpectedRackUpdateRequest instantiates a new ExpectedRackUpdateRequest object

--- a/sdk/standard/model_expected_switch.go
+++ b/sdk/standard/model_expected_switch.go
@@ -50,7 +50,8 @@ type ExpectedSwitch struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32     `json:"hostId,omitempty"`
+	HostId NullableInt32 `json:"hostId,omitempty"`
+	// User-defined key-value pairs for organizing and categorizing Expected Switches
 	Labels map[string]string `json:"labels,omitempty"`
 	// ISO 8601 datetime when the Expected Switch was created
 	Created *time.Time `json:"created,omitempty"`

--- a/sdk/standard/model_expected_switch_create_request.go
+++ b/sdk/standard/model_expected_switch_create_request.go
@@ -57,7 +57,8 @@ type ExpectedSwitchCreateRequest struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32     `json:"hostId,omitempty"`
+	HostId NullableInt32 `json:"hostId,omitempty"`
+	// User-defined key-value pairs for organizing and categorizing Expected Switches
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_expected_switch_update_request.go
+++ b/sdk/standard/model_expected_switch_update_request.go
@@ -55,7 +55,8 @@ type ExpectedSwitchUpdateRequest struct {
 	// Tray index within the rack
 	TrayIdx NullableInt32 `json:"trayIdx,omitempty"`
 	// Host ID within the tray
-	HostId NullableInt32     `json:"hostId,omitempty"`
+	HostId NullableInt32 `json:"hostId,omitempty"`
+	// User-defined key-value pairs for organizing and categorizing Expected Switches
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_infini_band_partition.go
+++ b/sdk/standard/model_infini_band_partition.go
@@ -23,23 +23,24 @@ var _ MappedNullable = &InfiniBandPartition{}
 
 // InfiniBandPartition InfiniBand Partitions are network segments utilizing InfiniBand topology
 type InfiniBandPartition struct {
-	Id                      *string                    `json:"id,omitempty"`
-	Name                    *string                    `json:"name,omitempty"`
-	Description             NullableString             `json:"description,omitempty"`
-	SiteId                  *string                    `json:"siteId,omitempty"`
-	TenantId                *string                    `json:"tenantId,omitempty"`
-	ControllerIBPartitionId NullableString             `json:"controllerIBPartitionId,omitempty"`
-	PartitionKey            NullableString             `json:"partitionKey,omitempty"`
-	PartitionName           NullableString             `json:"partitionName,omitempty"`
-	ServiceLevel            NullableInt32              `json:"serviceLevel,omitempty"`
-	RateLimit               NullableFloat32            `json:"rateLimit,omitempty"`
-	Mtu                     NullableInt32              `json:"mtu,omitempty"`
-	EnableSharp             *bool                      `json:"enableSharp,omitempty"`
-	Labels                  map[string]string          `json:"labels,omitempty"`
-	Status                  *InfiniBandPartitionStatus `json:"status,omitempty"`
-	StatusHistory           []StatusDetail             `json:"statusHistory,omitempty"`
-	Created                 *time.Time                 `json:"created,omitempty"`
-	Updated                 *time.Time                 `json:"updated,omitempty"`
+	Id                      *string         `json:"id,omitempty"`
+	Name                    *string         `json:"name,omitempty"`
+	Description             NullableString  `json:"description,omitempty"`
+	SiteId                  *string         `json:"siteId,omitempty"`
+	TenantId                *string         `json:"tenantId,omitempty"`
+	ControllerIBPartitionId NullableString  `json:"controllerIBPartitionId,omitempty"`
+	PartitionKey            NullableString  `json:"partitionKey,omitempty"`
+	PartitionName           NullableString  `json:"partitionName,omitempty"`
+	ServiceLevel            NullableInt32   `json:"serviceLevel,omitempty"`
+	RateLimit               NullableFloat32 `json:"rateLimit,omitempty"`
+	Mtu                     NullableInt32   `json:"mtu,omitempty"`
+	EnableSharp             *bool           `json:"enableSharp,omitempty"`
+	// String key value pairs describing InfiniBand Partition labels. Up to 10 key value pairs can be specified
+	Labels        map[string]string          `json:"labels,omitempty"`
+	Status        *InfiniBandPartitionStatus `json:"status,omitempty"`
+	StatusHistory []StatusDetail             `json:"statusHistory,omitempty"`
+	Created       *time.Time                 `json:"created,omitempty"`
+	Updated       *time.Time                 `json:"updated,omitempty"`
 }
 
 // NewInfiniBandPartition instantiates a new InfiniBandPartition object

--- a/sdk/standard/model_infini_band_partition_create_request.go
+++ b/sdk/standard/model_infini_band_partition_create_request.go
@@ -29,7 +29,8 @@ type InfiniBandPartitionCreateRequest struct {
 	// Optional description of the Partition
 	Description NullableString `json:"description,omitempty"`
 	// ID of the Site the Partition should belong to
-	SiteId string            `json:"siteId"`
+	SiteId string `json:"siteId"`
+	// String key value pairs describing Partition labels. Up to 10 key value pairs can be specified
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/sdk/standard/model_infini_band_partition_update_request.go
+++ b/sdk/standard/model_infini_band_partition_update_request.go
@@ -24,9 +24,10 @@ var _ MappedNullable = &InfiniBandPartitionUpdateRequest{}
 
 // InfiniBandPartitionUpdateRequest Request data to update an InfiniBand Partition
 type InfiniBandPartitionUpdateRequest struct {
-	Name        string            `json:"name"`
-	Description NullableString    `json:"description,omitempty"`
-	Labels      map[string]string `json:"labels,omitempty"`
+	Name        string         `json:"name"`
+	Description NullableString `json:"description,omitempty"`
+	// String key value pairs describing Partition labels. Up to 10 key value pairs can be specified
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 type _InfiniBandPartitionUpdateRequest InfiniBandPartitionUpdateRequest

--- a/sdk/standard/model_instance_update_request.go
+++ b/sdk/standard/model_instance_update_request.go
@@ -44,8 +44,9 @@ type InstanceUpdateRequest struct {
 	// Whether the custom iPXE data should be used for every boot.
 	AlwaysBootWithCustomIpxe NullableBool `json:"alwaysBootWithCustomIpxe,omitempty"`
 	// Indicates whether the Phone Home service should be enabled or disabled for Instance
-	PhoneHomeEnabled NullableBool      `json:"phoneHomeEnabled,omitempty"`
-	Labels           map[string]string `json:"labels,omitempty"`
+	PhoneHomeEnabled NullableBool `json:"phoneHomeEnabled,omitempty"`
+	// Update labels of the Instance. The labels will be entirely replaced by those sent in the request. Any labels not included in the request will be removed. To retain existing labels, first fetch them and include them along with this request.
+	Labels map[string]string `json:"labels,omitempty"`
 	// IDs of additional VPCs the Instance should attach to through non-primary interfaces. This field may only be specified when every entry in `interfaces` uses `vpcPrefixId`. IDs must be unique, must be valid UUIDs, and must not include the primary `vpcId`.
 	SecondaryVpcIds []string `json:"secondaryVpcIds,omitempty"`
 	// Update Interfaces of the Instance. Mutually exclusive with `autoNetwork`: when `autoNetwork` is true this list MUST be empty.

--- a/sdk/standard/model_machine_update_request.go
+++ b/sdk/standard/model_machine_update_request.go
@@ -29,9 +29,10 @@ type MachineUpdateRequest struct {
 	// Set to `true` to enable maintenance mode and to `false` to disable maintenance mode. Can be set by Provider or Privileged Tenant.
 	SetMaintenanceMode NullableBool `json:"setMaintenanceMode,omitempty"`
 	// Optional message describing the reason for moving Machine into maintenance mode. Can be updated by Provider or Privileged Tenant.
-	MaintenanceMessage NullableString       `json:"maintenanceMessage,omitempty"`
-	Labels             map[string]string    `json:"labels,omitempty"`
-	OnlineRepair       *MachineOnlineRepair `json:"onlineRepair,omitempty"`
+	MaintenanceMessage NullableString `json:"maintenanceMessage,omitempty"`
+	// Machine labels will be overwritten, include existing labels to preserve them. Can be updated by Provider or Privileged Tenant.
+	Labels       map[string]string    `json:"labels,omitempty"`
+	OnlineRepair *MachineOnlineRepair `json:"onlineRepair,omitempty"`
 	// Required when `onlineRepair.enabled` is true. Must not be set when exiting online repair (`onlineRepair.enabled` false).
 	HealthIssue *MachineHealthIssue `json:"healthIssue,omitempty"`
 }

--- a/sdk/standard/model_vpc.go
+++ b/sdk/standard/model_vpc.go
@@ -50,8 +50,9 @@ type VPC struct {
 	// Propagation details for the attached Network Security Group
 	NetworkSecurityGroupPropagationDetails *NetworkSecurityGroupPropagationDetails `json:"networkSecurityGroupPropagationDetails,omitempty"`
 	// ID of the default NVLink Logical Partition that GPUs for all Instances in the VPC will attach to
-	NvLinkLogicalPartitionId NullableString    `json:"nvLinkLogicalPartitionId,omitempty"`
-	Labels                   map[string]string `json:"labels,omitempty"`
+	NvLinkLogicalPartitionId NullableString `json:"nvLinkLogicalPartitionId,omitempty"`
+	// String key value pairs describing VPC labels
+	Labels map[string]string `json:"labels,omitempty"`
 	// Status of the VPC
 	Status *VpcStatus `json:"status,omitempty"`
 	// History of status changes for the VPC

--- a/sdk/standard/model_vpc_create_request.go
+++ b/sdk/standard/model_vpc_create_request.go
@@ -41,8 +41,9 @@ type VpcCreateRequest struct {
 	// Explicitly requested VNI for the VPC
 	Vni NullableInt32 `json:"vni,omitempty"`
 	// ID of the default NVLink Logical Partition that GPUs for all Instances in the VPC will attach to
-	NvLinkLogicalPartitionId NullableString    `json:"nvLinkLogicalPartitionId,omitempty"`
-	Labels                   map[string]string `json:"labels,omitempty"`
+	NvLinkLogicalPartitionId NullableString `json:"nvLinkLogicalPartitionId,omitempty"`
+	// String key value pairs describing VPC labels. Up to 10 key value pairs can be specified
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 type _VpcCreateRequest VpcCreateRequest

--- a/sdk/standard/model_vpc_update_request.go
+++ b/sdk/standard/model_vpc_update_request.go
@@ -29,8 +29,9 @@ type VpcUpdateRequest struct {
 	// ID of the Network Security Group to attach to the VPC
 	NetworkSecurityGroupId NullableString `json:"networkSecurityGroupId,omitempty"`
 	// ID of the default NVLink Logical Partition that GPUs for all Instances in the VPC will attach to. Can only be updated if VPC currently has no active Instances
-	NvLinkLogicalPartitionId NullableString    `json:"nvLinkLogicalPartitionId,omitempty"`
-	Labels                   map[string]string `json:"labels,omitempty"`
+	NvLinkLogicalPartitionId NullableString `json:"nvLinkLogicalPartitionId,omitempty"`
+	// Update labels of the VPC. Up to 10 key value pairs can be specified. The labels will be entirely replaced by those sent in the request. Any labels not included in the request will be removed. To retain existing labels, first fetch them and include them along with this request.
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // NewVpcUpdateRequest instantiates a new VpcUpdateRequest object


### PR DESCRIPTION
## Description

`AuditEntry.queryParams` and `AuditEntry.body` were declared as `type: string` in `openapi/spec.yaml`, but the Go API model, DB model, and audit middleware all use `url.Values` (= `map[string][]string`) and `map[string]interface{}` respectively, so the wire shape on `GET /audit` is a JSON object, not a stringified JSON. 

Regenerate `docs/index.html` and `sdk/standard/` accordingly.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [x] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **API** - API models or endpoints updated
- [ ] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **Flow** - Flow service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
