### PR TITLE
refactor: Replace for loops with range-based iteration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,47 @@ make kind-down              # tear down cluster
 - OpenAPI schema in `openapi/spec.yaml` must be updated whenever API
   endpoints are added or modified.
 
+### Prefer range-based iteration over C-style `for` loops
+
+The module is on Go 1.25, so reach for range-based iteration before the
+three-clause `for i := 0; i < n; i++` / `i--` form. Go 1.22 range-over-integer
+and Go 1.23 range-over-function iterators (`slices.Backward`, `slices.All`,
+`slices.Values`, `maps.Keys`, `maps.Values`, …) drop the manual index
+bookkeeping that the older form makes a reader re-derive to trust.
+
+1. **Counting loop → range-over-integer.** When the bound is a count (not a
+   slice you also index for values), use `for i := range n` (index needed) or
+   `for range n` (index unused) instead of `for i := 0; i < n; i++`. This
+   covers `reflect` walks: `for i := range v.NumField()` /
+   `for i := range v.Len()`.
+2. **Reverse loop → `slices.Backward`.** Replace
+   `for i := len(s) - 1; i >= 0; i--` with `for i, v := range slices.Backward(s)`.
+   When the reverse order is intentional (LIFO teardown, "find the last element
+   matching X"), `slices.Backward` states that intent instead of leaving it
+   implicit in the index arithmetic. Use `for i := range slices.Backward(s)`
+   when you only need the index (to take `&s[i]` or mutate `s[i]`).
+3. **Index loop over a slice → plain `range`.** `for i := 0; i < len(s); i++`
+   that reads `s[i]` becomes `for i, v := range s` (or `for _, v := range s`);
+   keep the index-only `for i := range s` when the body needs `&s[i]`.
+
+Keep the C-style form when range can't express the loop, and say why if it
+isn't obvious:
+
+- **Byte-wise string scans.** A loop that indexes `s[i]` on a `string` must
+  stay C-style — `for i := range s` over a string yields *runes*, silently
+  changing byte offsets.
+- **The index is mutated or looks ahead/behind** in the body (`i++` to consume
+  a paired argument, `s[i+1]`, `i = j-1`). Range indices are read-only.
+- **1-indexed or offset-start loops** (`for page := 1; page <= total; page++`,
+  `for i := windowStart; i < windowEnd; i++`). Range-over-integer is 0-based;
+  forcing a `+1` reads worse than the original.
+- **Generated code** (e.g. `sdk/standard`) — leave it; regeneration overwrites
+  hand edits.
+
+A related cleanup: a backward byte scan for a delimiter is
+`strings.LastIndexByte`, not a hand-rolled `for i := idx; i >= 0; i--` — see
+`(*IPAddr).Scan` in `powershelf-manager/pkg/db/model/types.go`.
+
 ### Proto conversion methods
 
 DB and API model types that round-trip with a workflow-schema (`cwssaws`)

--- a/api/pkg/api/handler/audit_entry.go
+++ b/api/pkg/api/handler/audit_entry.go
@@ -128,7 +128,7 @@ func (gaaeh GetAllAuditEntryHandler) Handle(c echo.Context) error {
 		logger.Error().Err(err).Msg("error retrieving Users from DB")
 		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to retrieve Users", nil)
 	}
-	for i := 0; i < len(dbUsers); i++ {
+	for i := range dbUsers {
 		dbUsersMap[dbUsers[i].ID] = &dbUsers[i]
 	}
 

--- a/api/pkg/api/handler/instance.go
+++ b/api/pkg/api/handler/instance.go
@@ -1250,7 +1250,7 @@ func (cih CreateInstanceHandler) Handle(c echo.Context) error {
 			// For a given Machine, all the GPUs should be connected to the same NVLink Logical Partition
 			for _, nvlCap := range nvlCaps {
 				if nvlCap.Count != nil {
-					for i := 0; i < *nvlCap.Count; i++ {
+					for i := range *nvlCap.Count {
 						dbnvlic = append(dbnvlic, cdbm.NVLinkInterface{NVLinkLogicalPartitionID: *defaultNvllpID, Device: cdb.GetStrPtr(nvlCap.Name), DeviceInstance: i})
 					}
 				}

--- a/api/pkg/api/handler/instancebatch.go
+++ b/api/pkg/api/handler/instancebatch.go
@@ -851,7 +851,7 @@ func (bcih BatchCreateInstanceHandler) Handle(c echo.Context) error {
 	// Build all instance names first, then check in a single batch query
 	inDAO := cdbm.NewInstanceDAO(bcih.dbSession)
 	allInstanceNames := make([]string, apiRequest.Count)
-	for i := 0; i < apiRequest.Count; i++ {
+	for i := range apiRequest.Count {
 		allInstanceNames[i] = generateInstanceName(i)
 	}
 
@@ -1108,7 +1108,7 @@ func (bcih BatchCreateInstanceHandler) Handle(c echo.Context) error {
 		dbnvlic = []cdbm.NVLinkInterface{}
 		for _, nvlCap := range itNvlCaps {
 			if nvlCap.Count != nil {
-				for i := 0; i < *nvlCap.Count; i++ {
+				for i := range *nvlCap.Count {
 					dbnvlic = append(dbnvlic, cdbm.NVLinkInterface{
 						NVLinkLogicalPartitionID: *defaultNvllpID,
 						Device:                   cdb.GetStrPtr(nvlCap.Name),

--- a/api/pkg/api/handler/util/common/common.go
+++ b/api/pkg/api/handler/util/common/common.go
@@ -1574,7 +1574,7 @@ func QueryTagsFor(v any) []string {
 		return cached.([]string)
 	}
 	var tags []string
-	for i := 0; i < t.NumField(); i++ {
+	for i := range t.NumField() {
 		if tag := t.Field(i).Tag.Get("query"); tag != "" {
 			tags = append(tags, tag)
 		}

--- a/auth/pkg/testing/utilities.go
+++ b/auth/pkg/testing/utilities.go
@@ -224,14 +224,14 @@ func NewConcurrencyHelper(t *testing.T) *ConcurrencyHelper {
 func (h *ConcurrencyHelper) RunConcurrent(fn func() error, numGoroutines int, description string) []error {
 	errChan := make(chan error, numGoroutines)
 
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		go func() {
 			errChan <- fn()
 		}()
 	}
 
 	var errors []error
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		if err := <-errChan; err != nil {
 			errors = append(errors, err)
 		}

--- a/cli/tui/repl.go
+++ b/cli/tui/repl.go
@@ -477,7 +477,7 @@ func clearSuggestionLines(count int) {
 	if count == 0 {
 		return
 	}
-	for i := 0; i < count; i++ {
+	for range count {
 		fmt.Print("\r\n")
 		ClearLine()
 	}

--- a/flow/internal/task/executor/temporalworkflow/manager/manager.go
+++ b/flow/internal/task/executor/temporalworkflow/manager/manager.go
@@ -149,8 +149,8 @@ func (m *Manager) Start(ctx context.Context) error {
 	for queue, worker := range m.workers {
 		log.Info().Msgf("Starting temporal worker for queue %s", queue)
 		if err := worker.Start(); err != nil {
-			for i := len(started) - 1; i >= 0; i-- {
-				started[i].Stop()
+			for _, s := range slices.Backward(started) {
+				s.Stop()
 			}
 			// Do not close publisherClient/subscriberClient here: they are
 			// owned by the Manager (created in Build, not in Start) and must

--- a/flow/pkg/common/utils/utils.go
+++ b/flow/pkg/common/utils/utils.go
@@ -43,7 +43,7 @@ func StructToMap(obj any) map[string]any {
 	}
 
 	t := reflect.TypeOf(obj)
-	for i := 0; i < v.NumField(); i++ {
+	for i := range v.NumField() {
 		field := t.Field(i)
 		fieldValue := v.Field(i)
 
@@ -185,7 +185,7 @@ func deepCopyValue(value any) any {
 		return mapCopy.Interface()
 	case reflect.Slice:
 		sliceCopy := reflect.MakeSlice(v.Type(), v.Len(), v.Cap())
-		for i := 0; i < v.Len(); i++ {
+		for i := range v.Len() {
 			sliceCopy.Index(i).Set(reflect.ValueOf(deepCopyValue(v.Index(i).Interface())))
 		}
 		return sliceCopy.Interface()
@@ -198,7 +198,7 @@ func deepCopyValue(value any) any {
 		return ptrCopy.Interface()
 	case reflect.Struct:
 		structCopy := reflect.New(v.Type()).Elem()
-		for i := 0; i < v.NumField(); i++ {
+		for i := range v.NumField() {
 			if structCopy.Field(i).CanSet() {
 				structCopy.Field(i).Set(reflect.ValueOf(deepCopyValue(v.Field(i).Interface())))
 			}

--- a/flow/pkg/inventoryobjects/rack/rack.go
+++ b/flow/pkg/inventoryobjects/rack/rack.go
@@ -5,6 +5,7 @@ package rack
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -113,8 +114,7 @@ func (r *Rack) sortComponentsByPosition() {
 	trayIndexMap := make(map[devicetypes.ComponentType]int)
 	prevRackSlot := make(map[devicetypes.ComponentType]int)
 
-	for i := len(r.Components) - 1; i >= 0; i-- {
-		c := r.Components[i]
+	for i, c := range slices.Backward(r.Components) {
 		t := c.Type
 		if prevRackSlot[t] > 0 && c.Position.SlotID > prevRackSlot[t] {
 			// Not the first tray for a component category and the rack slot

--- a/flow/pkg/workerpool/workerpool.go
+++ b/flow/pkg/workerpool/workerpool.go
@@ -93,7 +93,7 @@ func (wp *WorkerPool) Start() error {
 	}
 
 	// Create and start workers
-	for i := 0; i < wp.config.MaxWorkers; i++ {
+	for i := range wp.config.MaxWorkers {
 		worker := &worker{
 			id:   i + 1,
 			pool: wp,

--- a/nvswitch-manager/pkg/firmwaremanager/worker.go
+++ b/nvswitch-manager/pkg/firmwaremanager/worker.go
@@ -94,7 +94,7 @@ func (p *WorkerPool) Start() {
 	log.Infof("Starting worker pool with %d workers (scheduler interval: %v)", p.numWorkers, p.schedulerInterval)
 
 	// Start workers
-	for i := 0; i < p.numWorkers; i++ {
+	for i := range p.numWorkers {
 		p.wg.Add(1)
 		go p.worker(i)
 	}

--- a/powershelf-manager/pkg/db/model/types.go
+++ b/powershelf-manager/pkg/db/model/types.go
@@ -7,6 +7,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"net"
+	"strings"
 )
 
 // MacAddr wraps net.HardwareAddr to provide proper SQL driver support for PostgreSQL macaddr type.
@@ -88,13 +89,8 @@ func (ip *IPAddr) Scan(src interface{}) error {
 	}
 
 	// PostgreSQL inet type may include CIDR notation, strip it if present
-	if idx := len(ipStr) - 1; idx > 0 {
-		for i := idx; i >= 0; i-- {
-			if ipStr[i] == '/' {
-				ipStr = ipStr[:i]
-				break
-			}
-		}
+	if i := strings.LastIndexByte(ipStr, '/'); i >= 0 {
+		ipStr = ipStr[:i]
 	}
 
 	parsed := net.ParseIP(ipStr)

--- a/powershelf-manager/pkg/db/model/types_test.go
+++ b/powershelf-manager/pkg/db/model/types_test.go
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIPAddrScan covers (*IPAddr).Scan, with emphasis on the CIDR-notation
+// stripping that PostgreSQL's inet type can return (e.g. "192.168.1.100/24").
+// The strip is implemented with strings.LastIndexByte, so these cases pin that
+// behavior — including the IPv6 path (a single '/' prefix delimiter, never a
+// colon) and the bare "/" edge case, which strips to "" and is then rejected
+// by net.ParseIP.
+func TestIPAddrScan(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     interface{}
+		wantIP  string // expected IPAddr.String(); ignored when wantErr is true
+		wantErr bool
+	}{
+		{name: "plain IPv4 string", src: "192.168.1.100", wantIP: "192.168.1.100"},
+		{name: "IPv4 with CIDR prefix", src: "192.168.1.100/24", wantIP: "192.168.1.100"},
+		{name: "IPv4 with /32", src: "10.0.0.2/32", wantIP: "10.0.0.2"},
+		{name: "IPv6 plain", src: "2001:db8::1", wantIP: "2001:db8::1"},
+		{name: "IPv6 with CIDR prefix", src: "2001:db8::1/64", wantIP: "2001:db8::1"},
+		{name: "[]byte with CIDR prefix", src: []byte("172.16.0.5/16"), wantIP: "172.16.0.5"},
+		{name: "[]byte plain", src: []byte("8.8.8.8"), wantIP: "8.8.8.8"},
+		{name: "nil src clears to <nil>", src: nil, wantIP: "<nil>"},
+		{name: "unsupported type errors", src: 42, wantErr: true},
+		{name: "unparseable string errors", src: "not-an-ip", wantErr: true},
+		{name: "bare slash strips to empty and errors", src: "/", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ip IPAddr
+			err := ip.Scan(tt.src)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			if !assert.NoError(t, err) {
+				return
+			}
+			assert.Equal(t, tt.wantIP, ip.String())
+		})
+	}
+}

--- a/site-workflow/pkg/grpc/client/testing.go
+++ b/site-workflow/pkg/grpc/client/testing.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"slices"
 	"time"
 
 	"github.com/gogo/status"
@@ -46,7 +47,7 @@ func generateSiteVersion() string {
 // It handles carrying over to the next byte when a byte overflows (reaches 255).
 func incrementMAC(mac net.HardwareAddr) {
 	// Iterate from the last byte to the first.
-	for i := len(mac) - 1; i >= 0; i-- {
+	for i := range slices.Backward(mac) {
 		// Increment the current byte.
 		mac[i]++
 		// If the byte is not 0, it means there was no overflow, so we can stop.
@@ -101,7 +102,7 @@ func (mcgsc *MockCoreGrpcServiceClient) FindVpcIds(ctx context.Context, in *wflo
 
 	count, ok := ctx.Value("wantCount").(int)
 	if ok {
-		for i := 0; i < count; i++ {
+		for range count {
 			out.VpcIds = append(out.VpcIds, &wflows.VpcId{Value: uuid.NewString()})
 		}
 	}
@@ -149,7 +150,7 @@ func (mcgsc *MockCoreGrpcServiceClient) FindNetworkSegmentIds(ctx context.Contex
 
 	count, ok := ctx.Value("wantCount").(int)
 	if ok {
-		for i := 0; i < count; i++ {
+		for range count {
 			out.NetworkSegmentsIds = append(out.NetworkSegmentsIds, &wflows.NetworkSegmentId{Value: uuid.NewString()})
 		}
 	}
@@ -210,7 +211,7 @@ func (mcgsc *MockCoreGrpcServiceClient) FindIBPartitionIds(ctx context.Context, 
 
 	count, ok := ctx.Value("wantCount").(int)
 	if ok {
-		for i := 0; i < count; i++ {
+		for range count {
 			out.IbPartitionIds = append(out.IbPartitionIds, &wflows.IBPartitionId{Value: uuid.NewString()})
 		}
 	}
@@ -283,7 +284,7 @@ func (mcgsc *MockCoreGrpcServiceClient) FindInstanceIds(ctx context.Context, in 
 
 	count, ok := ctx.Value("wantCount").(int)
 	if ok {
-		for i := 0; i < count; i++ {
+		for range count {
 			out.InstanceIds = append(out.InstanceIds, &wflows.InstanceId{Value: uuid.NewString()})
 		}
 	}
@@ -362,7 +363,7 @@ func (mcgsc *MockCoreGrpcServiceClient) FindMachineIds(ctx context.Context, in *
 
 	count, ok := ctx.Value("wantCount").(int)
 	if ok {
-		for i := 0; i < count; i++ {
+		for range count {
 			out.MachineIds = append(out.MachineIds, &wflows.MachineId{Id: uuid.NewString()})
 		}
 	}
@@ -425,7 +426,7 @@ func (mcgsc *MockCoreGrpcServiceClient) FindTenantKeysetIds(ctx context.Context,
 	count, ok := ctx.Value("wantCount").(int)
 	if ok {
 		orgID := uuid.NewString()
-		for i := 0; i < count; i++ {
+		for range count {
 			out.KeysetIds = append(out.KeysetIds, &wflows.TenantKeysetIdentifier{OrganizationId: orgID, KeysetId: uuid.NewString()})
 		}
 	}
@@ -480,7 +481,7 @@ func (mcgsc *MockCoreGrpcServiceClient) ListOsImage(ctx context.Context, in *wfl
 	count, ok := ctx.Value("wantCount").(int)
 	if ok {
 		id := uuid.NewString()
-		for i := 0; i < count; i++ {
+		for range count {
 			out.Images = append(out.Images, &wflows.OsImage{Attributes: &wflows.OsImageAttributes{Id: &wflows.UUID{Value: id}}})
 		}
 	}
@@ -520,7 +521,7 @@ func (mcgsc *MockCoreGrpcServiceClient) FindTenantOrganizationIds(ctx context.Co
 
 	count, ok := ctx.Value("wantCount").(int)
 	if ok {
-		for i := 0; i < count; i++ {
+		for range count {
 			out.TenantOrganizationIds = append(out.TenantOrganizationIds, randSeq(10))
 		}
 	}
@@ -585,7 +586,7 @@ func (mcgsc *MockCoreGrpcServiceClient) FindInstanceTypeIds(ctx context.Context,
 
 	count, ok := ctx.Value("wantCount").(int)
 	if ok {
-		for i := 0; i < count; i++ {
+		for range count {
 			out.InstanceTypeIds = append(out.InstanceTypeIds, randSeq(10))
 		}
 	}
@@ -635,7 +636,7 @@ func (mcgsc *MockCoreGrpcServiceClient) SearchVpcPrefixes(ctx context.Context, i
 
 	count, ok := ctx.Value("wantCount").(int)
 	if ok {
-		for i := 0; i < count; i++ {
+		for range count {
 			out.VpcPrefixIds = append(out.VpcPrefixIds, &wflows.VpcPrefixId{Value: uuid.NewString()})
 		}
 	}
@@ -685,7 +686,7 @@ func (mcgsc *MockCoreGrpcServiceClient) FindVpcPeeringIds(ctx context.Context, i
 
 	count, ok := ctx.Value("WantCount").(int)
 	if ok {
-		for i := 0; i < count; i++ {
+		for range count {
 			out.VpcPeeringIds = append(out.VpcPeeringIds, &wflows.VpcPeeringId{Value: uuid.NewString()})
 		}
 	}
@@ -809,7 +810,7 @@ func (mcgsc *MockCoreGrpcServiceClient) FindNetworkSecurityGroupIds(ctx context.
 
 	count, ok := ctx.Value("wantCount").(int)
 	if ok {
-		for i := 0; i < count; i++ {
+		for range count {
 			out.NetworkSecurityGroupIds = append(out.NetworkSecurityGroupIds, randSeq(10))
 		}
 	}
@@ -969,7 +970,7 @@ func (mcgsc *MockCoreGrpcServiceClient) GetAllExpectedMachines(ctx context.Conte
 	count, ok := ctx.Value("wantCount").(int)
 	if ok {
 		mac, _ := net.ParseMAC("02:00:00:00:00:00")
-		for i := 0; i < count; i++ {
+		for range count {
 			// Create a 16-byte array for UUID from MAC address (6 bytes) + padding
 			var uuidBytes [16]byte
 			copy(uuidBytes[:6], mac)
@@ -1007,7 +1008,7 @@ func (mcgsc *MockCoreGrpcServiceClient) GetAllExpectedMachinesLinked(ctx context
 	count, ok := ctx.Value("wantCount").(int)
 	if ok {
 		mac, _ := net.ParseMAC("02:00:00:00:00:00")
-		for i := 0; i < count; i++ {
+		for range count {
 			// Create a 16-byte array for UUID from MAC address (6 bytes) + padding
 			var uuidBytes [16]byte
 			copy(uuidBytes[:6], mac)
@@ -1075,7 +1076,7 @@ func (mcgsc *MockCoreGrpcServiceClient) GetAllExpectedPowerShelves(ctx context.C
 	count, ok := ctx.Value("wantCount").(int)
 	if ok {
 		mac, _ := net.ParseMAC("02:00:00:00:00:00")
-		for i := 0; i < count; i++ {
+		for range count {
 			var uuidBytes [16]byte
 			copy(uuidBytes[:6], mac)
 			epsID, _ := uuid.FromBytes(uuidBytes[:])
@@ -1103,7 +1104,7 @@ func (mcgsc *MockCoreGrpcServiceClient) GetAllExpectedPowerShelvesLinked(ctx con
 	count, ok := ctx.Value("wantCount").(int)
 	if ok {
 		mac, _ := net.ParseMAC("02:00:00:00:00:00")
-		for i := 0; i < count; i++ {
+		for range count {
 			var uuidBytes [16]byte
 			copy(uuidBytes[:6], mac)
 			powerShelfID, _ := uuid.FromBytes(uuidBytes[:])
@@ -1170,7 +1171,7 @@ func (mcgsc *MockCoreGrpcServiceClient) GetAllExpectedSwitches(ctx context.Conte
 	count, ok := ctx.Value("wantCount").(int)
 	if ok {
 		mac, _ := net.ParseMAC("02:00:00:00:00:00")
-		for i := 0; i < count; i++ {
+		for range count {
 			var uuidBytes [16]byte
 			copy(uuidBytes[:6], mac)
 			esID, _ := uuid.FromBytes(uuidBytes[:])
@@ -1198,7 +1199,7 @@ func (mcgsc *MockCoreGrpcServiceClient) GetAllExpectedSwitchesLinked(ctx context
 	count, ok := ctx.Value("wantCount").(int)
 	if ok {
 		mac, _ := net.ParseMAC("02:00:00:00:00:00")
-		for i := 0; i < count; i++ {
+		for range count {
 			var uuidBytes [16]byte
 			copy(uuidBytes[:6], mac)
 			switchID, _ := uuid.FromBytes(uuidBytes[:])
@@ -1275,7 +1276,7 @@ func (mcgsc *MockCoreGrpcServiceClient) GetAllExpectedRacks(ctx context.Context,
 
 	count, ok := ctx.Value("wantCount").(int)
 	if ok {
-		for i := 0; i < count; i++ {
+		for range count {
 			out.ExpectedRacks = append(out.ExpectedRacks, &wflows.ExpectedRack{
 				RackId:   &wflows.RackId{Id: uuid.NewString()},
 				RackType: uuid.NewString(),
@@ -1335,7 +1336,7 @@ func (mcgsc *MockCoreGrpcServiceClient) GetAllSkuIds(ctx context.Context, in *em
 
 	count, ok := ctx.Value("wantCount").(int)
 	if ok {
-		for i := 0; i < count; i++ {
+		for range count {
 			out.Ids = append(out.Ids, uuid.NewString())
 		}
 	}
@@ -1411,7 +1412,7 @@ func (mcgsc *MockCoreGrpcServiceClient) FindDpuExtensionServiceIds(ctx context.C
 	out := &wflows.DpuExtensionServiceIdList{}
 	count, ok := ctx.Value("wantCount").(int)
 	if ok {
-		for i := 0; i < count; i++ {
+		for range count {
 			out.ServiceIds = append(out.ServiceIds, uuid.NewString())
 		}
 	}
@@ -1436,7 +1437,7 @@ func (mcgsc *MockCoreGrpcServiceClient) GetDpuExtensionServiceVersionsInfo(ctx c
 	}
 	count, ok := ctx.Value("wantCount").(int)
 	if ok {
-		for i := 0; i < count; i++ {
+		for range count {
 			out.VersionInfos = append(out.VersionInfos, &wflows.DpuExtensionServiceVersionInfo{
 				Version:       generateSiteVersion(),
 				Data:          "test data",
@@ -1481,7 +1482,7 @@ func (mcgsc *MockCoreGrpcServiceClient) FindNVLinkLogicalPartitionIds(ctx contex
 
 	count, ok := ctx.Value("wantCount").(int)
 	if ok {
-		for i := 0; i < count; i++ {
+		for range count {
 			out.PartitionIds = append(out.PartitionIds, &wflows.NVLinkLogicalPartitionId{Value: uuid.NewString()})
 		}
 	}
@@ -1512,7 +1513,7 @@ func (mcgsc *MockCoreGrpcServiceClient) NVLinkLogicalPartitionsForTenant(ctx con
 
 	count, ok := ctx.Value("wantCount").(int)
 	if ok {
-		for i := 0; i < count; i++ {
+		for range count {
 			out.Partitions = append(out.Partitions, &wflows.NVLinkLogicalPartition{
 				Id: &wflows.NVLinkLogicalPartitionId{Value: uuid.NewString()},
 			})

--- a/workflow/pkg/activity/instance/instance.go
+++ b/workflow/pkg/activity/instance/instance.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/google/uuid"
@@ -1348,7 +1349,7 @@ func (milm ManageInstanceLifecycleMetrics) RecordInstanceStatusTransitionMetrics
 			// DELETE event: Measure time from Terminating to actual deletion
 			// Find the earliest Terminating status (iterate backwards since sorted DESC)
 			var terminatingSD *cdbm.StatusDetail
-			for i := len(statusDetails) - 1; i >= 0; i-- {
+			for i := range slices.Backward(statusDetails) {
 				if statusDetails[i].Status == cdbm.InstanceStatusTerminating {
 					terminatingSD = &statusDetails[i]
 					break

--- a/workflow/pkg/activity/subnet/subnet.go
+++ b/workflow/pkg/activity/subnet/subnet.go
@@ -6,6 +6,7 @@ package subnet
 import (
 	"context"
 	"database/sql"
+	"slices"
 	"time"
 
 	"github.com/google/uuid"
@@ -476,7 +477,7 @@ func (mslm ManageSubnetLifecycleMetrics) RecordSubnetStatusTransitionMetrics(ctx
 			// DELETE event: Measure time from Deleting to actual deletion
 			// Find the earliest Deleting status (iterate backwards since sorted DESC)
 			var deletingSD *cdbm.StatusDetail
-			for i := len(statusDetails) - 1; i >= 0; i-- {
+			for i := range slices.Backward(statusDetails) {
 				if statusDetails[i].Status == cdbm.SubnetStatusDeleting {
 					deletingSD = &statusDetails[i]
 					break

--- a/workflow/pkg/activity/vpc/vpc.go
+++ b/workflow/pkg/activity/vpc/vpc.go
@@ -6,6 +6,7 @@ package vpc
 import (
 	"context"
 	"errors"
+	"slices"
 	"time"
 
 	"github.com/google/uuid"
@@ -478,7 +479,7 @@ func (mvlm ManageVpcLifecycleMetrics) RecordVpcStatusTransitionMetrics(ctx conte
 			// DELETE event: Measure time from Deleting to actual deletion
 			// Find the earliest Deleting status (iterate backwards since sorted DESC)
 			var deletingStatusDetail *cdbm.StatusDetail
-			for i := len(statusDetails) - 1; i >= 0; i-- {
+			for i := range slices.Backward(statusDetails) {
 				sd := &statusDetails[i]
 				if sd.Status == cdbm.VpcStatusDeleting {
 					deletingStatusDetail = sd


### PR DESCRIPTION
## Description

Since we're on a modern-enough version of Go, we can modernize ~45 `for` loops to range-based iteration (instead of `i++`, `i--`, etc...).

Includes:
- plain `range` over a slice where the body only indexed it.
- `range` over an integer (e.g. `for i := range n` / `for range n`, used by count and `reflect` loops, worker pools, NVLink interface generation, batch instance naming, struct/slice field walks, etc).
- `slices.Backward` for reverse loops (e.g. manager LIFO shutdown, rack tray indexing, VPC/Instance/Subnet deletion-duration metrics, MAC carry-increment, etc).

Also a tweak where `(*IPAddr).Scan` strips CIDR with `strings.LastIndexByte` instead of a backward byte scan.

I left the three clause/C-style/whatever you call them loops where range can't express it:
- Any string scans (because `range` over a string yields runes).
- Any index-mutated / look-ahead loops.
- Things related to pagination.
- Generated/SDK code.

Tests added! New `TestIPAddrScan` checks the CIDR-strip behavior (there was no coverage before).

Also updated `AGENTS.md` to document this (the entry itself was written by an agent so it makes sense to an agent -- personally to me it's a little dense but if that's what it wants for itself, go for it).

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [ ] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [x] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [x] **API** - API models or endpoints updated
- [x] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [x] **Flow** - Flow service updated
- [x] **Powershelf Manager** - Powershelf Manager updated
- [x] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
