### PR TITLE
fix: Log the local serr in workflow status-update fallbacks

### DIFF
--- a/workflow/pkg/activity/machine/machine.go
+++ b/workflow/pkg/activity/machine/machine.go
@@ -158,7 +158,7 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 			Status:            &status,
 		})
 		if serr != nil {
-			logger.Error().Err(err).Msg("failed to update Site status in DB")
+			logger.Error().Err(serr).Msg("failed to update Site status in DB")
 		}
 
 		sdDAO := cdbm.NewStatusDetailDAO(mm.dbSession)
@@ -173,7 +173,7 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 			InventoryReceived: &curTime,
 		})
 		if serr != nil {
-			logger.Error().Err(err).Msg("failed to update Site status in DB")
+			logger.Error().Err(serr).Msg("failed to update Site status in DB")
 		}
 	}
 

--- a/workflow/pkg/activity/operatingsystem/operatingsystem.go
+++ b/workflow/pkg/activity/operatingsystem/operatingsystem.go
@@ -174,7 +174,7 @@ func (mskg ManageOsImage) UpdateOsImagesInDB(ctx context.Context, siteID uuid.UU
 			if ossaStatus != ossa.Status {
 				serr := mskg.updateOperatingSystemSiteAssociationStatusInDB(ctx, nil, ossa.ID, cdb.GetStrPtr(ossaStatus), ossaStatusMessage)
 				if serr != nil {
-					slogger.Error().Err(err).Msg("failed to update OS Image Site Association status detail in DB")
+					slogger.Error().Err(serr).Msg("failed to update OS Image Site Association status detail in DB")
 				}
 				updatedOperatingSystemMap[ossa.OperatingSystemID] = true
 			}
@@ -211,7 +211,7 @@ func (mskg ManageOsImage) UpdateOsImagesInDB(ctx context.Context, siteID uuid.UU
 			// Trigger re-evaluation of Operating System status (delete if no association exists)
 			serr = mskg.UpdateOperatingSystemStatusInDB(ctx, ossa.OperatingSystemID)
 			if serr != nil {
-				slogger.Error().Err(err).Msg("failed to trigger Operating System status update in DB")
+				slogger.Error().Err(serr).Msg("failed to trigger Operating System status update in DB")
 			}
 		} else {
 			// Was this created within inventory receipt interval? If so, we may be processing an older inventory
@@ -235,7 +235,7 @@ func (mskg ManageOsImage) UpdateOsImagesInDB(ctx context.Context, siteID uuid.UU
 
 			serr = mskg.updateOperatingSystemSiteAssociationStatusInDB(ctx, nil, ossa.ID, cdb.GetStrPtr(cdbm.OperatingSystemSiteAssociationStatusError), cdb.GetStrPtr("Operating System is missing on Site"))
 			if serr != nil {
-				slogger.Error().Err(err).Msg("failed to update Operating System Site Association status detail in DB")
+				slogger.Error().Err(serr).Msg("failed to update Operating System Site Association status detail in DB")
 			}
 
 			updatedOperatingSystemMap[ossa.OperatingSystemID] = true

--- a/workflow/pkg/activity/sshkeygroup/sshkeygroup.go
+++ b/workflow/pkg/activity/sshkeygroup/sshkeygroup.go
@@ -395,7 +395,7 @@ func (mskg ManageSSHKeyGroup) UpdateSSHKeyGroupsInDB(ctx context.Context, siteID
 
 						serr = mskg.updateSSHKeyGroupSiteAssociationStatusInDB(ctx, nil, skgsa.ID, cdb.GetStrPtr(cdbm.SSHKeyGroupSiteAssociationStatusError), cdb.GetStrPtr("SSHKeyGroup is missing on Site"))
 						if serr != nil {
-							slogger.Error().Err(err).Msg("failed to update SSH Key Group Site Association status detail in DB")
+							slogger.Error().Err(serr).Msg("failed to update SSH Key Group Site Association status detail in DB")
 						}
 
 						updatedSkgMap[skgID] = true
@@ -413,7 +413,7 @@ func (mskg ManageSSHKeyGroup) UpdateSSHKeyGroupsInDB(ctx context.Context, siteID
 			// but the status is not synced, so we need to sync it
 			serr := mskg.updateSSHKeyGroupSiteAssociationStatusInDB(ctx, nil, skgsa.ID, cdb.GetStrPtr(cdbm.SSHKeyGroupSiteAssociationStatusSynced), cdb.GetStrPtr("SSH Key Group has successfully been synced with Site"))
 			if serr != nil {
-				slogger.Error().Err(err).Msg("failed to update SSH Key Group status detail in DB")
+				slogger.Error().Err(serr).Msg("failed to update SSH Key Group status detail in DB")
 			}
 
 			updatedSkgMap[skgID] = true

--- a/workflow/pkg/activity/vpcprefix/vpcprefix.go
+++ b/workflow/pkg/activity/vpcprefix/vpcprefix.go
@@ -187,7 +187,7 @@ func (mvp ManageVpcPrefix) UpdateVpcPrefixesInDB(ctx context.Context, siteID uui
 
 			serr = mvp.updateVpcPrefixStatusInDB(ctx, nil, vpcPrefix.ID, cdb.GetStrPtr(cdbm.VpcPrefixStatusError), cdb.GetStrPtr("VPC Prefix is missing on Site"))
 			if serr != nil {
-				slogger.Error().Err(err).Msg("failed to update VPC Prefix status detail in DB")
+				slogger.Error().Err(serr).Msg("failed to update VPC Prefix status detail in DB")
 			}
 		}
 	}


### PR DESCRIPTION
## Description

Cleans up a recurring "wrong variable logged"... mmmm pattern? ...across four workflow activity files. In each spot, an inner `if serr != nil { ... Err(err) }` was logging the outer-scope `err` (instead of the local `serr` returned by the status-update helper) -- so when a status write failed, the log surfaced whatever stale value happened to be in `err` (often nil), masking the actual error.

Doing this because CodeRabbit flagged a similar finding in #594, and since I've been trying to keep everything boilerplate, I was like hrmmm.... so I went back through prior PRs to do a sweep and make sure this was addressed in other call sites that already went in.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Feature** - New feature or functionality (feat:)
- [x] **Fix** - Bug fixes (fix:)
- [ ] **Chore** - Modification or removal of existing functionality (chore:)
- [ ] **Refactor** - Refactoring of existing functionality (refactor:)
- [ ] **Docs** - Changes in documentation or OpenAPI schema (docs:)
- [ ] **CI** - Changes in GitHub workflows. Requires additional scrutiny (ci:)
- [ ] **Version** - Issuing a new release version (version:)

## Services Affected
<!-- Check one or more if appropriate -->
- [ ] **API** - API models or endpoints updated
- [x] **Workflow** - Workflow service updated
- [ ] **DB** - DB DAOs or migrations updated
- [ ] **Site Manager** - Site Manager updated
- [ ] **Cert Manager** - Cert Manager updated
- [ ] **Site Agent** - Site Agent updated
- [ ] **Flow** - Flow service updated
- [ ] **Powershelf Manager** - Powershelf Manager updated
- [ ] **NVSwitch Manager** - NVSwitch Manager updated

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
